### PR TITLE
Jahreskalender für Personenabwesenheiten (WP1–WP9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ data/
 # Review / planning documents with real data — keep local only
 /*.txt
 
+# Claude Code project instructions — contains internal infra (ADO host, project codes); local only
+CLAUDE.md
+
 # Frontend
 node_modules/
 frontend/dist/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@ DATABASE_URL=sqlite:///./data/projektplanner.db
 # Public holiday API (feiertage-api.de)
 HOLIDAY_API_URL=https://feiertage-api.de/api/
 HOLIDAY_API_FALLBACK_URL=https://openholidaysapi.org
+HOLIDAY_API_FOREIGN_URL=https://date.nager.at/api/v3
 
 # Default region for holiday lookups
 DEFAULT_HOLIDAY_COUNTRY=DE

--- a/backend/alembic/versions/f7a3b9c14d20_person_holiday_region_override.py
+++ b/backend/alembic/versions/f7a3b9c14d20_person_holiday_region_override.py
@@ -1,0 +1,35 @@
+"""Person holiday-region override — per-MA country/state (§22 WP6)
+
+Revision ID: f7a3b9c14d20
+Revises: e5b9d2c73a41
+Create Date: 2026-07-16
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f7a3b9c14d20"
+down_revision: Union[str, None] = "e5b9d2c73a41"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _cols(conn, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(sa.text(f"PRAGMA table_info({table})"))}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    existing = _cols(conn, "person")
+    if "holiday_country" not in existing:
+        op.add_column("person", sa.Column("holiday_country", sa.String(), nullable=True))
+    if "holiday_state" not in existing:
+        op.add_column("person", sa.Column("holiday_state", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("person", "holiday_state")
+    op.drop_column("person", "holiday_country")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     # Holiday API
     holiday_api_url: str = "https://feiertage-api.de/api/"
     holiday_api_fallback_url: str = "https://openholidaysapi.org"
+    # Foreign holidays (non-DE): Nager.Date covers ~all countries incl. Greece.
+    holiday_api_foreign_url: str = "https://date.nager.at/api/v3"
     default_holiday_country: str = "DE"
     default_holiday_state: str = "BY"
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -47,6 +47,11 @@ def seed_default_settings() -> None:
         "default_vacation_days": "30",
         "sick_days_per_year": "10",
         "training_days_per_year": "5",
+        # Holiday region for the year calendar (WP5). holiday_extra = CSV of
+        # activated optional local holidays (keys from EXTRA_HOLIDAY_CATALOG).
+        "holiday_country": "DE",
+        "holiday_state": "BY",
+        "holiday_extra": "",
     }
     with Session(engine) as session:
         for key, value in defaults.items():

--- a/backend/app/models/holiday.py
+++ b/backend/app/models/holiday.py
@@ -24,5 +24,6 @@ class Holiday(ValidatedSQLModel, table=True):
     holiday_date: date = Field(index=True)
     name: str
     country: str = Field(min_length=2, max_length=2)  # ISO 3166-1 alpha-2
-    state: str = Field(min_length=2)
+    # Subdivision code (e.g. "BY"); empty for national-only countries (e.g. GR).
+    state: str = Field(default="")
     is_workday: bool

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -21,6 +21,10 @@ class Person(ValidatedSQLModel, table=True):
     # Comma-separated daily hours Mon–Fri, e.g. "8,8,8,8,0" for 4-day/32h week.
     work_week_pattern: str | None = Field(default=None)
     default_billing_rate: float | None = Field(default=None, gt=0)
+    # Per-person holiday region override (WP6). NULL = inherit the global
+    # setting; a value overrides it (e.g. nearshore staff in another region).
+    holiday_country: str | None = Field(default=None)
+    holiday_state: str | None = Field(default=None)
 
 
 class VacationContingent(ValidatedSQLModel, table=True):

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -18,6 +18,7 @@ from app.models.person import Person, PersonAbsence
 from app.models.project import Project
 from app.models.timebooking import TimeBooking
 from app.services.holiday import HolidayFetchError, get_holidays_in_range
+from app.services.holiday_region import resolve_holiday_region
 
 router = APIRouter(prefix="/calendar", tags=["calendar"])
 SessionDep = Annotated[Session, Depends(get_session)]
@@ -83,6 +84,32 @@ class CalendarResponse(BaseModel):
     holidays: list[HolidayOut]
     persons: list[PersonOut]
     milestones: list[MilestoneOut]
+
+
+# ── Year view (absence calendar) ──────────────────────────────────────────────
+
+class YearHolidayOut(BaseModel):
+    holiday_date: date
+    name: str
+    is_workday: bool
+    country: str
+    state: str
+
+
+class YearPersonOut(BaseModel):
+    id: int
+    name: str
+    default_weekly_hours: float
+    absences: list[AbsenceOut]
+    memberships: list[MembershipOut]
+
+
+class YearCalendarResponse(BaseModel):
+    year: int
+    country: str
+    state: str
+    holidays: list[YearHolidayOut]
+    persons: list[YearPersonOut]
 
 
 # ---------------------------------------------------------------------------
@@ -246,4 +273,113 @@ def get_calendar(
         holidays=holidays,
         persons=persons_out,
         milestones=milestones_out,
+    )
+
+
+@router.get("/year", response_model=YearCalendarResponse)
+def get_calendar_year(
+    session: SessionDep,
+    year: int = Query(..., ge=2000, le=2100),
+    country: str | None = Query(None),
+    state: str | None = Query(None),
+) -> YearCalendarResponse:
+    """Whole-year aggregation for the absence calendar.
+
+    Returns holidays plus every person's absences and memberships that overlap
+    the year. Region defaults to the globally-resolved one (``resolve_holiday_region``)
+    but can be overridden via query params (used by the region filter later).
+    """
+    default_country, default_state = resolve_holiday_region(session)
+    country = country or default_country
+    state = state or default_state
+
+    start = date(year, 1, 1)
+    end = date(year, 12, 31)
+
+    # Holidays (best-effort: silently return empty list on fetch failure)
+    try:
+        raw_holidays = get_holidays_in_range(start, end, country, state, session)
+    except HolidayFetchError:
+        raw_holidays = []
+
+    holidays = [
+        YearHolidayOut(
+            holiday_date=h.holiday_date,
+            name=h.name,
+            is_workday=h.is_workday,
+            country=h.country,
+            state=h.state,
+        )
+        for h in sorted(raw_holidays, key=lambda h: h.holiday_date)
+    ]
+
+    persons_raw = list(session.exec(select(Person).order_by(Person.name)).all())
+    person_ids = [p.id for p in persons_raw if p.id is not None]
+
+    # Absences overlapping [start, end]
+    absences_raw = session.exec(
+        select(PersonAbsence).where(
+            PersonAbsence.person_id.in_(person_ids),
+            PersonAbsence.start_date <= end,
+            or_(PersonAbsence.end_date.is_(None), PersonAbsence.end_date >= start),
+        )
+    ).all()
+
+    absences_by_person: dict[int, list[AbsenceOut]] = {pid: [] for pid in person_ids}
+    for a in absences_raw:
+        if a.person_id in absences_by_person and a.id is not None:
+            absences_by_person[a.person_id].append(
+                AbsenceOut(
+                    id=a.id,
+                    start_date=a.start_date,
+                    end_date=a.end_date,
+                    absence_type=a.absence_type.value,
+                    status=a.status.value,
+                )
+            )
+
+    # Memberships overlapping [start, end], joined with Project (for project filter)
+    memberships_raw = session.exec(
+        select(ProjectMembership, Project)
+        .join(Project, ProjectMembership.project_id == Project.id)
+        .where(
+            ProjectMembership.person_id.in_(person_ids),
+            ProjectMembership.from_date <= end,
+            ProjectMembership.to_date >= start,
+        )
+    ).all()
+
+    memberships_by_person: dict[int, list[MembershipOut]] = {pid: [] for pid in person_ids}
+    for m, proj in memberships_raw:
+        if m.person_id in memberships_by_person:
+            memberships_by_person[m.person_id].append(
+                MembershipOut(
+                    project_id=proj.id,  # type: ignore[arg-type]
+                    project_number=proj.project_number,
+                    project_name=proj.name,
+                    program_id=proj.program_id,
+                    from_date=m.from_date,
+                    to_date=m.to_date,
+                    weekly_capacity_hours=m.weekly_capacity_hours,
+                )
+            )
+
+    persons_out = [
+        YearPersonOut(
+            id=p.id,  # type: ignore[arg-type]
+            name=p.name,
+            default_weekly_hours=p.default_weekly_hours,
+            absences=absences_by_person.get(p.id, []),  # type: ignore[arg-type]
+            memberships=memberships_by_person.get(p.id, []),  # type: ignore[arg-type]
+        )
+        for p in persons_raw
+        if p.id is not None
+    ]
+
+    return YearCalendarResponse(
+        year=year,
+        country=country,
+        state=state,
+        holidays=holidays,
+        persons=persons_out,
     )

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -18,7 +18,11 @@ from app.models.person import Person, PersonAbsence
 from app.models.project import Project
 from app.models.timebooking import TimeBooking
 from app.services.holiday import HolidayFetchError, get_holidays_in_range
-from app.services.holiday_region import resolve_holiday_region
+from app.services.holiday_region import (
+    extra_holiday_dates,
+    get_active_extra_keys,
+    resolve_holiday_region,
+)
 
 router = APIRouter(prefix="/calendar", tags=["calendar"])
 SessionDep = Annotated[Session, Depends(get_session)]
@@ -312,6 +316,23 @@ def get_calendar_year(
         )
         for h in sorted(raw_holidays, key=lambda h: h.holiday_date)
     ]
+
+    # Inject activated optional local holidays (WP5), skipping dates the API
+    # already returned for this region.
+    existing_dates = {h.holiday_date for h in holidays}
+    for name, hdate in extra_holiday_dates(year, get_active_extra_keys(session)):
+        if hdate in existing_dates:
+            continue
+        holidays.append(
+            YearHolidayOut(
+                holiday_date=hdate,
+                name=name,
+                is_workday=hdate.weekday() < 5,
+                country=country,
+                state=state,
+            )
+        )
+    holidays.sort(key=lambda h: h.holiday_date)
 
     persons_raw = list(session.exec(select(Person).order_by(Person.name)).all())
     person_ids = [p.id for p in persons_raw if p.id is not None]

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -104,6 +104,9 @@ class YearPersonOut(BaseModel):
     id: int
     name: str
     default_weekly_hours: float
+    # Effective holiday region for this person (override or inherited global).
+    holiday_country: str
+    holiday_state: str
     absences: list[AbsenceOut]
     memberships: list[MembershipOut]
 
@@ -290,52 +293,66 @@ def get_calendar_year(
     """Whole-year aggregation for the absence calendar.
 
     Returns holidays plus every person's absences and memberships that overlap
-    the year. Region defaults to the globally-resolved one (``resolve_holiday_region``)
-    but can be overridden via query params (used by the region filter later).
+    the year. Holidays cover the union of every person's effective region
+    (per-person override or the global default), each tagged with its country/
+    state so the frontend can show and colour them per region. Passing both
+    ``country`` and ``state`` forces a single region (manual region filter).
     """
-    default_country, default_state = resolve_holiday_region(session)
-    country = country or default_country
-    state = state or default_state
+    global_country, global_state = resolve_holiday_region(session)
+    forced = country is not None and state is not None
 
     start = date(year, 1, 1)
     end = date(year, 12, 31)
 
-    # Holidays (best-effort: silently return empty list on fetch failure)
-    try:
-        raw_holidays = get_holidays_in_range(start, end, country, state, session)
-    except HolidayFetchError:
-        raw_holidays = []
-
-    holidays = [
-        YearHolidayOut(
-            holiday_date=h.holiday_date,
-            name=h.name,
-            is_workday=h.is_workday,
-            country=h.country,
-            state=h.state,
-        )
-        for h in sorted(raw_holidays, key=lambda h: h.holiday_date)
-    ]
-
-    # Inject activated optional local holidays (WP5), skipping dates the API
-    # already returned for this region.
-    existing_dates = {h.holiday_date for h in holidays}
-    for name, hdate in extra_holiday_dates(year, get_active_extra_keys(session)):
-        if hdate in existing_dates:
-            continue
-        holidays.append(
-            YearHolidayOut(
-                holiday_date=hdate,
-                name=name,
-                is_workday=hdate.weekday() < 5,
-                country=country,
-                state=state,
-            )
-        )
-    holidays.sort(key=lambda h: h.holiday_date)
-
     persons_raw = list(session.exec(select(Person).order_by(Person.name)).all())
     person_ids = [p.id for p in persons_raw if p.id is not None]
+
+    # Effective region per person + the set of regions we must fetch holidays for.
+    person_region: dict[int, tuple[str, str]] = {}
+    for p in persons_raw:
+        if p.id is not None:
+            person_region[p.id] = resolve_holiday_region(session, p)
+
+    if forced:
+        regions = {(country, state)}
+    else:
+        regions = set(person_region.values()) | {(global_country, global_state)}
+
+    # Holidays for every region (best-effort per region).
+    holidays: list[YearHolidayOut] = []
+    for rc, rs in sorted(regions):
+        try:
+            raw = get_holidays_in_range(start, end, rc, rs, session)
+        except HolidayFetchError:
+            raw = []
+        for h in raw:
+            holidays.append(
+                YearHolidayOut(
+                    holiday_date=h.holiday_date,
+                    name=h.name,
+                    is_workday=h.is_workday,
+                    country=h.country,
+                    state=h.state,
+                )
+            )
+
+    # Inject activated optional local holidays (WP5) for the global region,
+    # skipping dates that region already returned.
+    global_dates = {h.holiday_date for h in holidays if (h.country, h.state) == (global_country, global_state)}
+    if (global_country, global_state) in regions:
+        for name, hdate in extra_holiday_dates(year, get_active_extra_keys(session)):
+            if hdate in global_dates:
+                continue
+            holidays.append(
+                YearHolidayOut(
+                    holiday_date=hdate,
+                    name=name,
+                    is_workday=hdate.weekday() < 5,
+                    country=global_country,
+                    state=global_state,
+                )
+            )
+    holidays.sort(key=lambda h: (h.holiday_date, h.country, h.state))
 
     # Absences overlapping [start, end]
     absences_raw = session.exec(
@@ -390,6 +407,8 @@ def get_calendar_year(
             id=p.id,  # type: ignore[arg-type]
             name=p.name,
             default_weekly_hours=p.default_weekly_hours,
+            holiday_country=person_region[p.id][0],
+            holiday_state=person_region[p.id][1],
             absences=absences_by_person.get(p.id, []),  # type: ignore[arg-type]
             memberships=memberships_by_person.get(p.id, []),  # type: ignore[arg-type]
         )
@@ -397,10 +416,11 @@ def get_calendar_year(
         if p.id is not None
     ]
 
+    resp_country, resp_state = (country, state) if forced else (global_country, global_state)
     return YearCalendarResponse(
         year=year,
-        country=country,
-        state=state,
+        country=resp_country,  # type: ignore[arg-type]
+        state=resp_state,
         holidays=holidays,
         persons=persons_out,
     )

--- a/backend/app/services/holiday.py
+++ b/backend/app/services/holiday.py
@@ -100,6 +100,45 @@ def _fetch_primary(
     return _parse_feiertage_response(response.json(), year, country, state)
 
 
+def _parse_nager_response(
+    data: list, year: int, country: str, state: str
+) -> list[Holiday]:
+    holidays: list[Holiday] = []
+    seen: set = set()
+    for item in data:
+        # National holidays only (subnational 'counties' left to DE providers).
+        if item.get("global") is False:
+            continue
+        types = item.get("types") or []
+        if types and "Public" not in types:
+            continue
+        d = date.fromisoformat(item["date"])
+        if d in seen:  # dedupe same-date entries (e.g. GR 25.03. carries two)
+            continue
+        seen.add(d)
+        name = item.get("localName") or item.get("name") or "Holiday"
+        holidays.append(
+            Holiday(
+                holiday_date=d,
+                name=name,
+                country=country,
+                state=state,
+                is_workday=d.weekday() < 5,
+            )
+        )
+    return holidays
+
+
+def _fetch_foreign(
+    year: int, country: str, state: str, client: httpx.Client
+) -> list[Holiday]:
+    """Public holidays for a non-DE country via Nager.Date."""
+    url = f"{settings.holiday_api_foreign_url}/PublicHolidays/{year}/{country}"
+    response = client.get(url)
+    response.raise_for_status()
+    return _parse_nager_response(response.json(), year, country, state)
+
+
 def _fetch_fallback(
     year: int, country: str, state: str, client: httpx.Client
 ) -> list[Holiday]:
@@ -153,17 +192,22 @@ def ensure_holidays(
 
     http = client or httpx.Client()
     holidays: list[Holiday] | None = None
-    primary_succeeded = False
+
+    # Germany: feiertage-api.de (best subdivision quality) with openholidays
+    # fallback. Any other country: Nager.Date, openholidays as fallback.
+    if country == "DE":
+        primary, fallback = _fetch_primary, _fetch_fallback
+    else:
+        primary, fallback = _fetch_foreign, _fetch_fallback
 
     try:
-        holidays = _fetch_primary(year, country, state, http)
-        primary_succeeded = True
+        holidays = primary(year, country, state, http)
     except (httpx.HTTPError, httpx.ConnectError):
         pass
 
-    if not primary_succeeded:
+    if holidays is None:
         try:
-            holidays = _fetch_fallback(year, country, state, http)
+            holidays = fallback(year, country, state, http)
         except (httpx.HTTPError, httpx.ConnectError):
             pass
 

--- a/backend/app/services/holiday_region.py
+++ b/backend/app/services/holiday_region.py
@@ -48,13 +48,13 @@ def resolve_holiday_region(
     A per-person override (WP6) wins over the global setting; NULL fields on the
     person inherit the corresponding global value independently.
     """
+    # A per-person country override is taken as a (country, state) pair — the
+    # state is used as-is (empty for national-only countries like GR), never
+    # mixed with the global state. Without a country override, inherit global.
+    if person is not None and person.holiday_country:
+        return person.holiday_country, (person.holiday_state or "")
     country = _get(session, KEY_COUNTRY, config.default_holiday_country)
     state = _get(session, KEY_STATE, config.default_holiday_state)
-    if person is not None:
-        if person.holiday_country:
-            country = person.holiday_country
-        if person.holiday_state:
-            state = person.holiday_state
     return country, state
 
 

--- a/backend/app/services/holiday_region.py
+++ b/backend/app/services/holiday_region.py
@@ -1,0 +1,26 @@
+"""Resolve which holiday region (country/state) applies.
+
+Single seam for holiday-region resolution so later phases can extend it without
+touching callers:
+
+- Phase 1 (now): always the global default from config.
+- Phase 5: read global app settings (Setting store) as override of config.
+- Phase 6: honor a per-person override (``person`` arg) above the global value.
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+from app.models.person import Person
+
+
+def resolve_holiday_region(
+    session,  # noqa: ANN001 — Session, kept loose to avoid import cycle churn
+    person: Person | None = None,
+) -> tuple[str, str]:
+    """Return the (country, state) whose holidays apply for ``person``.
+
+    ``person`` is accepted already so Phase 6 can add per-person overrides here
+    without changing the endpoint signatures that call this.
+    """
+    return settings.default_holiday_country, settings.default_holiday_state

--- a/backend/app/services/holiday_region.py
+++ b/backend/app/services/holiday_region.py
@@ -1,21 +1,46 @@
-"""Resolve which holiday region (country/state) applies.
+"""Resolve which holiday region (country/state) applies, plus optional extras.
 
-Single seam for holiday-region resolution so later phases can extend it without
+Single seam for holiday-region resolution so later phases extend it without
 touching callers:
 
-- Phase 1 (now): always the global default from config.
-- Phase 5: read global app settings (Setting store) as override of config.
+- Phase 1: always the config default.
+- Phase 5 (now): read the global app settings (Setting store) as override of
+  config, plus a catalog of optionally-activated local holidays.
 - Phase 6: honor a per-person override (``person`` arg) above the global value.
 """
 
 from __future__ import annotations
 
-from app.config import settings
+from datetime import date
+
+from sqlmodel import Session
+
+from app.config import settings as config
 from app.models.person import Person
+from app.models.setting import Setting
+
+# Setting keys (seeded in db.seed_default_settings)
+KEY_COUNTRY = "holiday_country"
+KEY_STATE = "holiday_state"
+KEY_EXTRA = "holiday_extra"  # CSV of activated catalog keys below
+
+# Optional local holidays that the public APIs don't reliably return for a
+# state. Fixed-date only (movable feasts like Fronleichnam are already covered
+# statewide where they apply). name is the German label shown in the calendar.
+EXTRA_HOLIDAY_CATALOG: dict[str, dict] = {
+    "mariae_himmelfahrt": {"name": "Mariä Himmelfahrt", "month": 8, "day": 15},
+    "augsburger_friedensfest": {"name": "Augsburger Friedensfest", "month": 8, "day": 8},
+    "reformationstag": {"name": "Reformationstag", "month": 10, "day": 31},
+}
+
+
+def _get(session: Session, key: str, default: str) -> str:
+    row = session.get(Setting, key)
+    return row.value if row and row.value else default
 
 
 def resolve_holiday_region(
-    session,  # noqa: ANN001 — Session, kept loose to avoid import cycle churn
+    session: Session,
     person: Person | None = None,
 ) -> tuple[str, str]:
     """Return the (country, state) whose holidays apply for ``person``.
@@ -23,4 +48,22 @@ def resolve_holiday_region(
     ``person`` is accepted already so Phase 6 can add per-person overrides here
     without changing the endpoint signatures that call this.
     """
-    return settings.default_holiday_country, settings.default_holiday_state
+    country = _get(session, KEY_COUNTRY, config.default_holiday_country)
+    state = _get(session, KEY_STATE, config.default_holiday_state)
+    return country, state
+
+
+def get_active_extra_keys(session: Session) -> list[str]:
+    """Activated optional-local-holiday keys from settings (valid ones only)."""
+    raw = _get(session, KEY_EXTRA, "")
+    return [k for k in (s.strip() for s in raw.split(",")) if k in EXTRA_HOLIDAY_CATALOG]
+
+
+def extra_holiday_dates(year: int, keys: list[str]) -> list[tuple[str, date]]:
+    """(name, date) for each activated catalog key in the given year."""
+    out: list[tuple[str, date]] = []
+    for key in keys:
+        entry = EXTRA_HOLIDAY_CATALOG.get(key)
+        if entry:
+            out.append((entry["name"], date(year, entry["month"], entry["day"])))
+    return out

--- a/backend/app/services/holiday_region.py
+++ b/backend/app/services/holiday_region.py
@@ -45,11 +45,16 @@ def resolve_holiday_region(
 ) -> tuple[str, str]:
     """Return the (country, state) whose holidays apply for ``person``.
 
-    ``person`` is accepted already so Phase 6 can add per-person overrides here
-    without changing the endpoint signatures that call this.
+    A per-person override (WP6) wins over the global setting; NULL fields on the
+    person inherit the corresponding global value independently.
     """
     country = _get(session, KEY_COUNTRY, config.default_holiday_country)
     state = _get(session, KEY_STATE, config.default_holiday_state)
+    if person is not None:
+        if person.holiday_country:
+            country = person.holiday_country
+        if person.holiday_state:
+            state = person.holiday_state
     return country, state
 
 

--- a/backend/tests/unit/test_routers_calendar.py
+++ b/backend/tests/unit/test_routers_calendar.py
@@ -178,7 +178,7 @@ def test_calendar_year_person_region_override(client):
     """A per-person region override wins; others inherit the global default."""
     p_over = client.post("/persons", json={
         "name": "Nearshore MA", "sage_employee_name": "Nearshore MA",
-        "default_weekly_hours": 40.0, "holiday_state": "BW",
+        "default_weekly_hours": 40.0, "holiday_country": "DE", "holiday_state": "BW",
     }).json()
     p_inherit = client.post("/persons", json={
         "name": "Local MA", "sage_employee_name": "Local MA",

--- a/backend/tests/unit/test_routers_calendar.py
+++ b/backend/tests/unit/test_routers_calendar.py
@@ -172,3 +172,31 @@ def test_calendar_year_ignores_unknown_extra_key(client, session):
     session.commit()
     r = client.get("/calendar/year?year=2026")
     assert r.status_code == 200
+
+
+def test_calendar_year_person_region_override(client):
+    """A per-person region override wins; others inherit the global default."""
+    p_over = client.post("/persons", json={
+        "name": "Nearshore MA", "sage_employee_name": "Nearshore MA",
+        "default_weekly_hours": 40.0, "holiday_state": "BW",
+    }).json()
+    p_inherit = client.post("/persons", json={
+        "name": "Local MA", "sage_employee_name": "Local MA",
+        "default_weekly_hours": 40.0,
+    }).json()
+    r = client.get("/calendar/year?year=2026")
+    assert r.status_code == 200
+    by_id = {p["id"]: p for p in r.json()["persons"]}
+    assert by_id[p_over["id"]]["holiday_state"] == "BW"
+    assert by_id[p_inherit["id"]]["holiday_state"] == "BY"  # inherited global default
+
+
+def test_calendar_year_person_override_persists(client):
+    """holiday_state set on create round-trips through the person endpoint."""
+    p = client.post("/persons", json={
+        "name": "Region MA", "sage_employee_name": "Region MA",
+        "default_weekly_hours": 40.0, "holiday_country": "DE", "holiday_state": "NW",
+    }).json()
+    got = client.get(f"/persons/{p['id']}").json()
+    assert got["holiday_country"] == "DE"
+    assert got["holiday_state"] == "NW"

--- a/backend/tests/unit/test_routers_calendar.py
+++ b/backend/tests/unit/test_routers_calendar.py
@@ -80,3 +80,62 @@ def test_calendar_no_milestones_returns_empty_list(client):
     r = client.get("/calendar?year=2026&month=1")
     assert r.status_code == 200
     assert r.json()["milestones"] == []
+
+
+# ── Year view (absence calendar) ──────────────────────────────────────────────
+
+def test_calendar_year_returns_persons_and_default_region(client):
+    """GET /calendar/year returns all persons and defaults the region to DE/BY."""
+    person = client.post("/persons", json={
+        "name": "Year Person",
+        "sage_employee_name": "Year Person",
+        "default_weekly_hours": 40.0,
+    }).json()
+    r = client.get("/calendar/year?year=2026")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["year"] == 2026
+    assert data["country"] == "DE"
+    assert data["state"] == "BY"
+    assert isinstance(data["holidays"], list)
+    assert any(p["id"] == person["id"] for p in data["persons"])
+
+
+def test_calendar_year_includes_overlapping_absence(client):
+    """An absence within the year appears on the person; one outside does not."""
+    person = client.post("/persons", json={
+        "name": "Abs Person",
+        "sage_employee_name": "Abs Person",
+        "default_weekly_hours": 40.0,
+    }).json()
+    # Absence inside 2026 (spanning a month boundary)
+    client.post(f"/persons/{person['id']}/absences", json={
+        "start_date": "2026-01-28",
+        "end_date": "2026-02-03",
+        "absence_type": "vacation",
+        "status": "confirmed",
+        "note": "",
+    })
+    # Absence entirely in 2025 — must not appear in the 2026 view
+    client.post(f"/persons/{person['id']}/absences", json={
+        "start_date": "2025-03-01",
+        "end_date": "2025-03-05",
+        "absence_type": "vacation",
+        "status": "confirmed",
+        "note": "",
+    })
+    r = client.get("/calendar/year?year=2026")
+    assert r.status_code == 200
+    p = next(p for p in r.json()["persons"] if p["id"] == person["id"])
+    starts = {a["start_date"] for a in p["absences"]}
+    assert "2026-01-28" in starts
+    assert "2025-03-01" not in starts
+
+
+def test_calendar_year_region_override_via_query(client):
+    """Region query params override the resolved default."""
+    r = client.get("/calendar/year?year=2026&country=DE&state=BW")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["country"] == "DE"
+    assert data["state"] == "BW"

--- a/backend/tests/unit/test_routers_calendar.py
+++ b/backend/tests/unit/test_routers_calendar.py
@@ -139,3 +139,36 @@ def test_calendar_year_region_override_via_query(client):
     data = r.json()
     assert data["country"] == "DE"
     assert data["state"] == "BW"
+
+
+def test_calendar_year_region_reads_settings(client, session):
+    """Without query params, the region comes from the Setting store."""
+    from app.models.setting import Setting
+
+    session.add(Setting(key="holiday_state", value="BW"))
+    session.commit()
+    r = client.get("/calendar/year?year=2026")
+    assert r.status_code == 200
+    assert r.json()["state"] == "BW"
+
+
+def test_calendar_year_injects_active_extra_holiday(client, session):
+    """An activated optional local holiday appears in the holiday list."""
+    from app.models.setting import Setting
+
+    session.add(Setting(key="holiday_extra", value="mariae_himmelfahrt"))
+    session.commit()
+    r = client.get("/calendar/year?year=2026")
+    assert r.status_code == 200
+    dates = {h["holiday_date"] for h in r.json()["holidays"]}
+    assert "2026-08-15" in dates
+
+
+def test_calendar_year_ignores_unknown_extra_key(client, session):
+    """Unknown extra keys are ignored (no crash, no bogus holiday)."""
+    from app.models.setting import Setting
+
+    session.add(Setting(key="holiday_extra", value="not_a_real_holiday"))
+    session.commit()
+    r = client.get("/calendar/year?year=2026")
+    assert r.status_code == 200

--- a/backend/tests/unit/test_services_holiday.py
+++ b/backend/tests/unit/test_services_holiday.py
@@ -289,3 +289,61 @@ def test_is_workday_matches_weekday(day):
         is_workday=(d.weekday() < 5),
     )
     assert h.is_workday == (d.weekday() < 5)
+
+
+# ---------------------------------------------------------------------------
+# Foreign countries — Nager.Date adapter (§22 WP9)
+# ---------------------------------------------------------------------------
+
+NAGER_2026_GR = [
+    {"date": "2026-01-01", "localName": "Πρωτοχρονιά", "name": "New Year's Day", "global": True, "counties": None, "types": ["Public"]},
+    {"date": "2026-03-25", "localName": "Ευαγγελισμός της Θεοτόκου", "name": "Annunciation", "global": True, "counties": None, "types": ["Public"]},
+    {"date": "2026-03-25", "localName": "Εικοστή Πέμπτη Μαρτίου", "name": "Independence Day", "global": True, "counties": None, "types": ["Public"]},
+    {"date": "2026-04-12", "localName": "Κυριακή του Πάσχα", "name": "Easter Sunday", "global": True, "counties": None, "types": ["Public"]},
+    {"date": "2026-07-04", "localName": "Nur regional", "name": "Regional", "global": False, "counties": ["GR-A"], "types": ["Public"]},
+    {"date": "2026-08-15", "localName": "Κοίμηση της Θεοτόκου", "name": "Assumption", "global": True, "counties": None, "types": ["Bank"]},
+]
+
+
+def _nager_client(payload=NAGER_2026_GR):
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "date.nager.at" in url:
+            if isinstance(payload, int):
+                return httpx.Response(payload)
+            return httpx.Response(200, json=payload)
+        return httpx.Response(503)  # openholidays fallback unavailable for GR
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_foreign_country_uses_nager(mem_session):
+    holidays = ensure_holidays(2026, "GR", "", mem_session, _nager_client())
+    dates = {h.holiday_date.isoformat() for h in holidays}
+    assert "2026-04-12" in dates  # Orthodox Easter (not Western 2026-04-05)
+    assert all(h.country == "GR" and h.state == "" for h in holidays)
+
+
+def test_nager_dedupes_same_date(mem_session):
+    holidays = ensure_holidays(2026, "GR", "", mem_session, _nager_client())
+    same_day = [h for h in holidays if h.holiday_date.isoformat() == "2026-03-25"]
+    assert len(same_day) == 1  # two GR entries on 25.03. collapse to one
+
+
+def test_nager_skips_regional_and_non_public(mem_session):
+    holidays = ensure_holidays(2026, "GR", "", mem_session, _nager_client())
+    dates = {h.holiday_date.isoformat() for h in holidays}
+    assert "2026-07-04" not in dates  # global=false → skipped
+    assert "2026-08-15" not in dates  # types=[Bank] (no Public) → skipped
+
+
+def test_germany_still_uses_feiertage_api(mem_session):
+    """Routing must not send DE to Nager."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        assert "date.nager.at" not in url, "DE must not hit Nager"
+        if "feiertage-api.de" in url:
+            return httpx.Response(200, json=FEIERTAGE_2026_BY)
+        return httpx.Response(503)
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    holidays = ensure_holidays(2026, "DE", "BY", mem_session, client)
+    assert len(holidays) == len(FEIERTAGE_2026_BY)

--- a/backend/tests/unit/test_services_holiday_region.py
+++ b/backend/tests/unit/test_services_holiday_region.py
@@ -1,0 +1,46 @@
+"""Unit tests for holiday-region resolution (global vs. per-person override)."""
+
+from sqlmodel import Session, SQLModel, create_engine
+
+import pytest
+
+from app.models.person import Person
+from app.services.holiday_region import resolve_holiday_region
+
+
+@pytest.fixture
+def mem_session():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _person(**kw) -> Person:
+    return Person(name="P", sage_employee_name="P", default_weekly_hours=40.0, **kw)
+
+
+def test_default_is_global(mem_session):
+    assert resolve_holiday_region(mem_session) == ("DE", "BY")
+
+
+def test_person_without_override_inherits_global(mem_session):
+    assert resolve_holiday_region(mem_session, _person()) == ("DE", "BY")
+
+
+def test_foreign_country_override_uses_empty_state(mem_session):
+    # country override wins as a pair — never mixes with the global state (BY)
+    p = _person(holiday_country="GR")
+    assert resolve_holiday_region(mem_session, p) == ("GR", "")
+
+
+def test_german_state_override(mem_session):
+    p = _person(holiday_country="DE", holiday_state="BW")
+    assert resolve_holiday_region(mem_session, p) == ("DE", "BW")
+
+
+def test_settings_override_global(mem_session):
+    from app.models.setting import Setting
+    mem_session.add(Setting(key="holiday_state", value="NW"))
+    mem_session.commit()
+    assert resolve_holiday_region(mem_session) == ("DE", "NW")

--- a/docs/implementation/22-absence-year-calendar.md
+++ b/docs/implementation/22-absence-year-calendar.md
@@ -83,6 +83,12 @@ Der Kalender lebt **unter dem Reiter „Personen"**, zusätzlich zur Personenlis
 5. **Feiertags-Region global + Zusatz-Checkliste** — Settings-Keys + Region-Sektion unter Einstellungen; Endpoint liest Settings.
 6. **Per-MA Feiertagsregion-Override + Multi-Region** — `Person`-Region-Attribute (Default global, überschreibbar), PersonForm-UI, Kalender zeigt Union der Regionen sichtbarer MA, Region-Filter, farblich abgesetzte Feiertage je Region.
 
+## 7a. Nachträge aus der Review (WP7–WP9)
+
+- **WP7 (#16):** Kalender breiter (2rem-Zellen), Platzhalterzellen mit diagonaler Grau-Schraffur, **vertikales Monats-Scrolling** über mehrere Jahre (statt Jahre-Paging) mit Monat-/Jahr-Sprung + Recenter und vertikaler Jahres-Spalte; Personentabelle über dem Kalender.
+- **WP8 (#17):** Extra-Tab „Urlaubskontingente" entfernt; Kontingent-Verwaltung in das „Personeneinstellungen"-Modal integriert.
+- **WP9 (#18):** Auslands-Feiertage. **DE bleibt feiertage-api.de**; alle anderen Länder über einen **Nager.Date**-Adapter (`services/holiday.py`, geroutet in `ensure_holidays` nach `country`). `resolve_holiday_region` behandelt einen Länder-Override als (country, state)-Paar (state leer für national-only Länder wie GR). `Holiday.state` erlaubt jetzt leeren Wert. Per-MA-Länderauswahl via `components/absence/RegionOverrideSelect`; griechische Feiertage inkl. korrektem orthodoxem Ostern.
+
 ## 8. Invarianten / Nicht-Ziele
 
 - Bestehender Monatskalender, Abwesenheitstabelle & -formular bleiben funktional unverändert (nur Farb-/Label-Maps werden geteilt).

--- a/docs/implementation/22-absence-year-calendar.md
+++ b/docs/implementation/22-absence-year-calendar.md
@@ -1,0 +1,90 @@
+# Jahreskalender für Personenabwesenheiten
+
+_Status: 📋 Design & Implementierungsplan_
+_Datum: 2026-07-16_
+_Betrifft: `models/person.py`, `models/setting.py`, `services/holiday.py`, `routers/calendar.py`, `routers/persons.py`, `routers/settings.py`, `app/db.py`, `frontend/src/pages/PersonsPage.tsx`, `frontend/src/pages/PersonDetailPage.tsx`, `frontend/src/pages/SettingsPage.tsx`, neu `frontend/src/components/absence/*`, neu `frontend/src/lib/absenceColors.ts`_
+
+_Tracking: Epic-Issue + 6 Phasen-Issues (`sefalk/ProjektPlanner`)_
+
+---
+
+## 1. Ziel
+
+Die UX für Personenabwesenheiten ist heute umständlich: `Personen → MA → Abwesenheiten → Neue Abwesenheit` mit **zwei separaten Datepickern** für Start und Ende. Die Abwesenheitstabelle bleibt, wird aber um einen **Jahreskalender** ergänzt, der
+
+- Abwesenheiten **visuell ansprechend** über ein ganzes Jahr darstellt (Monate = Zeilen, Tage = Spalten), und
+- **direkten Input per Bereichsselektion** erlaubt (Ziehen über Tage → neue Abwesenheit).
+
+Der Kalender lebt **unter dem Reiter „Personen"**, zusätzlich zur Personenliste (nicht als eigener Nav-Punkt).
+
+## 2. Ist-Stand (Kurz)
+
+- **Abwesenheiten:** `PersonAbsence(person_id, start_date, end_date?, absence_type, status, note)`; `absence_type ∈ {vacation, training, sick}` (Enum `models/enums.py`). **Kein Projekt-FK** → Projektfilter läuft indirekt über `ProjectMembership`.
+- **Monatskalender existiert bereits** (`/calendar`, `CalendarPage.tsx` + `routers/calendar.py`): `GET /calendar?year=&month=&country=DE&state=BY` liefert `CalendarResponse{ holidays[], persons[]{absences[], memberships[]}, milestones[] }`, mit Wochenend-/Feiertags-Shading, Absence-Overlays, Projektfilter. Die Jahresansicht ist im Kern ein Re-Layout derselben Daten über 12 Monate.
+- **Feiertage:** `models/holiday.py` + `services/holiday.py` (`ensure_holidays(year, country, state)`, `get_holidays_in_range`), Fetch-&-Cache gegen feiertage-api.de (Fallback openholidaysapi.org), pro (Datum, country, state). Region heute **hart DE/BY** im Calendar-Endpoint bzw. per-Projekt-Feld ohne UI.
+- **Settings:** generischer Key/Value-Store (`Setting.key`/`.value`), Seeding in `db.py:seed_default_settings()`, `GET /settings` / `PUT /settings/{key}`. Frontend `SettingsPage.tsx` mit hartkodierter `SETTING_META` und **nur Number-Input** (`SettingRow`). Keine globale Region-Einstellung.
+- **Farben:** kein per-MA-Farbschema. Deterministisches Muster existiert (`CalendarPage.tsx: PROJECT_PALETTE`, `projectColor(id)=PALETTE[id%len]`). Absence-Label-/Farb-Maps **doppelt** in `PersonDetailPage.tsx` und `CalendarPage.tsx`.
+
+## 3. Grundregeln & Entscheidungen (verbindlich)
+
+- **C1 — Platzierung.** Jahreskalender auf der Personen-Seite, unter/neben der Personentabelle. Tabelle bleibt erhalten, ein-/ausklappbar.
+- **C2 — Default-Selektion.** Beim ersten Öffnen sind **alle MA** selektiert (Nutzerentscheidung).
+- **C3 — Filter (alle vier).** (a) Projekt-/Programm-Filter (indirekte MA-Selektion über `ProjectMembership`), (b) Einzel-MA mit Suchfeld, (c) Abwesenheitstyp-Toggles (Urlaub/Krank/Fortbildung), (d) Schnellaktionen (Alle/Keine, nur-MA-mit-Abwesenheit, Jahr vor/zurück). Filter leicht zugänglich, schnelle Selektion.
+- **C4 — Farb-Harmonisierung.** Jeder MA hat **eine eigene Farbe** (`personColor(id)`), die in Kalenderbalken **und** Personentabelle identisch ist. Deselektierte MA: ausgegraut, keine Farbhinterlegung. Tabellen-Selektion ↔ Kalender-Selektion synchron (Klick = Toggle).
+- **C5 — Feiertags-Region.** Global konfigurierbar unter Einstellungen: Land + Bundesland + **Checkliste optionaler lokaler Feiertage** (z. B. Mariä Himmelfahrt). **Forward-looking:** Region ist zusätzlich **pro MA überschreibbar** (Nearshoring, ausländische MA) — NULL erbt global.
+- **C6 — Bestehendes Verhalten unangetastet.** Monatskalender `/calendar`, Abwesenheitstabelle/-formular auf `PersonDetailPage` bleiben funktional. Doppelte Farb-/Label-Maps werden in ein geteiltes Modul (`lib/absenceColors.ts`) zusammengeführt, bevor der dritte Konsument (Jahresansicht) dazukommt.
+
+## 4. Kalender-Layout & Interaktion
+
+- **Raster:** 12 Zeilen (Monate) × Tagesspalten (bis 31). Fehlende Tage (z. B. 30./31. in kurzen Monaten) als leere/gesperrte Zellen.
+- **Scroll & Fokus:** vertikal scrollbar, initial **zentriert auf den aktuellen Monat** (aktueller Monat als Mittelpunkt).
+- **Wochenende:** Sa/So farblich leicht von Werktagen abgesetzt.
+- **Feiertage:** angezeigt; bei mehreren Regionen (per-MA) farblich **ähnlich, aber abgesetzt** (gleicher Farbwinkel, variierte Schattierung/Muster) → auf einen Blick als Feiertag erkennbar und dennoch regional unterscheidbar.
+- **Abwesenheitsbalken:** Balken mit **leicht transparentem Body** über die Tage Start→Ende.
+  - **Monatsumbruch:** läuft ein Balken über die Monatsgrenze (Zeilenende), wird der Umbruch durch eine **offene Umrahmung** an der Umbruchkante visualisiert (rechts offen in Monat _n_, links offen in Monat _n+1_).
+  - **Stacking:** Balken eines Tages stapeln sich gemäß Selektion und nutzen die volle vertikale Höhe der Monatszeile aus → je mehr MA, desto dünner. **Labels werden ausgeblendet, sobald sie die Balkenhöhe überschreiten würden.**
+  - **Typ-Anzeige:** Inline-Tag (Kürzel U/K/F) **plus** Hover-Tooltip mit Von/Bis (und Typ/Status).
+  - **Hover-Highlight:** Beim Hovern über eine Abwesenheit eines MA werden **alle** Abwesenheiten desselben MA hervorgehoben (Rahmenfarbe ändert sich, Balken leicht vergrößert).
+- **Direkt-Input:** Ziehen (drag) über einen Tagesbereich in der Zeile eines MA öffnet die bestehende `AbsenceForm` mit vorbelegtem `person_id`, `start_date`, `end_date`.
+
+## 5. Soll — Backend
+
+### 5.1 Jahres-Aggregation
+- Range-basierte Aggregation statt Einzelmonat. Entweder `GET /calendar` um `from`/`to` (oder `year` ohne `month`) erweitern **oder** `GET /calendar/year?year=` ergänzen. Response wie `CalendarResponse`, aber Holidays/Absences/Memberships über das ganze Jahr (Range-Overlap-Logik existiert bereits).
+- Feiertage: **mehrere Regionen** möglich. Endpoint ermittelt die benötigten Regionen (Union der Regionen der angefragten/sichtbaren MA bzw. explizit gefilterte Region) und ruft `ensure_holidays` je Region auf. Response-Holiday trägt `country`/`state` zur Unterscheidung.
+
+### 5.2 Regionsauflösung (Phase 1 vorbereiten)
+- Helper `resolve_holiday_region(person, settings)` → `(country, state, extra_holidays)`.
+  - Phase 1–5: liefert **immer global** (Settings), Person-Override ignoriert.
+  - Phase 6: Person-Override (falls gesetzt) schlägt global. So bleibt Phase 6 ein reines Attribut+UI-Add ohne Refactoring.
+
+### 5.3 Settings (Phase 5)
+- Neue Keys in `seed_default_settings()`: `holiday_country` (Default `DE`), `holiday_state` (Default `BY`), `holiday_extra` (Default `""`, CSV der aktivierten optionalen lokalen Feiertage).
+- Calendar-Endpoint liest diese Settings statt hart DE/BY.
+
+### 5.4 Person-Attribute (Phase 6)
+- Alembic: `Person.holiday_country: str|None`, `Person.holiday_state: str|None`, `Person.holiday_extra: str|None` — alle nullable, NULL = erbe global.
+- `AbsenceCreate`/Person-Schemas & Router entsprechend.
+
+## 6. Soll — Frontend
+
+- **Neues geteiltes Modul** `lib/absenceColors.ts`: `TYPE_LABELS`, `TYPE_SHORT` (U/K/F), `TYPE_COLORS`, `personColor(id)`. `PersonDetailPage` und `CalendarPage` migrieren darauf (keine Doppelung).
+- **Neue Komponenten** unter `components/absence/`: `YearCalendar`, `MonthRow`, `AbsenceBar`, `CalendarFilters`, `PersonLegendTable` (o. ä.).
+- **PersonsPage**: Kalender + ein-/ausklappbare Personentabelle einbetten; Selektions-State (welche MA sichtbar) zentral, an Filter + Tabelle + Kalender gebunden.
+- **SettingsPage** (Phase 5): Region-Sektion mit Dropdowns (Land/Bundesland) + Checkliste; `SettingRow` um Nicht-Number-Typen erweitern (oder dedizierte Sektion).
+- **PersonForm** (Phase 6): optionale Region-Override-Felder (leer = global).
+
+## 7. Phasen (je 1 Kind-Issue / PR)
+
+1. **Fundament + Jahresansicht** — geteiltes Farb-/Label-Modul + `personColor()`; Backend Year-Aggregation + `resolve_holiday_region` (global); Frontend 12×Tage-Raster auf Personen-Seite, scrollbar/zentriert, Wochenend- + Feiertags-Shading (globale Region).
+2. **Abwesenheitsbalken + Interaktion** — transparente Balken, Monatsumbruch-Umrahmung, Stacking + dynamische Höhe + Label-Ausblendung, Inline-Tag, Hover-Tooltip, Hover-Highlight aller Abwesenheiten eines MA.
+3. **Direkt-Input per Bereichsselektion** — Drag-Selektion → `AbsenceForm` vorbelegt (person/start/end).
+4. **Filter + Personentabelle-Harmonisierung** — alle vier Filter, Default = alle MA; Tabelle farblich gekoppelt, deselektierte ausgegraut, ein-/ausklappbar, Selektion Tabelle ↔ Kalender synchron.
+5. **Feiertags-Region global + Zusatz-Checkliste** — Settings-Keys + Region-Sektion unter Einstellungen; Endpoint liest Settings.
+6. **Per-MA Feiertagsregion-Override + Multi-Region** — `Person`-Region-Attribute (Default global, überschreibbar), PersonForm-UI, Kalender zeigt Union der Regionen sichtbarer MA, Region-Filter, farblich abgesetzte Feiertage je Region.
+
+## 8. Invarianten / Nicht-Ziele
+
+- Bestehender Monatskalender, Abwesenheitstabelle & -formular bleiben funktional unverändert (nur Farb-/Label-Maps werden geteilt).
+- Keine echten GitHub-Sub-Issues nötig: Epic mit Task-Liste + Kind-Issues mit `Teil von #Epic`.
+- Keine sensiblen/personenbezogenen Daten in Code/Commits (DSGVO); Dev nur mit Pseudodaten.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,6 +75,9 @@ export interface Person {
   default_weekly_hours: number;
   work_week_pattern: string | null;
   default_billing_rate: number | null;
+  // Per-person holiday region override (null = inherit global setting).
+  holiday_country?: string | null;
+  holiday_state?: string | null;
 }
 
 export interface PersonWithProjects extends Person {
@@ -514,6 +517,8 @@ export interface YearCalendarPerson {
   id: number;
   name: string;
   default_weekly_hours: number;
+  holiday_country: string;
+  holiday_state: string;
   absences: CalendarAbsence[];
   memberships: CalendarMembership[];
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -502,9 +502,40 @@ export interface CalendarResponse {
   milestones: CalendarMilestone[];
 }
 
+export interface YearHoliday {
+  holiday_date: string;
+  name: string;
+  is_workday: boolean;
+  country: string;
+  state: string;
+}
+
+export interface YearCalendarPerson {
+  id: number;
+  name: string;
+  default_weekly_hours: number;
+  absences: CalendarAbsence[];
+  memberships: CalendarMembership[];
+}
+
+export interface YearCalendarResponse {
+  year: number;
+  country: string;
+  state: string;
+  holidays: YearHoliday[];
+  persons: YearCalendarPerson[];
+}
+
 export const calendar = {
   get: (year: number, month: number) =>
     req<CalendarResponse>('GET', `/calendar?year=${year}&month=${month}`),
+  year: (year: number, country?: string, state?: string) =>
+    req<YearCalendarResponse>(
+      'GET',
+      `/calendar/year?year=${year}` +
+        (country ? `&country=${encodeURIComponent(country)}` : '') +
+        (state ? `&state=${encodeURIComponent(state)}` : ''),
+    ),
 };
 
 // ─── Settings ────────────────────────────────────────────────────────────────

--- a/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
+++ b/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { persons as personsApi } from '../../api'
+import Modal from '../Modal'
+import { TYPE_LABELS, STATUS_LABELS } from '../../lib/absenceColors'
+
+type AbsenceType = 'vacation' | 'sick' | 'training'
+type AbsenceStatus = 'planned' | 'confirmed' | 'ongoing'
+
+const TYPES: AbsenceType[] = ['vacation', 'training', 'sick']
+
+function allowedStatuses(type: AbsenceType): AbsenceStatus[] {
+  return type === 'sick' ? ['confirmed', 'ongoing'] : ['planned', 'confirmed']
+}
+
+/**
+ * Quick "new absence" form opened from the year calendar. Dates come prefilled
+ * from the drag selection; the person is preselected when the drag started on a
+ * person's lane, otherwise it must be chosen here.
+ */
+export default function AbsenceQuickCreateModal({
+  persons,
+  initialPersonId,
+  startDate,
+  endDate,
+  onClose,
+  onCreated,
+}: {
+  persons: { id: number; name: string }[]
+  initialPersonId: number | null
+  startDate: string
+  endDate: string
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const qc = useQueryClient()
+  const [personId, setPersonId] = useState<number | null>(initialPersonId)
+  const [type, setType] = useState<AbsenceType>('vacation')
+  const [status, setStatus] = useState<AbsenceStatus>('confirmed')
+  const [start, setStart] = useState(startDate)
+  const [end, setEnd] = useState(endDate)
+  const [note, setNote] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const isOngoing = type === 'sick' && status === 'ongoing'
+
+  const create = useMutation({
+    mutationFn: () =>
+      personsApi.addAbsence(personId as number, {
+        start_date: start,
+        end_date: isOngoing ? null : end,
+        absence_type: type,
+        status,
+        note,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['calendar-year'] })
+      qc.invalidateQueries({ queryKey: ['persons', personId, 'absences'] })
+      onCreated()
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  function handleType(t: AbsenceType) {
+    setType(t)
+    if (!allowedStatuses(t).includes(status)) setStatus(allowedStatuses(t)[0])
+  }
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (personId == null) { setError('Bitte eine Person wählen.'); return }
+    if (!isOngoing && end < start) { setError('Das Ende darf nicht vor dem Beginn liegen.'); return }
+    create.mutate()
+  }
+
+  return (
+    <Modal title="Neue Abwesenheit" onClose={onClose}>
+      <form onSubmit={submit} className="space-y-3">
+        <div>
+          <label htmlFor="qc-person" className="block text-xs font-medium text-gray-600 mb-1">Mitarbeiter</label>
+          <select id="qc-person" required
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={personId ?? ''}
+            onChange={(e) => setPersonId(e.target.value ? parseInt(e.target.value) : null)}
+          >
+            <option value="">– wählen –</option>
+            {persons.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="qc-type" className="block text-xs font-medium text-gray-600 mb-1">Typ</label>
+            <select id="qc-type"
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={type}
+              onChange={(e) => handleType(e.target.value as AbsenceType)}
+            >
+              {TYPES.map((t) => <option key={t} value={t}>{TYPE_LABELS[t]}</option>)}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="qc-status" className="block text-xs font-medium text-gray-600 mb-1">Status</label>
+            <select id="qc-status"
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as AbsenceStatus)}
+            >
+              {allowedStatuses(type).map((s) => <option key={s} value={s}>{STATUS_LABELS[s]}</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="qc-start" className="block text-xs font-medium text-gray-600 mb-1">Von</label>
+            <input id="qc-start" type="date" required
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="qc-end" className="block text-xs font-medium text-gray-600 mb-1">
+              Bis {isOngoing && <span className="font-normal text-gray-400">(offen)</span>}
+            </label>
+            <input id="qc-end" type="date" required={!isOngoing} disabled={isOngoing}
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-400"
+              value={isOngoing ? '' : end}
+              onChange={(e) => setEnd(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="qc-note" className="block text-xs font-medium text-gray-600 mb-1">Notiz <span className="font-normal text-gray-400">optional</span></label>
+          <input id="qc-note"
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
+          <button type="submit" disabled={create.isPending}
+            className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+            Speichern
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/absence/RegionOverrideSelect.tsx
+++ b/frontend/src/components/absence/RegionOverrideSelect.tsx
@@ -1,0 +1,53 @@
+import { COUNTRIES, GERMAN_STATES } from '../../lib/holidayRegions'
+
+const cls = 'w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+
+/**
+ * Per-person holiday region override: pick a country (empty = inherit global),
+ * and a Bundesland when the country is Germany. Foreign countries are national
+ * (state = ''); Nager.Date supplies their holidays.
+ */
+export default function RegionOverrideSelect({
+  country,
+  state,
+  onChange,
+}: {
+  country: string | null
+  state: string | null
+  onChange: (country: string | null, state: string | null) => void
+}) {
+  return (
+    <div>
+      <label htmlFor="region-country" className="block text-xs font-medium text-gray-600 mb-1">
+        Feiertagsregion <span className="font-normal text-gray-400">optional — überschreibt global</span>
+      </label>
+      <div className="grid grid-cols-2 gap-2">
+        <select
+          id="region-country"
+          className={cls}
+          value={country ?? ''}
+          onChange={(e) => {
+            const c = e.target.value || null
+            if (!c) onChange(null, null)
+            else if (c === 'DE') onChange('DE', state || 'BY')
+            else onChange(c, '') // foreign countries are national-only
+          }}
+        >
+          <option value="">– global (aus Einstellungen) –</option>
+          {COUNTRIES.map(([code, name]) => <option key={code} value={code}>{name}</option>)}
+        </select>
+        {country === 'DE' && (
+          <select
+            id="region-state"
+            aria-label="Bundesland"
+            className={cls}
+            value={state ?? ''}
+            onChange={(e) => onChange('DE', e.target.value)}
+          >
+            {GERMAN_STATES.map(([code, name]) => <option key={code} value={code}>{name} ({code})</option>)}
+          </select>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type { YearHoliday, YearCalendarPerson } from '../../api'
 import { TYPE_SHORT, TYPE_LABELS, STATUS_LABELS, personColor } from '../../lib/absenceColors'
 import { computeAbsenceSegments } from '../../lib/absenceSegments'
+import { regionKey, regionShade } from '../../lib/holidayRegions'
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
@@ -51,11 +52,14 @@ export default function YearCalendar({
   year,
   holidays,
   persons,
+  displayedRegions,
   onRangeSelect,
 }: {
   year: number
   holidays: YearHoliday[]
   persons: YearCalendarPerson[]
+  /** region keys (country-state) whose holidays to show; undefined = all */
+  displayedRegions?: Set<string>
   /** drag a day range → create absence (personId from the lane, null if empty area) */
   onRangeSelect?: (personId: number | null, startISO: string, endISO: string) => void
 }) {
@@ -68,8 +72,12 @@ export default function YearCalendar({
   const todayStr = isoDate(today.getFullYear(), today.getMonth(), today.getDate())
   const currentMonthIdx = year === today.getFullYear() ? today.getMonth() : null
 
-  const holidayByDate: Record<string, YearHoliday> = {}
-  holidays.forEach((h) => { holidayByDate[h.holiday_date] = h })
+  // Holidays grouped by date, filtered to the displayed regions.
+  const holidaysByDate: Record<string, YearHoliday[]> = {}
+  for (const h of holidays) {
+    if (displayedRegions && !displayedRegions.has(regionKey(h.country, h.state))) continue
+    (holidaysByDate[h.holiday_date] ??= []).push(h)
+  }
 
   const dayNumbers = Array.from({ length: DAY_COLS }, (_, i) => i + 1)
   const months = Array.from({ length: 12 }, (_, i) => i)
@@ -227,11 +235,16 @@ export default function YearCalendar({
                     )
                   }
                   const dateStr = isoDate(year, monthIdx, day)
-                  const holiday = holidayByDate[dateStr]
+                  const dayHolidays = holidaysByDate[dateStr]
                   const weekend = isWeekend(year, monthIdx, day)
                   const isToday = dateStr === todayStr
                   const wd = weekdayIndex(year, monthIdx, day)
-                  const bg = holiday ? 'bg-red-100' : weekend ? 'bg-gray-100' : 'bg-white'
+                  const bg = dayHolidays
+                    ? regionShade(regionKey(dayHolidays[0].country, dayHolidays[0].state))
+                    : weekend ? 'bg-gray-100' : 'bg-white'
+                  const title = dayHolidays
+                    ? dayHolidays.map((h) => `${h.name} (${h.state})`).join(', ') + ` · ${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
+                    : `${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
                   return (
                     <div
                       key={day}
@@ -239,11 +252,7 @@ export default function YearCalendar({
                         isToday ? 'ring-1 ring-inset ring-blue-400' : ''
                       }`}
                       style={{ width: CELL_W }}
-                      title={
-                        holiday
-                          ? `${holiday.name} · ${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
-                          : `${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
-                      }
+                      title={title}
                     />
                   )
                 })}

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -40,18 +40,29 @@ function fmtDe(iso: string | null): string {
 
 // ─── Component ─────────────────────────────────────────────────────────────
 
+interface DragState {
+  monthIdx: number
+  anchorDay: number
+  currentDay: number
+  personId: number | null
+}
+
 export default function YearCalendar({
   year,
   holidays,
   persons,
+  onRangeSelect,
 }: {
   year: number
   holidays: YearHoliday[]
   persons: YearCalendarPerson[]
+  /** drag a day range → create absence (personId from the lane, null if empty area) */
+  onRangeSelect?: (personId: number | null, startISO: string, endISO: string) => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const currentRowRef = useRef<HTMLDivElement>(null)
   const [hoveredPersonId, setHoveredPersonId] = useState<number | null>(null)
+  const [drag, setDrag] = useState<DragState | null>(null)
 
   const today = new Date()
   const todayStr = isoDate(today.getFullYear(), today.getMonth(), today.getDate())
@@ -65,7 +76,7 @@ export default function YearCalendar({
 
   // Absence segments → lanes. Each person with ≥1 absence gets a fixed lane
   // (stable across months so month-spanning bars line up vertically).
-  const { segmentsByMonth, laneOf, laneCount } = useMemo(() => {
+  const { segmentsByMonth, laneOf, laneOrder, laneCount } = useMemo(() => {
     const segs = computeAbsenceSegments(persons, year)
     const order: number[] = []
     for (const p of persons) {
@@ -78,7 +89,7 @@ export default function YearCalendar({
     for (const s of segs) {
       (byMonth[s.monthIdx] ??= []).push(s)
     }
-    return { segmentsByMonth: byMonth, laneOf: lane, laneCount: order.length }
+    return { segmentsByMonth: byMonth, laneOf: lane, laneOrder: order, laneCount: order.length }
   }, [persons, year])
 
   const laneHpct = laneCount > 0 ? 100 / laneCount : 100
@@ -92,6 +103,59 @@ export default function YearCalendar({
     if (!container || !row) return
     container.scrollTop = Math.max(0, row.offsetTop - container.clientHeight / 2 + row.clientHeight / 2)
   }, [year])
+
+  // ── Drag-to-create ──────────────────────────────────────────────────────
+  function dayFromX(e: React.MouseEvent, numDays: number): number {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const idx = Math.floor((e.clientX - rect.left) / (rect.width / DAY_COLS))
+    return Math.min(numDays, Math.max(1, idx + 1))
+  }
+  function personFromY(e: React.MouseEvent): number | null {
+    if (laneCount === 0) return null
+    const rect = e.currentTarget.getBoundingClientRect()
+    let lane = Math.floor((e.clientY - rect.top) / (rect.height / laneCount))
+    lane = Math.max(0, Math.min(laneCount - 1, lane))
+    return laneOrder[lane] ?? null
+  }
+  // Refs let a single always-registered mouseup listener read the latest drag,
+  // callback and year without re-subscribing (and without timing races).
+  const dragRef = useRef<DragState | null>(null)
+  const rangeCbRef = useRef(onRangeSelect)
+  rangeCbRef.current = onRangeSelect
+  const yearRef = useRef(year)
+  yearRef.current = year
+
+  function updateDrag(d: DragState | null) {
+    dragRef.current = d
+    setDrag(d)
+  }
+  function onAreaMouseDown(e: React.MouseEvent, monthIdx: number, numDays: number) {
+    if (!onRangeSelect) return
+    const day = dayFromX(e, numDays)
+    updateDrag({ monthIdx, anchorDay: day, currentDay: day, personId: personFromY(e) })
+    e.preventDefault()
+  }
+  function onAreaMouseMove(e: React.MouseEvent, monthIdx: number, numDays: number) {
+    const d = dragRef.current
+    if (!d || d.monthIdx !== monthIdx) return
+    const day = dayFromX(e, numDays)
+    if (day !== d.currentDay) updateDrag({ ...d, currentDay: day })
+  }
+
+  useEffect(() => {
+    function finish() {
+      const d = dragRef.current
+      if (!d) return
+      const cb = rangeCbRef.current
+      updateDrag(null)
+      if (!cb) return
+      const lo = Math.min(d.anchorDay, d.currentDay)
+      const hi = Math.max(d.anchorDay, d.currentDay)
+      cb(d.personId, isoDate(yearRef.current, d.monthIdx, lo), isoDate(yearRef.current, d.monthIdx, hi))
+    }
+    window.addEventListener('mouseup', finish)
+    return () => window.removeEventListener('mouseup', finish)
+  }, [])
 
   return (
     <div
@@ -141,7 +205,12 @@ export default function YearCalendar({
               </div>
 
               {/* Day cells + absence bars */}
-              <div className="relative flex" style={{ height: ROW_H }}>
+              <div
+                className={`relative flex ${onRangeSelect ? 'cursor-crosshair select-none' : ''}`}
+                style={{ height: ROW_H }}
+                onMouseDown={(e) => onAreaMouseDown(e, monthIdx, numDays)}
+                onMouseMove={(e) => onAreaMouseMove(e, monthIdx, numDays)}
+              >
                 {dayNumbers.map((day) => {
                   const valid = day <= numDays
                   if (!valid) {
@@ -209,6 +278,18 @@ export default function YearCalendar({
                     </div>
                   )
                 })}
+
+                {/* Drag selection overlay */}
+                {drag && drag.monthIdx === monthIdx && (() => {
+                  const lo = Math.min(drag.anchorDay, drag.currentDay)
+                  const hi = Math.max(drag.anchorDay, drag.currentDay)
+                  return (
+                    <div
+                      className="absolute top-0 bottom-0 z-30 bg-blue-400/20 border border-blue-500 pointer-events-none"
+                      style={{ left: `calc(${lo - 1} * ${CELL_W})`, width: `calc(${hi - lo + 1} * ${CELL_W})` }}
+                    />
+                  )
+                })()}
               </div>
             </div>
           )

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -76,15 +76,18 @@ export default function YearCalendar({
 
   // Absence segments → lanes. Each person with ≥1 absence gets a fixed lane
   // (stable across months so month-spanning bars line up vertically).
+  // One lane per passed-in (i.e. selected) person, in the given order — so bar
+  // thickness scales with the selection and every selected person has a
+  // draggable lane, even in months where they have no absence.
   const { segmentsByMonth, laneOf, laneOrder, laneCount } = useMemo(() => {
     const segs = computeAbsenceSegments(persons, year)
     const order: number[] = []
-    for (const p of persons) {
-      if (order.includes(p.id)) continue
-      if (segs.some((s) => s.personId === p.id)) order.push(p.id)
-    }
     const lane: Record<number, number> = {}
-    order.forEach((id, i) => { lane[id] = i })
+    for (const p of persons) {
+      if (lane[p.id] !== undefined) continue
+      lane[p.id] = order.length
+      order.push(p.id)
+    }
     const byMonth: Record<number, typeof segs> = {}
     for (const s of segs) {
       (byMonth[s.monthIdx] ??= []).push(s)

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef } from 'react'
-import type { YearHoliday } from '../../api'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { YearHoliday, YearCalendarPerson } from '../../api'
+import { TYPE_SHORT, TYPE_LABELS, STATUS_LABELS, personColor } from '../../lib/absenceColors'
+import { computeAbsenceSegments } from '../../lib/absenceSegments'
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
@@ -12,25 +14,28 @@ const WEEKDAY_SHORT = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
 const DAY_COLS = 31
 const CELL_W = '1.6rem'
 const LABEL_W = '5.5rem'
-const ROW_H = '2.75rem' // leaves vertical room for stacked absence bars (Phase 2)
+const ROW_H = '2.75rem'
+const ROW_PX = 44 // must match ROW_H — used to decide when a bar is too thin for a label
 
 // ─── Date helpers ───────────────────────────────────────────────────────────
 
 function daysInMonth(year: number, monthIdx: number): number {
   return new Date(year, monthIdx + 1, 0).getDate()
 }
-
 function weekdayIndex(year: number, monthIdx: number, day: number): number {
   return new Date(year, monthIdx, day).getDay()
 }
-
 function isWeekend(year: number, monthIdx: number, day: number): boolean {
   const d = weekdayIndex(year, monthIdx, day)
   return d === 0 || d === 6
 }
-
 function isoDate(year: number, monthIdx: number, day: number): string {
   return `${year}-${String(monthIdx + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+function fmtDe(iso: string | null): string {
+  if (!iso) return 'offen'
+  const [y, m, d] = iso.split('-')
+  return `${d}.${m}.${y}`
 }
 
 // ─── Component ─────────────────────────────────────────────────────────────
@@ -38,12 +43,15 @@ function isoDate(year: number, monthIdx: number, day: number): string {
 export default function YearCalendar({
   year,
   holidays,
+  persons,
 }: {
   year: number
   holidays: YearHoliday[]
+  persons: YearCalendarPerson[]
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const currentRowRef = useRef<HTMLDivElement>(null)
+  const [hoveredPersonId, setHoveredPersonId] = useState<number | null>(null)
 
   const today = new Date()
   const todayStr = isoDate(today.getFullYear(), today.getMonth(), today.getDate())
@@ -55,13 +63,34 @@ export default function YearCalendar({
   const dayNumbers = Array.from({ length: DAY_COLS }, (_, i) => i + 1)
   const months = Array.from({ length: 12 }, (_, i) => i)
 
+  // Absence segments → lanes. Each person with ≥1 absence gets a fixed lane
+  // (stable across months so month-spanning bars line up vertically).
+  const { segmentsByMonth, laneOf, laneCount } = useMemo(() => {
+    const segs = computeAbsenceSegments(persons, year)
+    const order: number[] = []
+    for (const p of persons) {
+      if (order.includes(p.id)) continue
+      if (segs.some((s) => s.personId === p.id)) order.push(p.id)
+    }
+    const lane: Record<number, number> = {}
+    order.forEach((id, i) => { lane[id] = i })
+    const byMonth: Record<number, typeof segs> = {}
+    for (const s of segs) {
+      (byMonth[s.monthIdx] ??= []).push(s)
+    }
+    return { segmentsByMonth: byMonth, laneOf: lane, laneCount: order.length }
+  }, [persons, year])
+
+  const laneHpct = laneCount > 0 ? 100 / laneCount : 100
+  const laneHpx = laneCount > 0 ? ROW_PX / laneCount : ROW_PX
+  const showLabels = laneHpx >= 11
+
   // Center the current month vertically on mount / year change.
   useEffect(() => {
     const container = scrollRef.current
     const row = currentRowRef.current
     if (!container || !row) return
-    const target = row.offsetTop - container.clientHeight / 2 + row.clientHeight / 2
-    container.scrollTop = Math.max(0, target)
+    container.scrollTop = Math.max(0, row.offsetTop - container.clientHeight / 2 + row.clientHeight / 2)
   }, [year])
 
   return (
@@ -94,6 +123,7 @@ export default function YearCalendar({
         {months.map((monthIdx) => {
           const numDays = daysInMonth(year, monthIdx)
           const isCurrent = monthIdx === currentMonthIdx
+          const segs = segmentsByMonth[monthIdx] ?? []
           return (
             <div
               key={monthIdx}
@@ -110,7 +140,7 @@ export default function YearCalendar({
                 {MONTH_NAMES[monthIdx]}
               </div>
 
-              {/* Day cells (bars are overlaid here in Phase 2) */}
+              {/* Day cells + absence bars */}
               <div className="relative flex" style={{ height: ROW_H }}>
                 {dayNumbers.map((day) => {
                   const valid = day <= numDays
@@ -129,11 +159,7 @@ export default function YearCalendar({
                   const weekend = isWeekend(year, monthIdx, day)
                   const isToday = dateStr === todayStr
                   const wd = weekdayIndex(year, monthIdx, day)
-                  const bg = holiday
-                    ? 'bg-red-100'
-                    : weekend
-                      ? 'bg-gray-100'
-                      : 'bg-white'
+                  const bg = holiday ? 'bg-red-100' : weekend ? 'bg-gray-100' : 'bg-white'
                   return (
                     <div
                       key={day}
@@ -147,6 +173,40 @@ export default function YearCalendar({
                           : `${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
                       }
                     />
+                  )
+                })}
+
+                {/* Absence bars — one lane per person, stacked over the day cells */}
+                {segs.map((s, i) => {
+                  const c = personColor(s.personId)
+                  const lane = laneOf[s.personId] ?? 0
+                  const hovered = hoveredPersonId === s.personId
+                  const span = s.endDay - s.startDay + 1
+                  const roundCls =
+                    (s.openStart ? 'rounded-l-none border-l-0 ' : '') +
+                    (s.openEnd ? 'rounded-r-none border-r-0 ' : '')
+                  return (
+                    <div
+                      key={`${s.personId}-${s.absenceId}-${i}`}
+                      className={`absolute flex items-center justify-center overflow-hidden rounded-sm border ${c.bar} ${c.border} ${roundCls} ${
+                        hovered ? `ring-2 ${c.ring} z-20 brightness-105 scale-[1.08]` : 'z-10'
+                      } transition-transform`}
+                      style={{
+                        left: `calc(${s.startDay - 1} * ${CELL_W})`,
+                        width: `calc(${span} * ${CELL_W})`,
+                        top: `calc(${lane * laneHpct}% + 1px)`,
+                        height: `calc(${laneHpct}% - 2px)`,
+                      }}
+                      title={`${s.personName} · ${TYPE_LABELS[s.type]} (${STATUS_LABELS[s.status]}) · ${fmtDe(s.absStart)} – ${fmtDe(s.absEnd)}`}
+                      onMouseEnter={() => setHoveredPersonId(s.personId)}
+                      onMouseLeave={() => setHoveredPersonId(null)}
+                    >
+                      {showLabels && span >= 2 && (
+                        <span className="text-[9px] font-semibold leading-none text-gray-700 select-none pointer-events-none">
+                          {TYPE_SHORT[s.type]}
+                        </span>
+                      )}
+                    </div>
                   )
                 })}
               </div>

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronUp, ChevronDown, ChevronsUp, ChevronsDown, LocateFixed } from 'lucide-react'
 import type { YearHoliday, YearCalendarPerson } from '../../api'
 import { TYPE_SHORT, TYPE_LABELS, STATUS_LABELS, personColor } from '../../lib/absenceColors'
 import { computeAbsenceSegments } from '../../lib/absenceSegments'
@@ -13,10 +14,18 @@ const MONTH_NAMES = [
 const WEEKDAY_SHORT = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
 
 const DAY_COLS = 31
-const CELL_W = '1.6rem'
+const CELL_W = '2rem'       // ~+25% vs. the previous 1.6rem
 const LABEL_W = '5.5rem'
+const YEAR_W = '1.75rem'
 const ROW_H = '2.75rem'
-const ROW_PX = 44 // must match ROW_H — used to decide when a bar is too thin for a label
+const ROW_PX = 44
+
+// Diagonal hatch for out-of-month placeholder cells — clearly visible grey.
+const HATCH: React.CSSProperties = {
+  backgroundColor: '#eceef1',
+  backgroundImage:
+    'repeating-linear-gradient(45deg, rgba(100,116,139,0.35) 0, rgba(100,116,139,0.35) 1px, transparent 1px, transparent 5px)',
+}
 
 // ─── Date helpers ───────────────────────────────────────────────────────────
 
@@ -39,28 +48,27 @@ function fmtDe(iso: string | null): string {
   return `${d}.${m}.${y}`
 }
 
-// ─── Component ─────────────────────────────────────────────────────────────
-
 interface DragState {
+  year: number
   monthIdx: number
   anchorDay: number
   currentDay: number
   personId: number | null
 }
 
+// ─── Component ─────────────────────────────────────────────────────────────
+
 export default function YearCalendar({
-  year,
-  holidays,
+  years,
+  holidaysByYear,
   persons,
   displayedRegions,
   onRangeSelect,
 }: {
-  year: number
-  holidays: YearHoliday[]
+  years: number[]
+  holidaysByYear: Record<number, YearHoliday[]>
   persons: YearCalendarPerson[]
-  /** region keys (country-state) whose holidays to show; undefined = all */
   displayedRegions?: Set<string>
-  /** drag a day range → create absence (personId from the lane, null if empty area) */
   onRangeSelect?: (personId: number | null, startISO: string, endISO: string) => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -70,52 +78,69 @@ export default function YearCalendar({
 
   const today = new Date()
   const todayStr = isoDate(today.getFullYear(), today.getMonth(), today.getDate())
-  const currentMonthIdx = year === today.getFullYear() ? today.getMonth() : null
+  const curYear = today.getFullYear()
+  const curMonth = today.getMonth()
 
-  // Holidays grouped by date, filtered to the displayed regions.
-  const holidaysByDate: Record<string, YearHoliday[]> = {}
-  for (const h of holidays) {
-    if (displayedRegions && !displayedRegions.has(regionKey(h.country, h.state))) continue
-    (holidaysByDate[h.holiday_date] ??= []).push(h)
-  }
+  // Holidays across all years, grouped by ISO date, filtered to shown regions.
+  const holidaysByDate = useMemo(() => {
+    const map: Record<string, YearHoliday[]> = {}
+    for (const y of years) {
+      for (const h of holidaysByYear[y] ?? []) {
+        if (displayedRegions && !displayedRegions.has(regionKey(h.country, h.state))) continue
+        (map[h.holiday_date] ??= []).push(h)
+      }
+    }
+    return map
+  }, [years, holidaysByYear, displayedRegions])
 
-  const dayNumbers = Array.from({ length: DAY_COLS }, (_, i) => i + 1)
-  const months = Array.from({ length: 12 }, (_, i) => i)
-
-  // Absence segments → lanes. Each person with ≥1 absence gets a fixed lane
-  // (stable across months so month-spanning bars line up vertically).
-  // One lane per passed-in (i.e. selected) person, in the given order — so bar
-  // thickness scales with the selection and every selected person has a
-  // draggable lane, even in months where they have no absence.
-  const { segmentsByMonth, laneOf, laneOrder, laneCount } = useMemo(() => {
-    const segs = computeAbsenceSegments(persons, year)
-    const order: number[] = []
+  // One lane per passed-in (selected) person. Segments per year.
+  const { segmentsByYearMonth, laneOf, laneOrder, laneCount } = useMemo(() => {
     const lane: Record<number, number> = {}
+    const order: number[] = []
     for (const p of persons) {
       if (lane[p.id] !== undefined) continue
       lane[p.id] = order.length
       order.push(p.id)
     }
-    const byMonth: Record<number, typeof segs> = {}
-    for (const s of segs) {
-      (byMonth[s.monthIdx] ??= []).push(s)
+    const byYM: Record<string, ReturnType<typeof computeAbsenceSegments>> = {}
+    for (const y of years) {
+      for (const s of computeAbsenceSegments(persons, y)) {
+        (byYM[`${y}-${s.monthIdx}`] ??= []).push(s)
+      }
     }
-    return { segmentsByMonth: byMonth, laneOf: lane, laneOrder: order, laneCount: order.length }
-  }, [persons, year])
+    return { segmentsByYearMonth: byYM, laneOf: lane, laneOrder: order, laneCount: order.length }
+  }, [persons, years])
 
   const laneHpct = laneCount > 0 ? 100 / laneCount : 100
   const laneHpx = laneCount > 0 ? ROW_PX / laneCount : ROW_PX
   const showLabels = laneHpx >= 11
 
-  // Center the current month vertically on mount / year change.
+  const dayNumbers = Array.from({ length: DAY_COLS }, (_, i) => i + 1)
+
+  // Center the current month on mount / when the year range changes.
   useEffect(() => {
     const container = scrollRef.current
     const row = currentRowRef.current
     if (!container || !row) return
     container.scrollTop = Math.max(0, row.offsetTop - container.clientHeight / 2 + row.clientHeight / 2)
-  }, [year])
+  }, [years])
+
+  function scrollBy(rows: number) {
+    scrollRef.current?.scrollBy({ top: rows * ROW_PX, behavior: 'smooth' })
+  }
+  function recenter() {
+    const container = scrollRef.current
+    const row = currentRowRef.current
+    if (!container || !row) return
+    container.scrollTo({ top: Math.max(0, row.offsetTop - container.clientHeight / 2 + row.clientHeight / 2), behavior: 'smooth' })
+  }
 
   // ── Drag-to-create ──────────────────────────────────────────────────────
+  const dragRef = useRef<DragState | null>(null)
+  const rangeCbRef = useRef(onRangeSelect)
+  rangeCbRef.current = onRangeSelect
+
+  function updateDrag(d: DragState | null) { dragRef.current = d; setDrag(d) }
   function dayFromX(e: React.MouseEvent, numDays: number): number {
     const rect = e.currentTarget.getBoundingClientRect()
     const idx = Math.floor((e.clientX - rect.left) / (rect.width / DAY_COLS))
@@ -128,31 +153,18 @@ export default function YearCalendar({
     lane = Math.max(0, Math.min(laneCount - 1, lane))
     return laneOrder[lane] ?? null
   }
-  // Refs let a single always-registered mouseup listener read the latest drag,
-  // callback and year without re-subscribing (and without timing races).
-  const dragRef = useRef<DragState | null>(null)
-  const rangeCbRef = useRef(onRangeSelect)
-  rangeCbRef.current = onRangeSelect
-  const yearRef = useRef(year)
-  yearRef.current = year
-
-  function updateDrag(d: DragState | null) {
-    dragRef.current = d
-    setDrag(d)
-  }
-  function onAreaMouseDown(e: React.MouseEvent, monthIdx: number, numDays: number) {
+  function onAreaMouseDown(e: React.MouseEvent, year: number, monthIdx: number, numDays: number) {
     if (!onRangeSelect) return
     const day = dayFromX(e, numDays)
-    updateDrag({ monthIdx, anchorDay: day, currentDay: day, personId: personFromY(e) })
+    updateDrag({ year, monthIdx, anchorDay: day, currentDay: day, personId: personFromY(e) })
     e.preventDefault()
   }
-  function onAreaMouseMove(e: React.MouseEvent, monthIdx: number, numDays: number) {
+  function onAreaMouseMove(e: React.MouseEvent, year: number, monthIdx: number, numDays: number) {
     const d = dragRef.current
-    if (!d || d.monthIdx !== monthIdx) return
+    if (!d || d.monthIdx !== monthIdx || d.year !== year) return
     const day = dayFromX(e, numDays)
     if (day !== d.currentDay) updateDrag({ ...d, currentDay: day })
   }
-
   useEffect(() => {
     function finish() {
       const d = dragRef.current
@@ -162,150 +174,154 @@ export default function YearCalendar({
       if (!cb) return
       const lo = Math.min(d.anchorDay, d.currentDay)
       const hi = Math.max(d.anchorDay, d.currentDay)
-      cb(d.personId, isoDate(yearRef.current, d.monthIdx, lo), isoDate(yearRef.current, d.monthIdx, hi))
+      cb(d.personId, isoDate(d.year, d.monthIdx, lo), isoDate(d.year, d.monthIdx, hi))
     }
     window.addEventListener('mouseup', finish)
     return () => window.removeEventListener('mouseup', finish)
   }, [])
 
+  // ── A single month row (label + day cells + bars) ────────────────────────
+  function MonthRow({ year, monthIdx }: { year: number; monthIdx: number }) {
+    const numDays = daysInMonth(year, monthIdx)
+    const isCurrent = year === curYear && monthIdx === curMonth
+    const segs = segmentsByYearMonth[`${year}-${monthIdx}`] ?? []
+    return (
+      <div
+        ref={isCurrent ? currentRowRef : undefined}
+        className={`flex border-b border-gray-100 ${isCurrent ? 'bg-blue-50/40' : ''}`}
+      >
+        <div
+          className={`sticky z-10 flex-shrink-0 flex items-center border-r border-gray-200 px-2 font-medium ${
+            isCurrent ? 'bg-blue-50 text-blue-700' : 'bg-white text-gray-600'
+          }`}
+          style={{ left: YEAR_W, width: LABEL_W, height: ROW_H }}
+        >
+          {MONTH_NAMES[monthIdx]}
+        </div>
+        <div
+          className={`relative flex ${onRangeSelect ? 'cursor-crosshair select-none' : ''}`}
+          style={{ height: ROW_H }}
+          onMouseDown={(e) => onAreaMouseDown(e, year, monthIdx, numDays)}
+          onMouseMove={(e) => onAreaMouseMove(e, year, monthIdx, numDays)}
+        >
+          {dayNumbers.map((day) => {
+            if (day > numDays) {
+              return <div key={day} className="flex-shrink-0 border-r border-gray-100" style={{ width: CELL_W, ...HATCH }} aria-hidden="true" />
+            }
+            const dateStr = isoDate(year, monthIdx, day)
+            const dayHolidays = holidaysByDate[dateStr]
+            const weekend = isWeekend(year, monthIdx, day)
+            const isToday = dateStr === todayStr
+            const wd = weekdayIndex(year, monthIdx, day)
+            const bg = dayHolidays
+              ? regionShade(regionKey(dayHolidays[0].country, dayHolidays[0].state))
+              : weekend ? 'bg-gray-100' : 'bg-white'
+            const title = dayHolidays
+              ? dayHolidays.map((h) => `${h.name} (${h.state})`).join(', ') + ` · ${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
+              : `${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
+            return (
+              <div
+                key={day}
+                className={`flex-shrink-0 border-r border-gray-100 ${bg} ${isToday ? 'ring-1 ring-inset ring-blue-400' : ''}`}
+                style={{ width: CELL_W }}
+                title={title}
+              />
+            )
+          })}
+
+          {segs.map((s, i) => {
+            const c = personColor(s.personId)
+            const lane = laneOf[s.personId] ?? 0
+            const hovered = hoveredPersonId === s.personId
+            const span = s.endDay - s.startDay + 1
+            const roundCls = (s.openStart ? 'rounded-l-none border-l-0 ' : '') + (s.openEnd ? 'rounded-r-none border-r-0 ' : '')
+            return (
+              <div
+                key={`${s.personId}-${s.absenceId}-${i}`}
+                className={`absolute flex items-center justify-center overflow-hidden rounded-sm border ${c.bar} ${c.border} ${roundCls} ${
+                  hovered ? `ring-2 ${c.ring} z-20 brightness-105 scale-[1.08]` : 'z-10'
+                } transition-transform`}
+                style={{
+                  left: `calc(${s.startDay - 1} * ${CELL_W})`,
+                  width: `calc(${span} * ${CELL_W})`,
+                  top: `calc(${lane * laneHpct}% + 1px)`,
+                  height: `calc(${laneHpct}% - 2px)`,
+                }}
+                title={`${s.personName} · ${TYPE_LABELS[s.type]} (${STATUS_LABELS[s.status]}) · ${fmtDe(s.absStart)} – ${fmtDe(s.absEnd)}`}
+                onMouseEnter={() => setHoveredPersonId(s.personId)}
+                onMouseLeave={() => setHoveredPersonId(null)}
+              >
+                {showLabels && span >= 2 && (
+                  <span className="text-[9px] font-semibold leading-none text-gray-700 select-none pointer-events-none">{TYPE_SHORT[s.type]}</span>
+                )}
+              </div>
+            )
+          })}
+
+          {drag && drag.year === year && drag.monthIdx === monthIdx && (() => {
+            const lo = Math.min(drag.anchorDay, drag.currentDay)
+            const hi = Math.max(drag.anchorDay, drag.currentDay)
+            return (
+              <div
+                className="absolute top-0 bottom-0 z-30 bg-blue-400/20 border border-blue-500 pointer-events-none"
+                style={{ left: `calc(${lo - 1} * ${CELL_W})`, width: `calc(${hi - lo + 1} * ${CELL_W})` }}
+              />
+            )
+          })()}
+        </div>
+      </div>
+    )
+  }
+
+  const scrollBtn = 'p-1 rounded border border-gray-200 text-gray-500 hover:bg-gray-100'
+
   return (
-    <div
-      ref={scrollRef}
-      className="overflow-auto rounded-lg border border-gray-200 bg-white max-h-[70vh]"
-      aria-label={`Jahreskalender ${year}`}
-    >
-      <div className="inline-block min-w-full text-xs">
-        {/* Header: day numbers */}
-        <div className="flex sticky top-0 z-20 bg-gray-50 border-b border-gray-200">
-          <div
-            className="sticky left-0 z-30 bg-gray-50 flex-shrink-0 border-r border-gray-200 px-2 py-1 font-semibold text-gray-500 uppercase tracking-wide"
-            style={{ width: LABEL_W }}
-          >
-            Monat
+    <div className="flex gap-1">
+      <div
+        ref={scrollRef}
+        className="overflow-auto rounded-lg border border-gray-200 bg-white max-h-[70vh] flex-1"
+        aria-label="Jahreskalender"
+      >
+        <div className="inline-block min-w-full text-xs">
+          {/* Header: day numbers */}
+          <div className="flex sticky top-0 z-30 bg-gray-50 border-b border-gray-200">
+            <div className="sticky left-0 z-40 bg-gray-50 flex-shrink-0 border-r border-gray-200" style={{ width: YEAR_W }} />
+            <div className="sticky z-40 bg-gray-50 flex-shrink-0 border-r border-gray-200 px-2 py-1 font-semibold text-gray-500 uppercase tracking-wide" style={{ left: YEAR_W, width: LABEL_W }}>
+              Monat
+            </div>
+            {dayNumbers.map((d) => (
+              <div key={d} className="flex-shrink-0 text-center py-1 text-[10px] font-medium text-gray-400 border-r border-gray-100" style={{ width: CELL_W }}>
+                {d}
+              </div>
+            ))}
           </div>
-          {dayNumbers.map((d) => (
-            <div
-              key={d}
-              className="flex-shrink-0 text-center py-1 text-[10px] font-medium text-gray-400 border-r border-gray-100"
-              style={{ width: CELL_W }}
-            >
-              {d}
+
+          {/* Year groups */}
+          {years.map((year) => (
+            <div key={year} className="flex">
+              <div
+                className="sticky left-0 z-20 flex-shrink-0 flex items-center justify-center bg-gray-50 border-r border-gray-200 font-semibold text-gray-500"
+                style={{ width: YEAR_W, writingMode: 'vertical-rl' }}
+              >
+                {year}
+              </div>
+              <div className="flex flex-col">
+                {MONTH_NAMES.map((_, monthIdx) => (
+                  <MonthRow key={monthIdx} year={year} monthIdx={monthIdx} />
+                ))}
+              </div>
             </div>
           ))}
         </div>
+      </div>
 
-        {/* One row per month */}
-        {months.map((monthIdx) => {
-          const numDays = daysInMonth(year, monthIdx)
-          const isCurrent = monthIdx === currentMonthIdx
-          const segs = segmentsByMonth[monthIdx] ?? []
-          return (
-            <div
-              key={monthIdx}
-              ref={isCurrent ? currentRowRef : undefined}
-              className={`flex border-b border-gray-100 ${isCurrent ? 'bg-blue-50/40' : ''}`}
-            >
-              {/* Sticky month label */}
-              <div
-                className={`sticky left-0 z-10 flex-shrink-0 flex items-center border-r border-gray-200 px-2 font-medium ${
-                  isCurrent ? 'bg-blue-50 text-blue-700' : 'bg-white text-gray-600'
-                }`}
-                style={{ width: LABEL_W, height: ROW_H }}
-              >
-                {MONTH_NAMES[monthIdx]}
-              </div>
-
-              {/* Day cells + absence bars */}
-              <div
-                className={`relative flex ${onRangeSelect ? 'cursor-crosshair select-none' : ''}`}
-                style={{ height: ROW_H }}
-                onMouseDown={(e) => onAreaMouseDown(e, monthIdx, numDays)}
-                onMouseMove={(e) => onAreaMouseMove(e, monthIdx, numDays)}
-              >
-                {dayNumbers.map((day) => {
-                  const valid = day <= numDays
-                  if (!valid) {
-                    return (
-                      <div
-                        key={day}
-                        className="flex-shrink-0 bg-gray-50/70 border-r border-gray-100"
-                        style={{ width: CELL_W }}
-                        aria-hidden="true"
-                      />
-                    )
-                  }
-                  const dateStr = isoDate(year, monthIdx, day)
-                  const dayHolidays = holidaysByDate[dateStr]
-                  const weekend = isWeekend(year, monthIdx, day)
-                  const isToday = dateStr === todayStr
-                  const wd = weekdayIndex(year, monthIdx, day)
-                  const bg = dayHolidays
-                    ? regionShade(regionKey(dayHolidays[0].country, dayHolidays[0].state))
-                    : weekend ? 'bg-gray-100' : 'bg-white'
-                  const title = dayHolidays
-                    ? dayHolidays.map((h) => `${h.name} (${h.state})`).join(', ') + ` · ${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
-                    : `${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
-                  return (
-                    <div
-                      key={day}
-                      className={`flex-shrink-0 border-r border-gray-100 ${bg} ${
-                        isToday ? 'ring-1 ring-inset ring-blue-400' : ''
-                      }`}
-                      style={{ width: CELL_W }}
-                      title={title}
-                    />
-                  )
-                })}
-
-                {/* Absence bars — one lane per person, stacked over the day cells */}
-                {segs.map((s, i) => {
-                  const c = personColor(s.personId)
-                  const lane = laneOf[s.personId] ?? 0
-                  const hovered = hoveredPersonId === s.personId
-                  const span = s.endDay - s.startDay + 1
-                  const roundCls =
-                    (s.openStart ? 'rounded-l-none border-l-0 ' : '') +
-                    (s.openEnd ? 'rounded-r-none border-r-0 ' : '')
-                  return (
-                    <div
-                      key={`${s.personId}-${s.absenceId}-${i}`}
-                      className={`absolute flex items-center justify-center overflow-hidden rounded-sm border ${c.bar} ${c.border} ${roundCls} ${
-                        hovered ? `ring-2 ${c.ring} z-20 brightness-105 scale-[1.08]` : 'z-10'
-                      } transition-transform`}
-                      style={{
-                        left: `calc(${s.startDay - 1} * ${CELL_W})`,
-                        width: `calc(${span} * ${CELL_W})`,
-                        top: `calc(${lane * laneHpct}% + 1px)`,
-                        height: `calc(${laneHpct}% - 2px)`,
-                      }}
-                      title={`${s.personName} · ${TYPE_LABELS[s.type]} (${STATUS_LABELS[s.status]}) · ${fmtDe(s.absStart)} – ${fmtDe(s.absEnd)}`}
-                      onMouseEnter={() => setHoveredPersonId(s.personId)}
-                      onMouseLeave={() => setHoveredPersonId(null)}
-                    >
-                      {showLabels && span >= 2 && (
-                        <span className="text-[9px] font-semibold leading-none text-gray-700 select-none pointer-events-none">
-                          {TYPE_SHORT[s.type]}
-                        </span>
-                      )}
-                    </div>
-                  )
-                })}
-
-                {/* Drag selection overlay */}
-                {drag && drag.monthIdx === monthIdx && (() => {
-                  const lo = Math.min(drag.anchorDay, drag.currentDay)
-                  const hi = Math.max(drag.anchorDay, drag.currentDay)
-                  return (
-                    <div
-                      className="absolute top-0 bottom-0 z-30 bg-blue-400/20 border border-blue-500 pointer-events-none"
-                      style={{ left: `calc(${lo - 1} * ${CELL_W})`, width: `calc(${hi - lo + 1} * ${CELL_W})` }}
-                    />
-                  )
-                })()}
-              </div>
-            </div>
-          )
-        })}
+      {/* Scroll controls */}
+      <div className="flex flex-col justify-center gap-1">
+        <button onClick={() => scrollBy(-12)} className={scrollBtn} title="Ein Jahr zurück" aria-label="Ein Jahr zurück"><ChevronsUp size={15} /></button>
+        <button onClick={() => scrollBy(-1)} className={scrollBtn} title="Ein Monat zurück" aria-label="Ein Monat zurück"><ChevronUp size={15} /></button>
+        <button onClick={recenter} className={scrollBtn} title="Zum aktuellen Monat" aria-label="Zum aktuellen Monat"><LocateFixed size={14} /></button>
+        <button onClick={() => scrollBy(1)} className={scrollBtn} title="Ein Monat vor" aria-label="Ein Monat vor"><ChevronDown size={15} /></button>
+        <button onClick={() => scrollBy(12)} className={scrollBtn} title="Ein Jahr vor" aria-label="Ein Jahr vor"><ChevronsDown size={15} /></button>
       </div>
     </div>
   )

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from 'react'
+import type { YearHoliday } from '../../api'
+
+// ─── Layout constants ─────────────────────────────────────────────────────────
+
+const MONTH_NAMES = [
+  'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',
+  'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+]
+const WEEKDAY_SHORT = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
+
+const DAY_COLS = 31
+const CELL_W = '1.6rem'
+const LABEL_W = '5.5rem'
+const ROW_H = '2.75rem' // leaves vertical room for stacked absence bars (Phase 2)
+
+// ─── Date helpers ───────────────────────────────────────────────────────────
+
+function daysInMonth(year: number, monthIdx: number): number {
+  return new Date(year, monthIdx + 1, 0).getDate()
+}
+
+function weekdayIndex(year: number, monthIdx: number, day: number): number {
+  return new Date(year, monthIdx, day).getDay()
+}
+
+function isWeekend(year: number, monthIdx: number, day: number): boolean {
+  const d = weekdayIndex(year, monthIdx, day)
+  return d === 0 || d === 6
+}
+
+function isoDate(year: number, monthIdx: number, day: number): string {
+  return `${year}-${String(monthIdx + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────
+
+export default function YearCalendar({
+  year,
+  holidays,
+}: {
+  year: number
+  holidays: YearHoliday[]
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const currentRowRef = useRef<HTMLDivElement>(null)
+
+  const today = new Date()
+  const todayStr = isoDate(today.getFullYear(), today.getMonth(), today.getDate())
+  const currentMonthIdx = year === today.getFullYear() ? today.getMonth() : null
+
+  const holidayByDate: Record<string, YearHoliday> = {}
+  holidays.forEach((h) => { holidayByDate[h.holiday_date] = h })
+
+  const dayNumbers = Array.from({ length: DAY_COLS }, (_, i) => i + 1)
+  const months = Array.from({ length: 12 }, (_, i) => i)
+
+  // Center the current month vertically on mount / year change.
+  useEffect(() => {
+    const container = scrollRef.current
+    const row = currentRowRef.current
+    if (!container || !row) return
+    const target = row.offsetTop - container.clientHeight / 2 + row.clientHeight / 2
+    container.scrollTop = Math.max(0, target)
+  }, [year])
+
+  return (
+    <div
+      ref={scrollRef}
+      className="overflow-auto rounded-lg border border-gray-200 bg-white max-h-[70vh]"
+      aria-label={`Jahreskalender ${year}`}
+    >
+      <div className="inline-block min-w-full text-xs">
+        {/* Header: day numbers */}
+        <div className="flex sticky top-0 z-20 bg-gray-50 border-b border-gray-200">
+          <div
+            className="sticky left-0 z-30 bg-gray-50 flex-shrink-0 border-r border-gray-200 px-2 py-1 font-semibold text-gray-500 uppercase tracking-wide"
+            style={{ width: LABEL_W }}
+          >
+            Monat
+          </div>
+          {dayNumbers.map((d) => (
+            <div
+              key={d}
+              className="flex-shrink-0 text-center py-1 text-[10px] font-medium text-gray-400 border-r border-gray-100"
+              style={{ width: CELL_W }}
+            >
+              {d}
+            </div>
+          ))}
+        </div>
+
+        {/* One row per month */}
+        {months.map((monthIdx) => {
+          const numDays = daysInMonth(year, monthIdx)
+          const isCurrent = monthIdx === currentMonthIdx
+          return (
+            <div
+              key={monthIdx}
+              ref={isCurrent ? currentRowRef : undefined}
+              className={`flex border-b border-gray-100 ${isCurrent ? 'bg-blue-50/40' : ''}`}
+            >
+              {/* Sticky month label */}
+              <div
+                className={`sticky left-0 z-10 flex-shrink-0 flex items-center border-r border-gray-200 px-2 font-medium ${
+                  isCurrent ? 'bg-blue-50 text-blue-700' : 'bg-white text-gray-600'
+                }`}
+                style={{ width: LABEL_W, height: ROW_H }}
+              >
+                {MONTH_NAMES[monthIdx]}
+              </div>
+
+              {/* Day cells (bars are overlaid here in Phase 2) */}
+              <div className="relative flex" style={{ height: ROW_H }}>
+                {dayNumbers.map((day) => {
+                  const valid = day <= numDays
+                  if (!valid) {
+                    return (
+                      <div
+                        key={day}
+                        className="flex-shrink-0 bg-gray-50/70 border-r border-gray-100"
+                        style={{ width: CELL_W }}
+                        aria-hidden="true"
+                      />
+                    )
+                  }
+                  const dateStr = isoDate(year, monthIdx, day)
+                  const holiday = holidayByDate[dateStr]
+                  const weekend = isWeekend(year, monthIdx, day)
+                  const isToday = dateStr === todayStr
+                  const wd = weekdayIndex(year, monthIdx, day)
+                  const bg = holiday
+                    ? 'bg-red-100'
+                    : weekend
+                      ? 'bg-gray-100'
+                      : 'bg-white'
+                  return (
+                    <div
+                      key={day}
+                      className={`flex-shrink-0 border-r border-gray-100 ${bg} ${
+                        isToday ? 'ring-1 ring-inset ring-blue-400' : ''
+                      }`}
+                      style={{ width: CELL_W }}
+                      title={
+                        holiday
+                          ? `${holiday.name} · ${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
+                          : `${WEEKDAY_SHORT[wd]} ${day}.${monthIdx + 1}.`
+                      }
+                    />
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/__tests__/absenceSegments.test.ts
+++ b/frontend/src/lib/__tests__/absenceSegments.test.ts
@@ -3,7 +3,7 @@ import { computeAbsenceSegments } from '../absenceSegments'
 import type { YearCalendarPerson } from '../../api'
 
 function person(absences: YearCalendarPerson['absences']): YearCalendarPerson {
-  return { id: 1, name: 'P', default_weekly_hours: 40, absences, memberships: [] }
+  return { id: 1, name: 'P', default_weekly_hours: 40, holiday_country: 'DE', holiday_state: 'BY', absences, memberships: [] }
 }
 
 function abs(start: string, end: string | null, type: 'vacation' | 'sick' | 'training' = 'vacation') {

--- a/frontend/src/lib/__tests__/absenceSegments.test.ts
+++ b/frontend/src/lib/__tests__/absenceSegments.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { computeAbsenceSegments } from '../absenceSegments'
+import type { YearCalendarPerson } from '../../api'
+
+function person(absences: YearCalendarPerson['absences']): YearCalendarPerson {
+  return { id: 1, name: 'P', default_weekly_hours: 40, absences, memberships: [] }
+}
+
+function abs(start: string, end: string | null, type: 'vacation' | 'sick' | 'training' = 'vacation') {
+  return { id: 1, start_date: start, end_date: end, absence_type: type, status: 'confirmed' as const }
+}
+
+describe('computeAbsenceSegments', () => {
+  it('keeps a single-month absence as one closed segment', () => {
+    const segs = computeAbsenceSegments([person([abs('2026-05-04', '2026-05-08')])], 2026)
+    expect(segs).toHaveLength(1)
+    expect(segs[0]).toMatchObject({ monthIdx: 4, startDay: 4, endDay: 8, openStart: false, openEnd: false })
+  })
+
+  it('splits a month-spanning absence and flags the break edges as open', () => {
+    const segs = computeAbsenceSegments([person([abs('2026-09-21', '2026-10-04')])], 2026)
+    expect(segs).toHaveLength(2)
+    const [sep, oct] = segs
+    expect(sep).toMatchObject({ monthIdx: 8, startDay: 21, endDay: 30, openStart: false, openEnd: true })
+    expect(oct).toMatchObject({ monthIdx: 9, startDay: 1, endDay: 4, openStart: true, openEnd: false })
+  })
+
+  it('marks the December segment open when the absence runs into the next year', () => {
+    const segs = computeAbsenceSegments([person([abs('2026-12-24', '2027-01-09')])], 2026)
+    expect(segs).toHaveLength(1)
+    expect(segs[0]).toMatchObject({ monthIdx: 11, startDay: 24, endDay: 31, openEnd: true })
+  })
+
+  it('marks the January segment open when the absence started in the previous year', () => {
+    const segs = computeAbsenceSegments([person([abs('2025-12-28', '2026-01-05')])], 2026)
+    expect(segs).toHaveLength(1)
+    expect(segs[0]).toMatchObject({ monthIdx: 0, startDay: 1, endDay: 5, openStart: true, openEnd: false })
+  })
+
+  it('treats an ongoing (null end) absence as running to year end, open at the tail', () => {
+    const segs = computeAbsenceSegments([person([abs('2026-11-15', null, 'sick')])], 2026)
+    // Nov (open end) + Dec (open both ends)
+    expect(segs).toHaveLength(2)
+    expect(segs[0]).toMatchObject({ monthIdx: 10, startDay: 15, openEnd: true })
+    expect(segs[1]).toMatchObject({ monthIdx: 11, endDay: 31, openStart: true, openEnd: true })
+  })
+
+  it('excludes absences that do not overlap the year', () => {
+    const segs = computeAbsenceSegments([person([abs('2025-03-01', '2025-03-05')])], 2026)
+    expect(segs).toHaveLength(0)
+  })
+})

--- a/frontend/src/lib/absenceColors.ts
+++ b/frontend/src/lib/absenceColors.ts
@@ -1,0 +1,90 @@
+// Shared absence label/color maps and per-person color palette.
+//
+// Single source of truth for what used to be duplicated in PersonDetailPage
+// (TYPE_LABELS / TYPE_COLORS / STATUS_LABELS) and CalendarPage
+// (ABSENCE_BG / ABSENCE_LABEL / ABSENCE_NAME / STATUS_NAME).
+//
+// NOTE: Tailwind's JIT only picks up class names that appear verbatim, so the
+// palette below enumerates every variant statically — do not build class names
+// by string concatenation.
+
+import type { PersonAbsence } from '../api'
+
+type AbsenceType = PersonAbsence['absence_type'] // 'vacation' | 'sick' | 'training'
+type AbsenceStatus = PersonAbsence['status'] // 'planned' | 'confirmed' | 'ongoing'
+
+/** Long German labels (Urlaub / Krank / Fortbildung). */
+export const TYPE_LABELS: Record<AbsenceType, string> = {
+  vacation: 'Urlaub',
+  sick: 'Krank',
+  training: 'Fortbildung',
+}
+
+/** Single-letter codes for compact inline tags (U / K / F). */
+export const TYPE_SHORT: Record<AbsenceType, string> = {
+  vacation: 'U',
+  sick: 'K',
+  training: 'F',
+}
+
+/** Light badge classes (bg + text) — tables, legends, chips. */
+export const TYPE_BADGE: Record<AbsenceType, string> = {
+  vacation: 'bg-blue-100 text-blue-700',
+  sick: 'bg-yellow-100 text-yellow-700',
+  training: 'bg-emerald-100 text-emerald-700',
+}
+
+/** Stronger fill classes — per-day overlays / bars in the month calendar. */
+export const TYPE_BAR_BG: Record<AbsenceType, string> = {
+  vacation: 'bg-blue-200',
+  sick: 'bg-yellow-200',
+  training: 'bg-emerald-200',
+}
+
+export const STATUS_LABELS: Record<AbsenceStatus, string> = {
+  planned: 'Geplant',
+  confirmed: 'Bestätigt',
+  ongoing: 'Laufend',
+}
+
+// ─── Per-person color palette ──────────────────────────────────────────────
+//
+// Each person is assigned one entry deterministically by id, used identically
+// in the year-calendar bars and the person table so the two views harmonize.
+// Reds are reserved for holidays and grays for weekends / deselected rows, so
+// those hues are excluded here.
+
+export interface PersonColor {
+  /** solid swatch — table legend dot */
+  dot: string
+  /** semi-transparent bar body */
+  bar: string
+  /** solid bar (e.g. hover-emphasized) */
+  barSolid: string
+  /** border color — hover highlight */
+  border: string
+  /** light row tint — table row background when selected */
+  rowBg: string
+  /** readable text color on light backgrounds */
+  text: string
+}
+
+export const PERSON_PALETTE: PersonColor[] = [
+  { dot: 'bg-sky-500', bar: 'bg-sky-400/30', barSolid: 'bg-sky-400', border: 'border-sky-500', rowBg: 'bg-sky-50', text: 'text-sky-700' },
+  { dot: 'bg-violet-500', bar: 'bg-violet-400/30', barSolid: 'bg-violet-400', border: 'border-violet-500', rowBg: 'bg-violet-50', text: 'text-violet-700' },
+  { dot: 'bg-amber-500', bar: 'bg-amber-400/30', barSolid: 'bg-amber-400', border: 'border-amber-500', rowBg: 'bg-amber-50', text: 'text-amber-700' },
+  { dot: 'bg-teal-500', bar: 'bg-teal-400/30', barSolid: 'bg-teal-400', border: 'border-teal-500', rowBg: 'bg-teal-50', text: 'text-teal-700' },
+  { dot: 'bg-pink-500', bar: 'bg-pink-400/30', barSolid: 'bg-pink-400', border: 'border-pink-500', rowBg: 'bg-pink-50', text: 'text-pink-700' },
+  { dot: 'bg-lime-500', bar: 'bg-lime-400/30', barSolid: 'bg-lime-400', border: 'border-lime-500', rowBg: 'bg-lime-50', text: 'text-lime-700' },
+  { dot: 'bg-indigo-500', bar: 'bg-indigo-400/30', barSolid: 'bg-indigo-400', border: 'border-indigo-500', rowBg: 'bg-indigo-50', text: 'text-indigo-700' },
+  { dot: 'bg-orange-500', bar: 'bg-orange-400/30', barSolid: 'bg-orange-400', border: 'border-orange-500', rowBg: 'bg-orange-50', text: 'text-orange-700' },
+  { dot: 'bg-cyan-500', bar: 'bg-cyan-400/30', barSolid: 'bg-cyan-400', border: 'border-cyan-500', rowBg: 'bg-cyan-50', text: 'text-cyan-700' },
+  { dot: 'bg-fuchsia-500', bar: 'bg-fuchsia-400/30', barSolid: 'bg-fuchsia-400', border: 'border-fuchsia-500', rowBg: 'bg-fuchsia-50', text: 'text-fuchsia-700' },
+  { dot: 'bg-emerald-500', bar: 'bg-emerald-400/30', barSolid: 'bg-emerald-400', border: 'border-emerald-500', rowBg: 'bg-emerald-50', text: 'text-emerald-700' },
+  { dot: 'bg-rose-500', bar: 'bg-rose-400/30', barSolid: 'bg-rose-400', border: 'border-rose-500', rowBg: 'bg-rose-50', text: 'text-rose-700' },
+]
+
+/** Deterministic per-person color (stable across views). */
+export function personColor(personId: number): PersonColor {
+  return PERSON_PALETTE[personId % PERSON_PALETTE.length]
+}

--- a/frontend/src/lib/absenceColors.ts
+++ b/frontend/src/lib/absenceColors.ts
@@ -61,8 +61,10 @@ export interface PersonColor {
   bar: string
   /** solid bar (e.g. hover-emphasized) */
   barSolid: string
-  /** border color — hover highlight */
+  /** border color — bar outline */
   border: string
+  /** ring color — hover highlight */
+  ring: string
   /** light row tint — table row background when selected */
   rowBg: string
   /** readable text color on light backgrounds */
@@ -70,18 +72,18 @@ export interface PersonColor {
 }
 
 export const PERSON_PALETTE: PersonColor[] = [
-  { dot: 'bg-sky-500', bar: 'bg-sky-400/30', barSolid: 'bg-sky-400', border: 'border-sky-500', rowBg: 'bg-sky-50', text: 'text-sky-700' },
-  { dot: 'bg-violet-500', bar: 'bg-violet-400/30', barSolid: 'bg-violet-400', border: 'border-violet-500', rowBg: 'bg-violet-50', text: 'text-violet-700' },
-  { dot: 'bg-amber-500', bar: 'bg-amber-400/30', barSolid: 'bg-amber-400', border: 'border-amber-500', rowBg: 'bg-amber-50', text: 'text-amber-700' },
-  { dot: 'bg-teal-500', bar: 'bg-teal-400/30', barSolid: 'bg-teal-400', border: 'border-teal-500', rowBg: 'bg-teal-50', text: 'text-teal-700' },
-  { dot: 'bg-pink-500', bar: 'bg-pink-400/30', barSolid: 'bg-pink-400', border: 'border-pink-500', rowBg: 'bg-pink-50', text: 'text-pink-700' },
-  { dot: 'bg-lime-500', bar: 'bg-lime-400/30', barSolid: 'bg-lime-400', border: 'border-lime-500', rowBg: 'bg-lime-50', text: 'text-lime-700' },
-  { dot: 'bg-indigo-500', bar: 'bg-indigo-400/30', barSolid: 'bg-indigo-400', border: 'border-indigo-500', rowBg: 'bg-indigo-50', text: 'text-indigo-700' },
-  { dot: 'bg-orange-500', bar: 'bg-orange-400/30', barSolid: 'bg-orange-400', border: 'border-orange-500', rowBg: 'bg-orange-50', text: 'text-orange-700' },
-  { dot: 'bg-cyan-500', bar: 'bg-cyan-400/30', barSolid: 'bg-cyan-400', border: 'border-cyan-500', rowBg: 'bg-cyan-50', text: 'text-cyan-700' },
-  { dot: 'bg-fuchsia-500', bar: 'bg-fuchsia-400/30', barSolid: 'bg-fuchsia-400', border: 'border-fuchsia-500', rowBg: 'bg-fuchsia-50', text: 'text-fuchsia-700' },
-  { dot: 'bg-emerald-500', bar: 'bg-emerald-400/30', barSolid: 'bg-emerald-400', border: 'border-emerald-500', rowBg: 'bg-emerald-50', text: 'text-emerald-700' },
-  { dot: 'bg-rose-500', bar: 'bg-rose-400/30', barSolid: 'bg-rose-400', border: 'border-rose-500', rowBg: 'bg-rose-50', text: 'text-rose-700' },
+  { dot: 'bg-sky-500', bar: 'bg-sky-400/30', barSolid: 'bg-sky-400', border: 'border-sky-500', ring: 'ring-sky-500', rowBg: 'bg-sky-50', text: 'text-sky-700' },
+  { dot: 'bg-violet-500', bar: 'bg-violet-400/30', barSolid: 'bg-violet-400', border: 'border-violet-500', ring: 'ring-violet-500', rowBg: 'bg-violet-50', text: 'text-violet-700' },
+  { dot: 'bg-amber-500', bar: 'bg-amber-400/30', barSolid: 'bg-amber-400', border: 'border-amber-500', ring: 'ring-amber-500', rowBg: 'bg-amber-50', text: 'text-amber-700' },
+  { dot: 'bg-teal-500', bar: 'bg-teal-400/30', barSolid: 'bg-teal-400', border: 'border-teal-500', ring: 'ring-teal-500', rowBg: 'bg-teal-50', text: 'text-teal-700' },
+  { dot: 'bg-pink-500', bar: 'bg-pink-400/30', barSolid: 'bg-pink-400', border: 'border-pink-500', ring: 'ring-pink-500', rowBg: 'bg-pink-50', text: 'text-pink-700' },
+  { dot: 'bg-lime-500', bar: 'bg-lime-400/30', barSolid: 'bg-lime-400', border: 'border-lime-500', ring: 'ring-lime-500', rowBg: 'bg-lime-50', text: 'text-lime-700' },
+  { dot: 'bg-indigo-500', bar: 'bg-indigo-400/30', barSolid: 'bg-indigo-400', border: 'border-indigo-500', ring: 'ring-indigo-500', rowBg: 'bg-indigo-50', text: 'text-indigo-700' },
+  { dot: 'bg-orange-500', bar: 'bg-orange-400/30', barSolid: 'bg-orange-400', border: 'border-orange-500', ring: 'ring-orange-500', rowBg: 'bg-orange-50', text: 'text-orange-700' },
+  { dot: 'bg-cyan-500', bar: 'bg-cyan-400/30', barSolid: 'bg-cyan-400', border: 'border-cyan-500', ring: 'ring-cyan-500', rowBg: 'bg-cyan-50', text: 'text-cyan-700' },
+  { dot: 'bg-fuchsia-500', bar: 'bg-fuchsia-400/30', barSolid: 'bg-fuchsia-400', border: 'border-fuchsia-500', ring: 'ring-fuchsia-500', rowBg: 'bg-fuchsia-50', text: 'text-fuchsia-700' },
+  { dot: 'bg-emerald-500', bar: 'bg-emerald-400/30', barSolid: 'bg-emerald-400', border: 'border-emerald-500', ring: 'ring-emerald-500', rowBg: 'bg-emerald-50', text: 'text-emerald-700' },
+  { dot: 'bg-rose-500', bar: 'bg-rose-400/30', barSolid: 'bg-rose-400', border: 'border-rose-500', ring: 'ring-rose-500', rowBg: 'bg-rose-50', text: 'text-rose-700' },
 ]
 
 /** Deterministic per-person color (stable across views). */

--- a/frontend/src/lib/absenceSegments.ts
+++ b/frontend/src/lib/absenceSegments.ts
@@ -1,0 +1,96 @@
+// Split each person's absences into per-month segments for the year calendar.
+//
+// A single absence that spans several months yields one segment per month, each
+// flagged openStart/openEnd when it continues across a month (or year) boundary
+// so the UI can draw an "open" edge at the break.
+
+import type { YearCalendarPerson, CalendarAbsence } from '../api'
+
+type AbsenceType = CalendarAbsence['absence_type']
+type AbsenceStatus = CalendarAbsence['status']
+
+export interface AbsenceSegment {
+  personId: number
+  personName: string
+  absenceId: number
+  type: AbsenceType
+  status: AbsenceStatus
+  monthIdx: number // 0-11
+  startDay: number // 1-based, inclusive
+  endDay: number // 1-based, inclusive
+  openStart: boolean // continues from a previous month / before the year
+  openEnd: boolean // continues into a following month / past the year
+  /** full absence range for tooltips (ISO, end null = ongoing) */
+  absStart: string
+  absEnd: string | null
+}
+
+interface YMD {
+  y: number
+  m: number // 0-based
+  d: number
+}
+
+function parse(s: string): YMD {
+  const [y, m, d] = s.split('-').map(Number)
+  return { y, m: m - 1, d }
+}
+
+/** comparable integer YYYYMMDD */
+function ord(v: YMD): number {
+  return v.y * 10000 + v.m * 100 + v.d
+}
+
+function daysInMonth(year: number, monthIdx: number): number {
+  return new Date(year, monthIdx + 1, 0).getDate()
+}
+
+export function computeAbsenceSegments(
+  persons: YearCalendarPerson[],
+  year: number,
+): AbsenceSegment[] {
+  const yearStart: YMD = { y: year, m: 0, d: 1 }
+  const yearEnd: YMD = { y: year, m: 11, d: 31 }
+  const segments: AbsenceSegment[] = []
+
+  for (const person of persons) {
+    for (const a of person.absences) {
+      const absStart = parse(a.start_date)
+      // Ongoing (null end) or beyond-year end → clamp to year end, mark open.
+      const absEndParsed = a.end_date ? parse(a.end_date) : null
+      const extendsBeforeYear = ord(absStart) < ord(yearStart)
+      const extendsAfterYear = absEndParsed === null || ord(absEndParsed) > ord(yearEnd)
+
+      const clampedStart = ord(absStart) < ord(yearStart) ? yearStart : absStart
+      const clampedEnd =
+        absEndParsed === null || ord(absEndParsed) > ord(yearEnd) ? yearEnd : absEndParsed
+
+      // No overlap with this year.
+      if (ord(clampedStart) > ord(clampedEnd)) continue
+
+      const firstMonth = clampedStart.m
+      const lastMonth = clampedEnd.m
+
+      for (let m = firstMonth; m <= lastMonth; m++) {
+        const startDay = m === firstMonth ? clampedStart.d : 1
+        const endDay = m === lastMonth ? clampedEnd.d : daysInMonth(year, m)
+        segments.push({
+          personId: person.id,
+          personName: person.name,
+          absenceId: a.id,
+          type: a.absence_type,
+          status: a.status,
+          monthIdx: m,
+          startDay,
+          endDay,
+          openStart: m > firstMonth || extendsBeforeYear,
+          openEnd: m < lastMonth || extendsAfterYear,
+          absStart: a.start_date,
+          absEnd: a.end_date,
+        })
+      }
+    }
+  }
+
+  return segments
+}

--- a/frontend/src/lib/holidayRegions.ts
+++ b/frontend/src/lib/holidayRegions.ts
@@ -11,6 +11,14 @@ export const GERMAN_STATES: [string, string][] = [
 
 export const STATE_LABEL: Record<string, string> = Object.fromEntries(GERMAN_STATES)
 
+/** Selectable holiday countries. DE uses feiertage-api.de; the rest use Nager.Date. */
+export const COUNTRIES: [string, string][] = [
+  ['DE', 'Deutschland'], ['GR', 'Griechenland'], ['AT', 'Österreich'], ['CH', 'Schweiz'],
+  ['FR', 'Frankreich'], ['IT', 'Italien'], ['ES', 'Spanien'], ['PL', 'Polen'],
+  ['GB', 'Vereinigtes Königreich'], ['RO', 'Rumänien'], ['BG', 'Bulgarien'], ['US', 'USA'],
+]
+export const COUNTRY_LABEL: Record<string, string> = Object.fromEntries(COUNTRIES)
+
 /** Optional local holidays — keys must match EXTRA_HOLIDAY_CATALOG in the backend. */
 export const EXTRA_HOLIDAYS: [string, string][] = [
   ['mariae_himmelfahrt', 'Mariä Himmelfahrt (15.8.)'],
@@ -23,10 +31,11 @@ export function regionKey(country: string, state: string): string {
   return `${country}-${state}`
 }
 
-/** Human label for a region key like "DE-BY". */
+/** Human label for a region key like "DE-BY" (→ Bayern) or "GR-" (→ Griechenland). */
 export function regionLabel(key: string): string {
-  const state = key.split('-')[1] ?? key
-  return STATE_LABEL[state] ?? state
+  const [country, state] = key.split('-')
+  if (state && STATE_LABEL[state]) return STATE_LABEL[state]
+  return COUNTRY_LABEL[country] ?? country
 }
 
 // Warm, similar-but-distinct shades so holidays of different regions read as

--- a/frontend/src/lib/holidayRegions.ts
+++ b/frontend/src/lib/holidayRegions.ts
@@ -1,0 +1,40 @@
+// Shared holiday-region constants used by SettingsPage (global region) and the
+// person forms (per-person override).
+
+/** German states — codes are the feiertage-api subdivision codes. */
+export const GERMAN_STATES: [string, string][] = [
+  ['BW', 'Baden-Württemberg'], ['BY', 'Bayern'], ['BE', 'Berlin'], ['BB', 'Brandenburg'],
+  ['HB', 'Bremen'], ['HH', 'Hamburg'], ['HE', 'Hessen'], ['MV', 'Mecklenburg-Vorpommern'],
+  ['NI', 'Niedersachsen'], ['NW', 'Nordrhein-Westfalen'], ['RP', 'Rheinland-Pfalz'], ['SL', 'Saarland'],
+  ['SN', 'Sachsen'], ['ST', 'Sachsen-Anhalt'], ['SH', 'Schleswig-Holstein'], ['TH', 'Thüringen'],
+]
+
+export const STATE_LABEL: Record<string, string> = Object.fromEntries(GERMAN_STATES)
+
+/** Optional local holidays — keys must match EXTRA_HOLIDAY_CATALOG in the backend. */
+export const EXTRA_HOLIDAYS: [string, string][] = [
+  ['mariae_himmelfahrt', 'Mariä Himmelfahrt (15.8.)'],
+  ['augsburger_friedensfest', 'Augsburger Friedensfest (8.8.)'],
+  ['reformationstag', 'Reformationstag (31.10.)'],
+]
+
+/** Stable key for a region (country/state) pair. */
+export function regionKey(country: string, state: string): string {
+  return `${country}-${state}`
+}
+
+/** Human label for a region key like "DE-BY". */
+export function regionLabel(key: string): string {
+  const state = key.split('-')[1] ?? key
+  return STATE_LABEL[state] ?? state
+}
+
+// Warm, similar-but-distinct shades so holidays of different regions read as
+// holidays yet stay distinguishable at a glance.
+export const REGION_SHADES = ['bg-red-100', 'bg-rose-100', 'bg-orange-100', 'bg-amber-100', 'bg-pink-100']
+
+export function regionShade(key: string): string {
+  let h = 0
+  for (let i = 0; i < key.length; i++) h = (h + key.charCodeAt(i)) % REGION_SHADES.length
+  return REGION_SHADES[h]
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -12,6 +12,12 @@ import {
   type CalendarMilestone, type MilestoneSuggestion, type Project,
 } from '../api'
 import PageHeader from '../components/PageHeader'
+import {
+  TYPE_BAR_BG as ABSENCE_BG,
+  TYPE_SHORT as ABSENCE_LABEL,
+  TYPE_LABELS as ABSENCE_NAME,
+  STATUS_LABELS as STATUS_NAME,
+} from '../lib/absenceColors'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -22,30 +28,6 @@ const MONTH_NAMES = [
 const MONTH_SHORT = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez']
 
 const WEEKDAY_SHORT = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
-
-const ABSENCE_BG: Record<string, string> = {
-  vacation: 'bg-blue-200',
-  sick: 'bg-yellow-200',
-  training: 'bg-emerald-200',
-}
-
-const ABSENCE_LABEL: Record<string, string> = {
-  vacation: 'U',
-  sick: 'K',
-  training: 'F',
-}
-
-const ABSENCE_NAME: Record<string, string> = {
-  vacation: 'Urlaub',
-  sick: 'Krank',
-  training: 'Fortbildung',
-}
-
-const STATUS_NAME: Record<string, string> = {
-  planned: 'geplant',
-  confirmed: 'bestätigt',
-  ongoing: 'laufend',
-}
 
 const PROJECT_PALETTE = [
   'bg-slate-300', 'bg-sky-300', 'bg-violet-300', 'bg-rose-300',

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, Pencil, Plus, Trash2 } from 'lucide-react'
 import { persons, projects as projectsApi, type Person, type PersonAbsence, type VacationContingent, type PersonMembershipDetail, type ProjectMembership } from '../api'
 import Modal from '../components/Modal'
 import { TYPE_LABELS, TYPE_BADGE as TYPE_COLORS, STATUS_LABELS } from '../lib/absenceColors'
-import { GERMAN_STATES } from '../lib/holidayRegions'
+import RegionOverrideSelect from '../components/absence/RegionOverrideSelect'
 
 // ─── Edit person form ─────────────────────────────────────────────────────────
 
@@ -50,21 +50,11 @@ function EditPersonForm({
           value={form.default_weekly_hours}
           onChange={(e) => setForm({ ...form, default_weekly_hours: parseFloat(e.target.value) })} />
       </div>
-      <div>
-        <label htmlFor="edit-region" className="block text-xs font-medium text-gray-600 mb-1">
-          Feiertagsregion <span className="font-normal text-gray-400">optional — überschreibt global</span>
-        </label>
-        <select id="edit-region"
-          className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          value={form.holiday_state ?? ''}
-          onChange={(e) => {
-            const st = e.target.value || null
-            setForm({ ...form, holiday_state: st, holiday_country: st ? 'DE' : null })
-          }}>
-          <option value="">– global (aus Einstellungen) –</option>
-          {GERMAN_STATES.map(([code, name]) => <option key={code} value={code}>{name} ({code})</option>)}
-        </select>
-      </div>
+      <RegionOverrideSelect
+        country={form.holiday_country}
+        state={form.holiday_state}
+        onChange={(c, s) => setForm({ ...form, holiday_country: c, holiday_state: s })}
+      />
       <div className="flex justify-end gap-2 pt-2">
         <button type="button" onClick={onCancel}
           className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -4,26 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ChevronLeft, Pencil, Plus, Trash2 } from 'lucide-react'
 import { persons, projects as projectsApi, type Person, type PersonAbsence, type VacationContingent, type PersonMembershipDetail, type ProjectMembership } from '../api'
 import Modal from '../components/Modal'
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const TYPE_LABELS: Record<PersonAbsence['absence_type'], string> = {
-  vacation: 'Urlaub',
-  sick: 'Krank',
-  training: 'Fortbildung',
-}
-
-const TYPE_COLORS: Record<PersonAbsence['absence_type'], string> = {
-  vacation: 'bg-blue-100 text-blue-700',
-  sick: 'bg-yellow-100 text-yellow-700',
-  training: 'bg-emerald-100 text-emerald-700',
-}
-
-const STATUS_LABELS: Record<PersonAbsence['status'], string> = {
-  planned: 'Geplant',
-  confirmed: 'Bestätigt',
-  ongoing: 'Laufend',
-}
+import { TYPE_LABELS, TYPE_BADGE as TYPE_COLORS, STATUS_LABELS } from '../lib/absenceColors'
 
 // ─── Edit person form ─────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, Pencil, Plus, Trash2 } from 'lucide-react'
 import { persons, projects as projectsApi, type Person, type PersonAbsence, type VacationContingent, type PersonMembershipDetail, type ProjectMembership } from '../api'
 import Modal from '../components/Modal'
 import { TYPE_LABELS, TYPE_BADGE as TYPE_COLORS, STATUS_LABELS } from '../lib/absenceColors'
+import { GERMAN_STATES } from '../lib/holidayRegions'
 
 // ─── Edit person form ─────────────────────────────────────────────────────────
 
@@ -23,6 +24,8 @@ function EditPersonForm({
     default_weekly_hours: initial.default_weekly_hours,
     work_week_pattern: initial.work_week_pattern,
     default_billing_rate: initial.default_billing_rate,
+    holiday_country: initial.holiday_country ?? null as string | null,
+    holiday_state: initial.holiday_state ?? null as string | null,
   })
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSave(form) }} className="space-y-3">
@@ -46,6 +49,21 @@ function EditPersonForm({
           className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           value={form.default_weekly_hours}
           onChange={(e) => setForm({ ...form, default_weekly_hours: parseFloat(e.target.value) })} />
+      </div>
+      <div>
+        <label htmlFor="edit-region" className="block text-xs font-medium text-gray-600 mb-1">
+          Feiertagsregion <span className="font-normal text-gray-400">optional — überschreibt global</span>
+        </label>
+        <select id="edit-region"
+          className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          value={form.holiday_state ?? ''}
+          onChange={(e) => {
+            const st = e.target.value || null
+            setForm({ ...form, holiday_state: st, holiday_country: st ? 'DE' : null })
+          }}>
+          <option value="">– global (aus Einstellungen) –</option>
+          {GERMAN_STATES.map(([code, name]) => <option key={code} value={code}>{name} ({code})</option>)}
+        </select>
       </div>
       <div className="flex justify-end gap-2 pt-2">
         <button type="button" onClick={onCancel}

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -226,7 +226,7 @@ function ContingentForm({
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
-type Tab = 'absences' | 'contingents' | 'projects'
+type Tab = 'absences' | 'projects'
 
 // ─── Membership form ──────────────────────────────────────────────────────────
 
@@ -421,7 +421,6 @@ export default function PersonDetailPage() {
         <div className="flex gap-0 mt-4 border-b border-gray-200 -mb-px">
           {([
             { id: 'absences' as Tab, label: 'Abwesenheiten' },
-            { id: 'contingents' as Tab, label: 'Urlaubskontingente' },
             { id: 'projects' as Tab, label: 'Projekte' },
           ]).map((t) => (
             <button key={t.id} onClick={() => { setTab(t.id); setError(null) }}
@@ -496,58 +495,6 @@ export default function PersonDetailPage() {
           </div>
         )}
 
-        {/* ── Vacation contingents ── */}
-        {tab === 'contingents' && (
-          <div>
-            <div className="flex justify-between items-center mb-4">
-              <h3 className="font-medium text-gray-700">Urlaubskontingente</h3>
-              <button onClick={() => setShowAddContingent(true)}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">
-                <Plus size={14} /> Neues Kontingent
-              </button>
-            </div>
-            <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
-                  <tr>
-                    {['Jahr', 'Urlaubstage', ''].map((h) => (
-                      <th key={h} scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100">
-                  {sortedContingents.length === 0 && (
-                    <tr><td colSpan={3} className="px-4 py-8 text-center text-sm text-gray-400">Noch keine Kontingente eingetragen.</td></tr>
-                  )}
-                  {sortedContingents.map((c) => (
-                    <tr key={c.id}>
-                      <td className="px-4 py-3 text-sm font-medium text-gray-700">{c.year}</td>
-                      <td className="px-4 py-3 text-sm text-gray-600">{c.total_days} Tage</td>
-                      <td className="px-4 py-3 text-sm">
-                        <div className="flex items-center gap-2">
-                          <button
-                            aria-label={`Kontingent ${c.year} bearbeiten`}
-                            onClick={() => setEditingContingent(c)}
-                            className="text-gray-400 hover:text-blue-500 transition-colors"
-                          >
-                            <Pencil size={14} />
-                          </button>
-                          <button
-                            aria-label={`Kontingent ${c.year} löschen`}
-                            onClick={() => setConfirmDeleteContingent(c)}
-                            className="text-gray-400 hover:text-red-500 transition-colors"
-                          >
-                            <Trash2 size={14} />
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
         {/* ── Projects (memberships) ── */}
         {tab === 'projects' && (
           <div>
@@ -600,14 +547,52 @@ export default function PersonDetailPage() {
         )}
       </div>
 
-      {/* Edit person modal */}
+      {/* Person settings modal (person fields + vacation contingents) */}
       {showEdit && (
-        <Modal title="Person bearbeiten" onClose={() => { setShowEdit(false); setError(null) }}>
+        <Modal title="Personeneinstellungen" onClose={() => { setShowEdit(false); setEditingContingent(null); setShowAddContingent(false); setError(null) }}>
           <EditPersonForm
             initial={person}
             onSave={(d) => updatePerson.mutate(d)}
             onCancel={() => { setShowEdit(false); setError(null) }}
           />
+
+          {/* Vacation contingents — moved here from the removed tab */}
+          <div className="mt-5 pt-4 border-t border-gray-200">
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-sm font-semibold text-gray-700">Urlaubskontingente</h4>
+              {!showAddContingent && !editingContingent && (
+                <button onClick={() => setShowAddContingent(true)}
+                  className="flex items-center gap-1 text-xs text-blue-600 hover:underline">
+                  <Plus size={12} /> Kontingent
+                </button>
+              )}
+            </div>
+
+            {(showAddContingent || editingContingent) ? (
+              <ContingentForm
+                initial={editingContingent ?? undefined}
+                onSave={(d) => editingContingent
+                  ? updateContingent.mutate({ id: editingContingent.id, d })
+                  : addContingent.mutate(d)}
+                onCancel={() => { setShowAddContingent(false); setEditingContingent(null); setError(null) }}
+              />
+            ) : (
+              <div className="space-y-1">
+                {sortedContingents.length === 0 && (
+                  <p className="text-xs text-gray-400">Noch keine Kontingente eingetragen.</p>
+                )}
+                {sortedContingents.map((c) => (
+                  <div key={c.id} className="flex items-center justify-between text-sm border border-gray-100 rounded px-2 py-1">
+                    <span className="text-gray-700"><span className="font-medium">{c.year}</span> · {c.total_days} Tage</span>
+                    <span className="flex items-center gap-2">
+                      <button aria-label={`Kontingent ${c.year} bearbeiten`} onClick={() => { setEditingContingent(c); setError(null) }} className="text-gray-400 hover:text-blue-500"><Pencil size={13} /></button>
+                      <button aria-label={`Kontingent ${c.year} löschen`} onClick={() => setConfirmDeleteContingent(c)} className="text-gray-400 hover:text-red-500"><Trash2 size={13} /></button>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </Modal>
       )}
 
@@ -628,27 +613,6 @@ export default function PersonDetailPage() {
             initial={editingAbsence}
             onSave={(d) => updateAbsence.mutate(d)}
             onCancel={() => { setEditingAbsence(null); setError(null) }}
-          />
-        </Modal>
-      )}
-
-      {/* Add contingent modal */}
-      {showAddContingent && (
-        <Modal title="Urlaubskontingent" onClose={() => { setShowAddContingent(false); setError(null) }}>
-          <ContingentForm
-            onSave={(d) => addContingent.mutate(d)}
-            onCancel={() => { setShowAddContingent(false); setError(null) }}
-          />
-        </Modal>
-      )}
-
-      {/* Edit contingent modal */}
-      {editingContingent && (
-        <Modal title="Kontingent bearbeiten" onClose={() => { setEditingContingent(null); setError(null) }}>
-          <ContingentForm
-            initial={editingContingent}
-            onSave={(d) => updateContingent.mutate({ id: editingContingent.id, d })}
-            onCancel={() => { setEditingContingent(null); setError(null) }}
           />
         </Modal>
       )}

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -8,6 +8,7 @@ import Modal from '../components/Modal'
 import YearCalendar from '../components/absence/YearCalendar'
 import AbsenceQuickCreateModal from '../components/absence/AbsenceQuickCreateModal'
 import { personColor, TYPE_LABELS, TYPE_SHORT } from '../lib/absenceColors'
+import { GERMAN_STATES, regionKey, regionLabel, regionShade } from '../lib/holidayRegions'
 
 type AbsenceType = 'vacation' | 'sick' | 'training'
 const ALL_TYPES: AbsenceType[] = ['vacation', 'training', 'sick']
@@ -33,6 +34,8 @@ function PersonForm({ initial, onSave, onCancel }: {
     default_weekly_hours: initial?.default_weekly_hours ?? 40,
     work_week_pattern: initPattern as string | null,
     default_billing_rate: initial?.default_billing_rate ?? null as number | null,
+    holiday_country: initial?.holiday_country ?? null as string | null,
+    holiday_state: initial?.holiday_state ?? null as string | null,
   })
   const [patternPreset, setPatternPreset] = useState(initPreset)
 
@@ -106,6 +109,22 @@ function PersonForm({ initial, onSave, onCancel }: {
           />
         )}
       </div>
+      <div>
+        <label htmlFor="person-region" className="block text-xs font-medium text-gray-600 mb-1">
+          Feiertagsregion <span className="font-normal text-gray-400">optional — überschreibt global</span>
+        </label>
+        <select id="person-region"
+          className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          value={form.holiday_state ?? ''}
+          onChange={(e) => {
+            const st = e.target.value || null
+            setForm({ ...form, holiday_state: st, holiday_country: st ? 'DE' : null })
+          }}
+        >
+          <option value="">– global (aus Einstellungen) –</option>
+          {GERMAN_STATES.map(([code, name]) => <option key={code} value={code}>{name} ({code})</option>)}
+        </select>
+      </div>
       <div className="flex justify-end gap-2 pt-2">
         <button type="button" onClick={onCancel}
           className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">
@@ -138,6 +157,7 @@ export default function PersonsPage() {
   const [tableCollapsed, setTableCollapsed] = useState(false)
   const [selProgram, setSelProgram] = useState<number | null>(null)
   const [selProject, setSelProject] = useState<number | null>(null)
+  const [regionFilter, setRegionFilter] = useState<string | null>(null) // null = auto (union of shown MA)
 
   const { data = [], isLoading } = useQuery({
     queryKey: ['persons-with-projects'],
@@ -195,6 +215,21 @@ export default function PersonsPage() {
       .filter((p) => isSelected(p.id))
       .map((p) => ({ ...p, absences: p.absences.filter((a) => typeFilter.has(a.absence_type)) }))
   }, [yearCal, deselected, typeFilter]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Holiday regions. Auto = union of the shown persons' regions; a manual pick overrides.
+  const globalRegion = yearCal ? regionKey(yearCal.country, yearCal.state) : 'DE-BY'
+  const regionOptions = useMemo(() => {
+    const set = new Set<string>()
+    if (yearCal) set.add(regionKey(yearCal.country, yearCal.state))
+    for (const p of yearCal?.persons ?? []) set.add(regionKey(p.holiday_country, p.holiday_state))
+    return [...set]
+  }, [yearCal])
+  const displayedRegions = useMemo(() => {
+    if (regionFilter) return new Set([regionFilter])
+    const s = new Set(calendarPersons.map((p) => regionKey(p.holiday_country, p.holiday_state)))
+    if (s.size === 0) s.add(globalRegion)
+    return s
+  }, [regionFilter, calendarPersons, globalRegion])
 
   // Project/program quick-select works off the project numbers shown in the
   // table (all-time membership) so selecting a project picks exactly the people
@@ -334,6 +369,22 @@ export default function PersonsPage() {
               </button>
             ))}
 
+            {regionOptions.length > 1 && (
+              <>
+                <div className="w-px h-4 bg-gray-200 mx-1" />
+                <select
+                  aria-label="Feiertagsregion anzeigen"
+                  className="text-xs border border-gray-200 rounded px-2 py-1 text-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  value={regionFilter ?? ''}
+                  onChange={(e) => setRegionFilter(e.target.value || null)}
+                  title="Welche Feiertagsregion angezeigt wird"
+                >
+                  <option value="">Feiertage: Auto</option>
+                  {regionOptions.map((r) => <option key={r} value={r}>Feiertage: {regionLabel(r)}</option>)}
+                </select>
+              </>
+            )}
+
             <div className="w-px h-4 bg-gray-200 mx-1" />
 
             <button onClick={selectAll} className="text-xs px-2 py-1 rounded border border-gray-200 text-gray-600 hover:bg-gray-50">Alle</button>
@@ -349,12 +400,18 @@ export default function PersonsPage() {
               year={calYear}
               holidays={yearCal?.holidays ?? []}
               persons={calendarPersons}
+              displayedRegions={displayedRegions}
               onRangeSelect={(personId, start, end) => setQuickCreate({ personId, start, end })}
             />
           )}
           <div className="mt-2 flex flex-wrap gap-4 text-xs text-gray-600" aria-label="Legende">
             <span className="flex items-center gap-1.5"><span className="inline-block w-4 h-4 rounded bg-gray-100 border border-gray-200" /> Wochenende</span>
-            <span className="flex items-center gap-1.5"><span className="inline-block w-4 h-4 rounded bg-red-100 border border-red-200" /> Feiertag</span>
+            {[...displayedRegions].map((r) => (
+              <span key={r} className="flex items-center gap-1.5">
+                <span className={`inline-block w-4 h-4 rounded border border-gray-200 ${regionShade(r)}`} />
+                Feiertag {regionOptions.length > 1 ? regionLabel(r) : ''}
+              </span>
+            ))}
           </div>
         </section>
 

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -7,6 +7,7 @@ import PageHeader from '../components/PageHeader'
 import Table from '../components/Table'
 import Modal from '../components/Modal'
 import YearCalendar from '../components/absence/YearCalendar'
+import AbsenceQuickCreateModal from '../components/absence/AbsenceQuickCreateModal'
 
 const WORK_WEEK_PRESETS = [
   { label: '40 h (5×8)', value: '8,8,8,8,8' },
@@ -125,6 +126,7 @@ export default function PersonsPage() {
   const [error, setError] = useState<string | null>(null)
 
   const [calYear, setCalYear] = useState(new Date().getFullYear())
+  const [quickCreate, setQuickCreate] = useState<{ personId: number | null; start: string; end: string } | null>(null)
 
   const { data = [], isLoading } = useQuery({
     queryKey: ['persons-with-projects'],
@@ -236,7 +238,10 @@ export default function PersonsPage() {
         {/* Year calendar for absences */}
         <section>
           <div className="flex items-center justify-between mb-2">
-            <h2 className="text-sm font-semibold text-gray-700">Jahreskalender – Abwesenheiten</h2>
+            <div className="flex items-baseline gap-2">
+              <h2 className="text-sm font-semibold text-gray-700">Jahreskalender – Abwesenheiten</h2>
+              <span className="text-xs text-gray-400">Zeitraum ziehen für neue Abwesenheit</span>
+            </div>
             <div className="flex items-center gap-1">
               <button
                 onClick={() => setCalYear((y) => y - 1)}
@@ -258,7 +263,12 @@ export default function PersonsPage() {
           {calLoading ? (
             <p className="text-sm text-gray-400">Lade Kalender…</p>
           ) : (
-            <YearCalendar year={calYear} holidays={yearCal?.holidays ?? []} persons={yearCal?.persons ?? []} />
+            <YearCalendar
+              year={calYear}
+              holidays={yearCal?.holidays ?? []}
+              persons={yearCal?.persons ?? []}
+              onRangeSelect={(personId, start, end) => setQuickCreate({ personId, start, end })}
+            />
           )}
           <div className="mt-2 flex flex-wrap gap-4 text-xs text-gray-600" aria-label="Legende">
             <span className="flex items-center gap-1.5"><span className="inline-block w-4 h-4 rounded bg-gray-100 border border-gray-200" /> Wochenende</span>
@@ -290,6 +300,17 @@ export default function PersonsPage() {
             onCancel={() => { setEditPerson(null); setError(null) }}
           />
         </Modal>
+      )}
+
+      {quickCreate && (
+        <AbsenceQuickCreateModal
+          persons={(yearCal?.persons ?? data).map((p) => ({ id: p.id, name: p.name }))}
+          initialPersonId={quickCreate.personId}
+          startDate={quickCreate.start}
+          endDate={quickCreate.end}
+          onClose={() => setQuickCreate(null)}
+          onCreated={() => setQuickCreate(null)}
+        />
       )}
 
       {confirmDelete && (

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -258,7 +258,7 @@ export default function PersonsPage() {
           {calLoading ? (
             <p className="text-sm text-gray-400">Lade Kalender…</p>
           ) : (
-            <YearCalendar year={calYear} holidays={yearCal?.holidays ?? []} />
+            <YearCalendar year={calYear} holidays={yearCal?.holidays ?? []} persons={yearCal?.persons ?? []} />
           )}
           <div className="mt-2 flex flex-wrap gap-4 text-xs text-gray-600" aria-label="Legende">
             <span className="flex items-center gap-1.5"><span className="inline-block w-4 h-4 rounded bg-gray-100 border border-gray-200" /> Wochenende</span>

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -1,13 +1,16 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Pencil, Trash2, ChevronLeft, ChevronRight } from 'lucide-react'
-import { persons, calendar, type Person, type PersonWithProjects } from '../api'
+import { Plus, Pencil, Trash2, ChevronLeft, ChevronRight, ChevronDown, Search, ArrowUpRight } from 'lucide-react'
+import { persons, calendar, programs, projects as projectsApi, type Person } from '../api'
 import PageHeader from '../components/PageHeader'
-import Table from '../components/Table'
 import Modal from '../components/Modal'
 import YearCalendar from '../components/absence/YearCalendar'
 import AbsenceQuickCreateModal from '../components/absence/AbsenceQuickCreateModal'
+import { personColor, TYPE_LABELS, TYPE_SHORT } from '../lib/absenceColors'
+
+type AbsenceType = 'vacation' | 'sick' | 'training'
+const ALL_TYPES: AbsenceType[] = ['vacation', 'training', 'sick']
 
 const WORK_WEEK_PRESETS = [
   { label: '40 h (5×8)', value: '8,8,8,8,8' },
@@ -128,6 +131,14 @@ export default function PersonsPage() {
   const [calYear, setCalYear] = useState(new Date().getFullYear())
   const [quickCreate, setQuickCreate] = useState<{ personId: number | null; start: string; end: string } | null>(null)
 
+  // Selection & filters. deselected = ids explicitly hidden; empty ⇒ all selected (default).
+  const [deselected, setDeselected] = useState<Set<number>>(new Set())
+  const [typeFilter, setTypeFilter] = useState<Set<AbsenceType>>(new Set(ALL_TYPES))
+  const [search, setSearch] = useState('')
+  const [tableCollapsed, setTableCollapsed] = useState(false)
+  const [selProgram, setSelProgram] = useState<number | null>(null)
+  const [selProject, setSelProject] = useState<number | null>(null)
+
   const { data = [], isLoading } = useQuery({
     queryKey: ['persons-with-projects'],
     queryFn: persons.withProjects,
@@ -137,6 +148,9 @@ export default function PersonsPage() {
     queryKey: ['calendar-year', calYear],
     queryFn: () => calendar.year(calYear),
   })
+
+  const { data: programList = [] } = useQuery({ queryKey: ['programs'], queryFn: programs.list })
+  const { data: projectList = [] } = useQuery({ queryKey: ['projects'], queryFn: projectsApi.list })
 
   const create = useMutation({
     mutationFn: persons.create,
@@ -170,52 +184,74 @@ export default function PersonsPage() {
     onError: (e: Error) => setError(e.message),
   })
 
-  const columns = [
-    { key: 'name', header: 'Name' },
-    { key: 'sage_employee_name', header: 'Sage-Name' },
-    {
-      key: 'default_weekly_hours', header: 'Wochenstunden',
-      render: (p: PersonWithProjects) => `${p.default_weekly_hours} h`,
-    },
-    {
-      key: 'projects', header: 'Projekte',
-      render: (p: PersonWithProjects) => {
-        if (!p.project_numbers || p.project_numbers.length === 0) {
-          return <span className="text-xs text-gray-400">–</span>
-        }
-        return (
-          <div className="flex flex-wrap gap-1">
-            {p.project_numbers.map((num) => (
-              <span key={num} className="px-1.5 py-0.5 bg-slate-100 text-slate-600 text-xs rounded">
-                {num}
-              </span>
-            ))}
-          </div>
-        )
-      },
-    },
-    {
-      key: 'actions', header: '',
-      render: (p: PersonWithProjects) => (
-        <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-          <button
-            aria-label={`${p.name} bearbeiten`}
-            onClick={() => { setEditPerson(p); setError(null) }}
-            className="p-1 text-gray-400 hover:text-blue-600 transition-colors"
-          >
-            <Pencil size={13} />
-          </button>
-          <button
-            aria-label={`${p.name} löschen`}
-            onClick={() => setConfirmDelete(p)}
-            className="p-1 text-gray-400 hover:text-red-500 transition-colors"
-          >
-            <Trash2 size={13} />
-          </button>
-        </div>
-      ),
-    },
-  ]
+  const allIds = useMemo(() => data.map((p) => p.id), [data])
+  const isSelected = (id: number) => !deselected.has(id)
+  const selectedCount = allIds.filter(isSelected).length
+
+  // Persons for the calendar: selected only, absences filtered by type.
+  const calendarPersons = useMemo(() => {
+    const src = yearCal?.persons ?? []
+    return src
+      .filter((p) => isSelected(p.id))
+      .map((p) => ({ ...p, absences: p.absences.filter((a) => typeFilter.has(a.absence_type)) }))
+  }, [yearCal, deselected, typeFilter]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Project/program quick-select works off the project numbers shown in the
+  // table (all-time membership) so selecting a project picks exactly the people
+  // whose row shows that project chip — regardless of the viewed year.
+  const membersOfProjects = (projectIds: number[]): Set<number> => {
+    const numbers = new Set(
+      projectIds
+        .map((id) => projectList.find((p) => p.id === id)?.project_number)
+        .filter((n): n is string => !!n),
+    )
+    const set = new Set<number>()
+    for (const p of data) {
+      if ((p.project_numbers ?? []).some((n) => numbers.has(n))) set.add(p.id)
+    }
+    return set
+  }
+
+  const selectOnly = (ids: Set<number>) => setDeselected(new Set(allIds.filter((id) => !ids.has(id))))
+  const toggle = (id: number) =>
+    setDeselected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  const selectAll = () => { setDeselected(new Set()); setSelProgram(null); setSelProject(null) }
+  const selectNone = () => setDeselected(new Set(allIds))
+  const selectWithAbsence = () => {
+    const withAbs = new Set((yearCal?.persons ?? []).filter((p) => p.absences.length > 0).map((p) => p.id))
+    selectOnly(withAbs)
+  }
+  const applyProgram = (progId: number | null) => {
+    setSelProgram(progId); setSelProject(null)
+    if (progId == null) { selectAll(); return }
+    const projectIds = projectList.filter((p) => p.program_id === progId).map((p) => p.id)
+    selectOnly(membersOfProjects(projectIds))
+  }
+  const applyProject = (projId: number | null) => {
+    setSelProject(projId); setSelProgram(null)
+    if (projId == null) { selectAll(); return }
+    selectOnly(membersOfProjects([projId]))
+  }
+  const toggleType = (t: AbsenceType) =>
+    setTypeFilter((prev) => {
+      const next = new Set(prev)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+
+  const filteredRows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return data
+    return data.filter(
+      (p) => p.name.toLowerCase().includes(q) || p.sage_employee_name.toLowerCase().includes(q),
+    )
+  }, [data, search])
 
   return (
     <div>
@@ -260,13 +296,59 @@ export default function PersonsPage() {
               </button>
             </div>
           </div>
+
+          {/* Filter bar */}
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <select
+              aria-label="Nach Hauptprojekt filtern"
+              className="text-xs border border-gray-200 rounded px-2 py-1 text-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-400"
+              value={selProgram ?? ''}
+              onChange={(e) => applyProgram(e.target.value ? parseInt(e.target.value) : null)}
+            >
+              <option value="">Alle Hauptprojekte</option>
+              {programList.map((p) => <option key={p.id} value={p.id}>{p.program_number} – {p.name}</option>)}
+            </select>
+            <select
+              aria-label="Nach Projekt filtern"
+              className="text-xs border border-gray-200 rounded px-2 py-1 text-gray-600 focus:outline-none focus:ring-1 focus:ring-blue-400"
+              value={selProject ?? ''}
+              onChange={(e) => applyProject(e.target.value ? parseInt(e.target.value) : null)}
+            >
+              <option value="">Alle Projekte</option>
+              {projectList.map((p) => <option key={p.id} value={p.id}>{p.project_number} – {p.name}</option>)}
+            </select>
+
+            <div className="w-px h-4 bg-gray-200 mx-1" />
+
+            {ALL_TYPES.map((t) => (
+              <button
+                key={t}
+                onClick={() => toggleType(t)}
+                className={`px-2 py-1 rounded-full text-xs font-medium border transition-opacity ${
+                  typeFilter.has(t) ? 'opacity-100 border-gray-300 bg-gray-50' : 'opacity-40 border-gray-200'
+                }`}
+                aria-pressed={typeFilter.has(t)}
+                title={`${TYPE_LABELS[t]} ein-/ausblenden`}
+              >
+                {TYPE_SHORT[t]} · {TYPE_LABELS[t]}
+              </button>
+            ))}
+
+            <div className="w-px h-4 bg-gray-200 mx-1" />
+
+            <button onClick={selectAll} className="text-xs px-2 py-1 rounded border border-gray-200 text-gray-600 hover:bg-gray-50">Alle</button>
+            <button onClick={selectNone} className="text-xs px-2 py-1 rounded border border-gray-200 text-gray-600 hover:bg-gray-50">Keine</button>
+            <button onClick={selectWithAbsence} className="text-xs px-2 py-1 rounded border border-gray-200 text-gray-600 hover:bg-gray-50">Nur mit Abwesenheit</button>
+            <span className="text-xs text-gray-400 ml-auto">{selectedCount} / {allIds.length} MA</span>
+          </div>
+
           {calLoading ? (
             <p className="text-sm text-gray-400">Lade Kalender…</p>
           ) : (
             <YearCalendar
               year={calYear}
               holidays={yearCal?.holidays ?? []}
-              persons={yearCal?.persons ?? []}
+              persons={calendarPersons}
               onRangeSelect={(personId, start, end) => setQuickCreate({ personId, start, end })}
             />
           )}
@@ -276,14 +358,103 @@ export default function PersonsPage() {
           </div>
         </section>
 
-        {/* Person list */}
-        {isLoading ? (
-          <p className="text-sm text-gray-400">Lade…</p>
-        ) : (
-          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-            <Table columns={columns} rows={data} keyFn={(p) => p.id} onRowClick={(p) => navigate(`/persons/${p.id}`)} />
+        {/* Person list — selection is shared with the calendar */}
+        <section>
+          <div className="flex items-center justify-between mb-2 gap-2">
+            <button
+              onClick={() => setTableCollapsed((v) => !v)}
+              className="flex items-center gap-1 text-sm font-semibold text-gray-700"
+              aria-expanded={!tableCollapsed}
+            >
+              <ChevronDown size={14} className={`transition-transform ${tableCollapsed ? '-rotate-90' : ''}`} />
+              Personen ({data.length})
+            </button>
+            <div className="relative">
+              <Search size={13} className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400" />
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="MA suchen…"
+                aria-label="Mitarbeiter suchen"
+                className="pl-7 pr-2 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-blue-400"
+              />
+            </div>
           </div>
-        )}
+
+          {!tableCollapsed && (
+            isLoading ? (
+              <p className="text-sm text-gray-400">Lade…</p>
+            ) : (
+              <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="w-8 px-3 py-2" />
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Name</th>
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Sage-Name</th>
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Wochenstunden</th>
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Projekte</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-100">
+                    {filteredRows.length === 0 && (
+                      <tr><td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-400">Keine MA gefunden.</td></tr>
+                    )}
+                    {filteredRows.map((p) => {
+                      const sel = isSelected(p.id)
+                      const c = personColor(p.id)
+                      return (
+                        <tr
+                          key={p.id}
+                          onClick={() => toggle(p.id)}
+                          className={`cursor-pointer transition-colors ${sel ? 'hover:bg-gray-50' : 'bg-gray-50/40 hover:bg-gray-50'}`}
+                          title={sel ? 'Abwählen' : 'Auswählen'}
+                        >
+                          <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                            <input
+                              type="checkbox"
+                              checked={sel}
+                              onChange={() => toggle(p.id)}
+                              className="accent-blue-600"
+                              aria-label={`${p.name} an-/abwählen`}
+                            />
+                          </td>
+                          <td className="px-4 py-2">
+                            <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-sm font-medium ${sel ? `${c.rowBg} ${c.text}` : 'text-gray-400'}`}>
+                              <span className={`inline-block w-2.5 h-2.5 rounded-full ${sel ? c.dot : 'bg-gray-300'}`} />
+                              {p.name}
+                            </span>
+                          </td>
+                          <td className={`px-4 py-2 text-sm ${sel ? 'text-gray-700' : 'text-gray-400'}`}>{p.sage_employee_name}</td>
+                          <td className={`px-4 py-2 text-sm ${sel ? 'text-gray-700' : 'text-gray-400'}`}>{p.default_weekly_hours} h</td>
+                          <td className="px-4 py-2">
+                            {(!p.project_numbers || p.project_numbers.length === 0)
+                              ? <span className="text-xs text-gray-400">–</span>
+                              : (
+                                <div className="flex flex-wrap gap-1">
+                                  {p.project_numbers.map((n) => (
+                                    <span key={n} className="px-1.5 py-0.5 bg-slate-100 text-slate-600 text-xs rounded">{n}</span>
+                                  ))}
+                                </div>
+                              )}
+                          </td>
+                          <td className="px-4 py-2">
+                            <div className="flex items-center gap-1 justify-end" onClick={(e) => e.stopPropagation()}>
+                              <button aria-label={`${p.name} öffnen`} onClick={() => navigate(`/persons/${p.id}`)} className="p-1 text-gray-400 hover:text-blue-600 transition-colors"><ArrowUpRight size={14} /></button>
+                              <button aria-label={`${p.name} bearbeiten`} onClick={() => { setEditPerson(p); setError(null) }} className="p-1 text-gray-400 hover:text-blue-600 transition-colors"><Pencil size={13} /></button>
+                              <button aria-label={`${p.name} löschen`} onClick={() => setConfirmDelete(p)} className="p-1 text-gray-400 hover:text-red-500 transition-colors"><Trash2 size={13} /></button>
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )
+          )}
+        </section>
       </div>
 
       {showCreate && (

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -8,7 +8,8 @@ import Modal from '../components/Modal'
 import YearCalendar from '../components/absence/YearCalendar'
 import AbsenceQuickCreateModal from '../components/absence/AbsenceQuickCreateModal'
 import { personColor, TYPE_LABELS, TYPE_SHORT } from '../lib/absenceColors'
-import { GERMAN_STATES, regionKey, regionLabel, regionShade } from '../lib/holidayRegions'
+import { regionKey, regionLabel, regionShade } from '../lib/holidayRegions'
+import RegionOverrideSelect from '../components/absence/RegionOverrideSelect'
 
 type AbsenceType = 'vacation' | 'sick' | 'training'
 const ALL_TYPES: AbsenceType[] = ['vacation', 'training', 'sick']
@@ -109,22 +110,11 @@ function PersonForm({ initial, onSave, onCancel }: {
           />
         )}
       </div>
-      <div>
-        <label htmlFor="person-region" className="block text-xs font-medium text-gray-600 mb-1">
-          Feiertagsregion <span className="font-normal text-gray-400">optional — überschreibt global</span>
-        </label>
-        <select id="person-region"
-          className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          value={form.holiday_state ?? ''}
-          onChange={(e) => {
-            const st = e.target.value || null
-            setForm({ ...form, holiday_state: st, holiday_country: st ? 'DE' : null })
-          }}
-        >
-          <option value="">– global (aus Einstellungen) –</option>
-          {GERMAN_STATES.map(([code, name]) => <option key={code} value={code}>{name} ({code})</option>)}
-        </select>
-      </div>
+      <RegionOverrideSelect
+        country={form.holiday_country}
+        state={form.holiday_state}
+        onChange={(c, s) => setForm({ ...form, holiday_country: c, holiday_state: s })}
+      />
       <div className="flex justify-end gap-2 pt-2">
         <button type="button" onClick={onCancel}
           className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Pencil, Trash2 } from 'lucide-react'
-import { persons, type Person, type PersonWithProjects } from '../api'
+import { Plus, Pencil, Trash2, ChevronLeft, ChevronRight } from 'lucide-react'
+import { persons, calendar, type Person, type PersonWithProjects } from '../api'
 import PageHeader from '../components/PageHeader'
 import Table from '../components/Table'
 import Modal from '../components/Modal'
+import YearCalendar from '../components/absence/YearCalendar'
 
 const WORK_WEEK_PRESETS = [
   { label: '40 h (5×8)', value: '8,8,8,8,8' },
@@ -123,9 +124,16 @@ export default function PersonsPage() {
   const [confirmDelete, setConfirmDelete] = useState<Person | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  const [calYear, setCalYear] = useState(new Date().getFullYear())
+
   const { data = [], isLoading } = useQuery({
     queryKey: ['persons-with-projects'],
     queryFn: persons.withProjects,
+  })
+
+  const { data: yearCal, isLoading: calLoading } = useQuery({
+    queryKey: ['calendar-year', calYear],
+    queryFn: () => calendar.year(calYear),
   })
 
   const create = useMutation({
@@ -224,7 +232,41 @@ export default function PersonsPage() {
       {error && (
         <div className="mx-6 mt-4 p-3 bg-red-50 text-red-700 text-sm rounded border border-red-200">{error}</div>
       )}
-      <div className="p-6">
+      <div className="p-6 space-y-6">
+        {/* Year calendar for absences */}
+        <section>
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold text-gray-700">Jahreskalender – Abwesenheiten</h2>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setCalYear((y) => y - 1)}
+                aria-label="Vorheriges Jahr"
+                className="p-1.5 rounded hover:bg-gray-100 text-gray-600"
+              >
+                <ChevronLeft size={16} />
+              </button>
+              <span className="text-sm font-medium text-gray-700 min-w-[3.5rem] text-center">{calYear}</span>
+              <button
+                onClick={() => setCalYear((y) => y + 1)}
+                aria-label="Nächstes Jahr"
+                className="p-1.5 rounded hover:bg-gray-100 text-gray-600"
+              >
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          </div>
+          {calLoading ? (
+            <p className="text-sm text-gray-400">Lade Kalender…</p>
+          ) : (
+            <YearCalendar year={calYear} holidays={yearCal?.holidays ?? []} />
+          )}
+          <div className="mt-2 flex flex-wrap gap-4 text-xs text-gray-600" aria-label="Legende">
+            <span className="flex items-center gap-1.5"><span className="inline-block w-4 h-4 rounded bg-gray-100 border border-gray-200" /> Wochenende</span>
+            <span className="flex items-center gap-1.5"><span className="inline-block w-4 h-4 rounded bg-red-100 border border-red-200" /> Feiertag</span>
+          </div>
+        </section>
+
+        {/* Person list */}
         {isLoading ? (
           <p className="text-sm text-gray-400">Lade…</p>
         ) : (

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Pencil, Trash2, ChevronLeft, ChevronRight, ChevronDown, Search, ArrowUpRight } from 'lucide-react'
-import { persons, calendar, programs, projects as projectsApi, type Person } from '../api'
+import { Plus, Pencil, Trash2, ChevronDown, Search, ArrowUpRight } from 'lucide-react'
+import { persons, calendar, programs, projects as projectsApi, type Person, type YearCalendarPerson } from '../api'
 import PageHeader from '../components/PageHeader'
 import Modal from '../components/Modal'
 import YearCalendar from '../components/absence/YearCalendar'
@@ -147,8 +147,11 @@ export default function PersonsPage() {
   const [confirmDelete, setConfirmDelete] = useState<Person | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const [calYear, setCalYear] = useState(new Date().getFullYear())
   const [quickCreate, setQuickCreate] = useState<{ personId: number | null; start: string; end: string } | null>(null)
+
+  // Vertical scroll spans several years; the calendar centres on the current month.
+  const currentYear = new Date().getFullYear()
+  const YEARS = useMemo(() => [-1, 0, 1, 2, 3].map((o) => currentYear + o), [currentYear])
 
   // Selection & filters. deselected = ids explicitly hidden; empty ⇒ all selected (default).
   const [deselected, setDeselected] = useState<Set<number>>(new Set())
@@ -164,10 +167,34 @@ export default function PersonsPage() {
     queryFn: persons.withProjects,
   })
 
-  const { data: yearCal, isLoading: calLoading } = useQuery({
-    queryKey: ['calendar-year', calYear],
-    queryFn: () => calendar.year(calYear),
+  const yearQueries = useQueries({
+    queries: YEARS.map((y) => ({ queryKey: ['calendar-year', y], queryFn: () => calendar.year(y) })),
   })
+  const calLoading = yearQueries.some((q) => q.isPending)
+  const dataSig = yearQueries.map((q) => q.dataUpdatedAt ?? 0).join(',')
+
+  const holidaysByYear = useMemo(() => {
+    const m: Record<number, import('../api').YearHoliday[]> = {}
+    YEARS.forEach((y, i) => { m[y] = yearQueries[i].data?.holidays ?? [] })
+    return m
+  }, [dataSig]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Merge persons across the fetched years (absences deduped by id).
+  const mergedPersons = useMemo(() => {
+    const map = new Map<number, YearCalendarPerson>()
+    YEARS.forEach((_, i) => {
+      for (const p of yearQueries[i].data?.persons ?? []) {
+        const ex = map.get(p.id)
+        if (!ex) { map.set(p.id, { ...p, absences: [...p.absences] }); continue }
+        const seen = new Set(ex.absences.map((a) => a.id))
+        for (const a of p.absences) if (!seen.has(a.id)) ex.absences.push(a)
+      }
+    })
+    return [...map.values()]
+  }, [dataSig]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const firstData = yearQueries.find((q) => q.data)?.data
+  const globalRegion = firstData ? regionKey(firstData.country, firstData.state) : 'DE-BY'
 
   const { data: programList = [] } = useQuery({ queryKey: ['programs'], queryFn: programs.list })
   const { data: projectList = [] } = useQuery({ queryKey: ['projects'], queryFn: projectsApi.list })
@@ -210,20 +237,17 @@ export default function PersonsPage() {
 
   // Persons for the calendar: selected only, absences filtered by type.
   const calendarPersons = useMemo(() => {
-    const src = yearCal?.persons ?? []
-    return src
+    return mergedPersons
       .filter((p) => isSelected(p.id))
       .map((p) => ({ ...p, absences: p.absences.filter((a) => typeFilter.has(a.absence_type)) }))
-  }, [yearCal, deselected, typeFilter]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [mergedPersons, deselected, typeFilter]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Holiday regions. Auto = union of the shown persons' regions; a manual pick overrides.
-  const globalRegion = yearCal ? regionKey(yearCal.country, yearCal.state) : 'DE-BY'
   const regionOptions = useMemo(() => {
-    const set = new Set<string>()
-    if (yearCal) set.add(regionKey(yearCal.country, yearCal.state))
-    for (const p of yearCal?.persons ?? []) set.add(regionKey(p.holiday_country, p.holiday_state))
+    const set = new Set<string>([globalRegion])
+    for (const p of mergedPersons) set.add(regionKey(p.holiday_country, p.holiday_state))
     return [...set]
-  }, [yearCal])
+  }, [mergedPersons, globalRegion])
   const displayedRegions = useMemo(() => {
     if (regionFilter) return new Set([regionFilter])
     const s = new Set(calendarPersons.map((p) => regionKey(p.holiday_country, p.holiday_state)))
@@ -258,7 +282,7 @@ export default function PersonsPage() {
   const selectAll = () => { setDeselected(new Set()); setSelProgram(null); setSelProject(null) }
   const selectNone = () => setDeselected(new Set(allIds))
   const selectWithAbsence = () => {
-    const withAbs = new Set((yearCal?.persons ?? []).filter((p) => p.absences.length > 0).map((p) => p.id))
+    const withAbs = new Set<number>(mergedPersons.filter((p) => p.absences.length > 0).map((p) => p.id))
     selectOnly(withAbs)
   }
   const applyProgram = (progId: number | null) => {
@@ -305,31 +329,12 @@ export default function PersonsPage() {
       {error && (
         <div className="mx-6 mt-4 p-3 bg-red-50 text-red-700 text-sm rounded border border-red-200">{error}</div>
       )}
-      <div className="p-6 space-y-6">
+      <div className="p-6 flex flex-col gap-6">
         {/* Year calendar for absences */}
-        <section>
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-baseline gap-2">
-              <h2 className="text-sm font-semibold text-gray-700">Jahreskalender – Abwesenheiten</h2>
-              <span className="text-xs text-gray-400">Zeitraum ziehen für neue Abwesenheit</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => setCalYear((y) => y - 1)}
-                aria-label="Vorheriges Jahr"
-                className="p-1.5 rounded hover:bg-gray-100 text-gray-600"
-              >
-                <ChevronLeft size={16} />
-              </button>
-              <span className="text-sm font-medium text-gray-700 min-w-[3.5rem] text-center">{calYear}</span>
-              <button
-                onClick={() => setCalYear((y) => y + 1)}
-                aria-label="Nächstes Jahr"
-                className="p-1.5 rounded hover:bg-gray-100 text-gray-600"
-              >
-                <ChevronRight size={16} />
-              </button>
-            </div>
+        <section className="order-2">
+          <div className="flex items-baseline gap-2 mb-2">
+            <h2 className="text-sm font-semibold text-gray-700">Jahreskalender – Abwesenheiten</h2>
+            <span className="text-xs text-gray-400">Zeitraum ziehen für neue Abwesenheit · vertikal scrollen für weitere Monate</span>
           </div>
 
           {/* Filter bar */}
@@ -397,8 +402,8 @@ export default function PersonsPage() {
             <p className="text-sm text-gray-400">Lade Kalender…</p>
           ) : (
             <YearCalendar
-              year={calYear}
-              holidays={yearCal?.holidays ?? []}
+              years={YEARS}
+              holidaysByYear={holidaysByYear}
               persons={calendarPersons}
               displayedRegions={displayedRegions}
               onRangeSelect={(personId, start, end) => setQuickCreate({ personId, start, end })}
@@ -416,7 +421,7 @@ export default function PersonsPage() {
         </section>
 
         {/* Person list — selection is shared with the calendar */}
-        <section>
+        <section className="order-1">
           <div className="flex items-center justify-between mb-2 gap-2">
             <button
               onClick={() => setTableCollapsed((v) => !v)}
@@ -532,7 +537,7 @@ export default function PersonsPage() {
 
       {quickCreate && (
         <AbsenceQuickCreateModal
-          persons={(yearCal?.persons ?? data).map((p) => ({ id: p.id, name: p.name }))}
+          persons={(mergedPersons.length ? mergedPersons : data).map((p) => ({ id: p.id, name: p.name }))}
           initialPersonId={quickCreate.personId}
           startDate={quickCreate.start}
           endDate={quickCreate.end}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,25 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Database, AlertTriangle, CheckCircle, RefreshCw, FolderOpen } from 'lucide-react'
+import { Database, AlertTriangle, CheckCircle, RefreshCw, FolderOpen, CalendarDays } from 'lucide-react'
 import { settings, type DbPathInfo } from '../api'
 import PageHeader from '../components/PageHeader'
+
+// German states (feiertage-api subdivision codes)
+const GERMAN_STATES: [string, string][] = [
+  ['BW', 'Baden-Württemberg'], ['BY', 'Bayern'], ['BE', 'Berlin'], ['BB', 'Brandenburg'],
+  ['HB', 'Bremen'], ['HH', 'Hamburg'], ['HE', 'Hessen'], ['MV', 'Mecklenburg-Vorpommern'],
+  ['NI', 'Niedersachsen'], ['NW', 'Nordrhein-Westfalen'], ['RP', 'Rheinland-Pfalz'], ['SL', 'Saarland'],
+  ['SN', 'Sachsen'], ['ST', 'Sachsen-Anhalt'], ['SH', 'Schleswig-Holstein'], ['TH', 'Thüringen'],
+]
+
+// Optional local holidays — keys must match EXTRA_HOLIDAY_CATALOG in the backend.
+const EXTRA_HOLIDAYS: [string, string][] = [
+  ['mariae_himmelfahrt', 'Mariä Himmelfahrt (15.8.)'],
+  ['augsburger_friedensfest', 'Augsburger Friedensfest (8.8.)'],
+  ['reformationstag', 'Reformationstag (31.10.)'],
+]
+
+const HOLIDAY_KEYS = ['holiday_country', 'holiday_state', 'holiday_extra']
 
 // ─── Generic key/value setting row ───────────────────────────────────────────
 
@@ -58,6 +75,86 @@ function SettingRow({ label, description, settingKey, value, onSave }: {
         )}
       </div>
     </div>
+  )
+}
+
+// ─── Holiday region section ───────────────────────────────────────────────────
+
+function RegionSection({ country, state, extra, onSave }: {
+  country: string
+  state: string
+  extra: string
+  onSave: (key: string, value: string) => void
+}) {
+  const [draftState, setDraftState] = useState(state)
+  const [draftExtra, setDraftExtra] = useState<Set<string>>(
+    new Set(extra.split(',').map((s) => s.trim()).filter(Boolean)),
+  )
+  const dirty = draftState !== state ||
+    [...draftExtra].sort().join(',') !== extra.split(',').map((s) => s.trim()).filter(Boolean).sort().join(',')
+
+  const toggleExtra = (key: string) =>
+    setDraftExtra((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+
+  const save = () => {
+    if (draftState !== state) onSave('holiday_state', draftState)
+    onSave('holiday_extra', [...draftExtra].join(','))
+    if (!country) onSave('holiday_country', 'DE')
+  }
+
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+        <CalendarDays size={15} className="text-gray-400" />
+        Feiertage / Region
+      </h2>
+      <div className="bg-white rounded-lg border border-gray-200 px-6 py-4 space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="hr-country" className="block text-xs font-medium text-gray-600 mb-1">Land</label>
+            <select id="hr-country" disabled value={country || 'DE'}
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm bg-gray-50 text-gray-500">
+              <option value="DE">Deutschland (DE)</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="hr-state" className="block text-xs font-medium text-gray-600 mb-1">Bundesland</label>
+            <select id="hr-state" value={draftState}
+              onChange={(e) => setDraftState(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              {GERMAN_STATES.map(([code, name]) => <option key={code} value={code}>{name} ({code})</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-medium text-gray-600 mb-1.5">Optionale lokale Feiertage</p>
+          <div className="space-y-1.5">
+            {EXTRA_HOLIDAYS.map(([key, label]) => (
+              <label key={key} className="flex items-center gap-2 text-sm text-gray-700">
+                <input type="checkbox" checked={draftExtra.has(key)} onChange={() => toggleExtra(key)} className="accent-blue-600" />
+                {label}
+              </label>
+            ))}
+          </div>
+          <p className="text-xs text-gray-400 mt-1.5">
+            Zusätzliche regionale Feiertage, die die Feiertags-API nicht flächendeckend liefert. Werden im Jahreskalender angezeigt.
+          </p>
+        </div>
+
+        <div className="flex justify-end">
+          <button onClick={save} disabled={!dirty}
+            className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+            Speichern
+          </button>
+        </div>
+      </div>
+    </section>
   )
 }
 
@@ -216,7 +313,7 @@ export default function SettingsPage() {
             <p className="text-sm text-gray-400">Lade…</p>
           ) : (
             <div className="bg-white rounded-lg border border-gray-200 px-6">
-              {data && Object.entries(data).map(([key, value]) => {
+              {data && Object.entries(data).filter(([key]) => !HOLIDAY_KEYS.includes(key)).map(([key, value]) => {
                 const meta = SETTING_META[key]
                 return (
                   <SettingRow
@@ -232,6 +329,16 @@ export default function SettingsPage() {
             </div>
           )}
         </section>
+
+        {/* Holiday region */}
+        {!isLoading && data && (
+          <RegionSection
+            country={data.holiday_country ?? 'DE'}
+            state={data.holiday_state ?? 'BY'}
+            extra={data.holiday_extra ?? ''}
+            onSave={(k, v) => update.mutate({ key: k, value: v })}
+          />
+        )}
 
         {/* Database path */}
         <DbPathSection />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,21 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Database, AlertTriangle, CheckCircle, RefreshCw, FolderOpen, CalendarDays } from 'lucide-react'
 import { settings, type DbPathInfo } from '../api'
 import PageHeader from '../components/PageHeader'
-
-// German states (feiertage-api subdivision codes)
-const GERMAN_STATES: [string, string][] = [
-  ['BW', 'Baden-Württemberg'], ['BY', 'Bayern'], ['BE', 'Berlin'], ['BB', 'Brandenburg'],
-  ['HB', 'Bremen'], ['HH', 'Hamburg'], ['HE', 'Hessen'], ['MV', 'Mecklenburg-Vorpommern'],
-  ['NI', 'Niedersachsen'], ['NW', 'Nordrhein-Westfalen'], ['RP', 'Rheinland-Pfalz'], ['SL', 'Saarland'],
-  ['SN', 'Sachsen'], ['ST', 'Sachsen-Anhalt'], ['SH', 'Schleswig-Holstein'], ['TH', 'Thüringen'],
-]
-
-// Optional local holidays — keys must match EXTRA_HOLIDAY_CATALOG in the backend.
-const EXTRA_HOLIDAYS: [string, string][] = [
-  ['mariae_himmelfahrt', 'Mariä Himmelfahrt (15.8.)'],
-  ['augsburger_friedensfest', 'Augsburger Friedensfest (8.8.)'],
-  ['reformationstag', 'Reformationstag (31.10.)'],
-]
+import { GERMAN_STATES, EXTRA_HOLIDAYS } from '../lib/holidayRegions'
 
 const HOLIDAY_KEYS = ['holiday_country', 'holiday_state', 'holiday_extra']
 


### PR DESCRIPTION
## Jahreskalender für Personenabwesenheiten

Umsetzung des Epics #9 (WP1–WP9). Neuer Jahreskalender unter *Personen* zur visuell ansprechenden Anzeige und zum Direkt-Input (Bereichsselektion) von Abwesenheiten; ersetzt den 2-Datepicker-Flow (Tabelle bleibt).

> Merge-Richtung: `dev → main`.

### Enthalten
- **WP1** Fundament + Jahresansicht (Backend `/calendar/year`, geteiltes Farb-/Label-Modul).
- **WP2** Abwesenheitsbalken (Stacking, Monatsumbruch offen, Tag/Tooltip, Hover-Highlight).
- **WP3** Direkt-Input per Bereichsselektion (Drag → vorbelegtes Modal).
- **WP4** Filter (Projekt/Programm, Einzel-MA+Suche, Typ-Toggles, Schnellaktionen) + farbharmonisierte, einklappbare Personentabelle.
- **WP5** Globale Feiertags-Region + optionale lokale Feiertage (Einstellungen).
- **WP6** Per-MA-Feiertagsregion-Override + Multi-Region-Darstellung.
- **WP7** UX-Verfeinerungen: breitere Zellen, schraffierte Platzhalter, **vertikales Monats-Scrolling** über mehrere Jahre + Jahr-Spalte, Tabelle über Kalender.
- **WP8** Urlaubskontingente in die Personeneinstellungen integriert (Extra-Tab entfernt).
- **WP9** Auslands-Feiertage: DE via feiertage-api.de, andere Länder (u. a. Griechenland) via Nager.Date; per-MA Länderauswahl.

### Tests / Verifikation
- Backend: **495 Tests grün**. Frontend: `tsc -b` sauber, **27 Vitest grün**.
- End-to-end im Browser verifiziert (Balken/Stacking/Hover, Drag-Anlage, Filter/Selektion, Feiertags-Region global + per-MA inkl. Griechenland/orthodoxes Ostern). Alle Verifikations-Pseudodaten zurückgesetzt.

### Datenmodell
- Alembic `f7a3b9c14d20`: `Person.holiday_country/holiday_state` (nullable). `Holiday.state` erlaubt jetzt leeren Wert (national-only Länder).

### Nicht enthalten (bewusst)
- `backend/debug_import.txt` (echte Namen, DSGVO) und die verirrte `backend/package-lock.json` bleiben ungetrackt.

Closes #9, #10, #11, #12, #13, #14, #15, #16, #17, #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)