### PR TITLE
Mehrere Posten pro MA (Multi-Assignment) + Abwesenheitskategorie 'Sonstiges'

### DIFF
--- a/backend/alembic/versions/b2d9f4a17c60_posten_multi_assignment.py
+++ b/backend/alembic/versions/b2d9f4a17c60_posten_multi_assignment.py
@@ -1,0 +1,86 @@
+"""Posten multi-assignment — MA may hold multiple positions per project (doc 23, WP1)
+
+Adds milestone_person_budget.billing_position_id and widens the per-row unique key
+to (milestone_id, person_id, billing_position_id); adds the composite unique key
+(project_id, person_id, billing_position_id) on project_membership so a person can be
+assigned to several line items of the same project.
+
+Note: runtime/tests build the schema via SQLModel.metadata.create_all; this migration
+keeps the Alembic chain (schema-of-record) in sync for migration-built databases.
+
+Revision ID: b2d9f4a17c60
+Revises: f7a3b9c14d20
+Create Date: 2026-07-17
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b2d9f4a17c60"
+down_revision: Union[str, None] = "f7a3b9c14d20"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _cols(conn, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(sa.text(f"PRAGMA table_info({table})"))}
+
+
+def _index_names(conn) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute(sa.text("SELECT name FROM sqlite_master WHERE type='index'"))
+    }
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # milestone_person_budget: add billing_position_id + widen unique key.
+    if "billing_position_id" not in _cols(conn, "milestone_person_budget"):
+        with op.batch_alter_table("milestone_person_budget") as batch_op:
+            batch_op.add_column(
+                sa.Column("billing_position_id", sa.Integer(), nullable=True)
+            )
+            batch_op.create_foreign_key(
+                "fk_mpb_billing_position", "billing_position",
+                ["billing_position_id"], ["id"],
+            )
+            batch_op.drop_constraint("uq_mpb_milestone_person", type_="unique")
+            batch_op.create_unique_constraint(
+                "uq_mpb_milestone_person_position",
+                ["milestone_id", "person_id", "billing_position_id"],
+            )
+        op.create_index(
+            op.f("ix_milestone_person_budget_billing_position_id"),
+            "milestone_person_budget", ["billing_position_id"], unique=False,
+        )
+
+    # project_membership: add the composite unique key (none existed before).
+    if "uq_membership_project_person_position" not in _index_names(conn):
+        with op.batch_alter_table("project_membership") as batch_op:
+            batch_op.create_unique_constraint(
+                "uq_membership_project_person_position",
+                ["project_id", "person_id", "billing_position_id"],
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("project_membership") as batch_op:
+        batch_op.drop_constraint(
+            "uq_membership_project_person_position", type_="unique"
+        )
+    op.drop_index(
+        op.f("ix_milestone_person_budget_billing_position_id"),
+        table_name="milestone_person_budget",
+    )
+    with op.batch_alter_table("milestone_person_budget") as batch_op:
+        batch_op.drop_constraint("uq_mpb_milestone_person_position", type_="unique")
+        batch_op.drop_constraint("fk_mpb_billing_position", type_="foreignkey")
+        batch_op.create_unique_constraint(
+            "uq_mpb_milestone_person", ["milestone_id", "person_id"]
+        )
+        batch_op.drop_column("billing_position_id")

--- a/backend/alembic/versions/c3e0a6b28d71_billing_position_overrunnable.py
+++ b/backend/alembic/versions/c3e0a6b28d71_billing_position_overrunnable.py
@@ -1,0 +1,40 @@
+"""BillingPosition.overrunnable — asymmetric position overrun (doc 23, WP3)
+
+Adds a boolean flag: False (default) = hard-capped position (never planned past budget),
+True = cheap/overrunnable position (the automatic distribution may fund it beyond budget).
+
+Note: runtime/tests build the schema via SQLModel.metadata.create_all; this migration keeps
+the Alembic chain in sync for migration-built databases.
+
+Revision ID: c3e0a6b28d71
+Revises: b2d9f4a17c60
+Create Date: 2026-07-17
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3e0a6b28d71"
+down_revision: Union[str, None] = "b2d9f4a17c60"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _cols(conn, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(sa.text(f"PRAGMA table_info({table})"))}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if "overrunnable" not in _cols(conn, "billing_position"):
+        op.add_column(
+            "billing_position",
+            sa.Column("overrunnable", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("billing_position", "overrunnable")

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -18,3 +18,10 @@ class BillingPosition(ValidatedSQLModel, table=True):
     # and the effective rate comes from here; hours = budget_euros / billing_rate_per_hour.
     billing_rate_per_hour: float = Field(default=0.0, ge=0)
     # SUM(budget_euros) across all positions = effective total € budget for the project
+    #
+    # Asymmetric overrun (doc 23, WP3): False = hard cap (teuer, darf nicht überschritten
+    # werden — the automatic distribution never plans past budget_euros). True = überschreitbar
+    # (günstig, darf über Budget) — the distribution funds this position to full assignment
+    # capacity even beyond its budget, so cheaper hours can absorb what expensive positions
+    # cannot. Default False keeps the pre-WP3 behavior (every position hard-capped).
+    overrunnable: bool = Field(default=False)

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -14,6 +14,10 @@ class AbsenceType(str, Enum):
     vacation = "vacation"
     training = "training"
     sick = "sick"
+    # Geplante Abwesenheit ohne Pauschale/Kontingent (z. B. Elternzeit, Sabbatical).
+    # Reduziert konkret die Verfügbarkeit, fließt aber in keine Richtwert-/Kontingent-
+    # Schätzung ein (die sind typ-selektiv auf vacation/sick/training verdrahtet).
+    other = "other"
 
 
 class AbsenceStatus(str, Enum):

--- a/backend/app/models/membership.py
+++ b/backend/app/models/membership.py
@@ -1,7 +1,17 @@
-"""ProjectMembership — links a person to a project for a specific period."""
+"""ProjectMembership — links a person to a project for a specific period.
+
+Multi-Assignment (doc 23, WP1): a person may hold several memberships in the
+same project, each bound to a different line item (Projektposten). The unique
+constraint therefore spans (project_id, person_id, billing_position_id):
+- Simple mode: billing_position_id is NULL and a person has exactly one row.
+- Position mode: one row per (person, position); the same person can be
+  assigned to multiple positions of the project, each with its own rate,
+  capacity and priority.
+"""
 
 from datetime import date
 
+from sqlalchemy import UniqueConstraint
 from sqlmodel import Field
 
 from app.models.base import ValidatedSQLModel
@@ -9,6 +19,12 @@ from app.models.base import ValidatedSQLModel
 
 class ProjectMembership(ValidatedSQLModel, table=True):
     __tablename__ = "project_membership"
+    __table_args__ = (
+        UniqueConstraint(
+            "project_id", "person_id", "billing_position_id",
+            name="uq_membership_project_person_position",
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     project_id: int = Field(foreign_key="project.id", index=True)

--- a/backend/app/models/milestone.py
+++ b/backend/app/models/milestone.py
@@ -41,19 +41,31 @@ class Milestone(ValidatedSQLModel, table=True):
 
 
 class MilestonePersonBudget(ValidatedSQLModel, table=True):
-    """Per-person hour split within a milestone.
+    """Per-(person, position) hour split within a milestone.
 
     Must sum to the parent Milestone.current_hours (invariant enforced by service).
+
+    Multi-Assignment (doc 23, WP1): the row is keyed by (milestone, person,
+    billing_position_id). billing_position_id is NULL in simple mode (one row
+    per person, as before); in position mode a person assigned to several
+    positions gets one budget row per position.
     """
 
     __tablename__ = "milestone_person_budget"
     __table_args__ = (
-        UniqueConstraint("milestone_id", "person_id", name="uq_mpb_milestone_person"),
+        UniqueConstraint(
+            "milestone_id", "person_id", "billing_position_id",
+            name="uq_mpb_milestone_person_position",
+        ),
     )
 
     id: int | None = Field(default=None, primary_key=True)
     milestone_id: int = Field(foreign_key="milestone.id", index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
+    # Line item this budget row belongs to (doc 23). None = simple mode / unassigned.
+    billing_position_id: int | None = Field(
+        default=None, foreign_key="billing_position.id", index=True
+    )
     initial_hours: float = Field(ge=0)
     current_hours: float = Field(ge=0)
     # V5/B6: when True, this row's hours are locked — manually set and preserved by

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -41,8 +41,8 @@ class PersonAbsence(ValidatedSQLModel, table=True):
     """A date-range absence record for a person.
 
     Status rules (enforced by model_validator):
-      vacation / training → planned | confirmed  (end_date required)
-      sick                → ongoing | confirmed  (end_date optional when ongoing)
+      vacation / training / other → planned | confirmed  (end_date required)
+      sick                        → ongoing | confirmed  (end_date optional when ongoing)
     """
 
     __tablename__ = "person_absence"

--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -40,6 +40,7 @@ class ImportResultOut(SQLModel):
     batch_ids: list[int]
     inserted: int
     skipped: int
+    mismatches: list[str] = []  # doc 23 WP4: MA booked on an unassigned Posten
 
 
 class MappingCreate(SQLModel):
@@ -104,6 +105,7 @@ async def post_import(file: UploadFile, session: SessionDep):
         batch_ids=result.batch_ids,
         inserted=result.inserted,
         skipped=result.skipped,
+        mismatches=result.mismatches,
     )
 
 

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -196,16 +196,16 @@ def clear_target_budget(project_id: int, milestone_id: int, session: SessionDep)
 
 
 @router.put(
-    "/{project_id}/milestones/{milestone_id}/persons/{person_id}/lock",
+    "/{project_id}/milestones/{milestone_id}/budgets/{budget_id}/lock",
     response_model=MilestonePersonBudget,
 )
-def put_hours_lock(project_id: int, milestone_id: int, person_id: int, body: LockUpdate, session: SessionDep):
-    """Lock/unlock a person's Soll-hours for the month (locked = preserved by resync/rebalancing)."""
+def put_hours_lock(project_id: int, milestone_id: int, budget_id: int, body: LockUpdate, session: SessionDep):
+    """Lock/unlock one budget row's Soll-hours for the month (locked = preserved by resync)."""
     milestone = session.get(Milestone, milestone_id)
     if not milestone or milestone.project_id != project_id:
         raise HTTPException(404, "Milestone not found.")
     try:
-        return set_budget_hours_lock(milestone_id, person_id, body.locked, session)
+        return set_budget_hours_lock(milestone_id, budget_id, body.locked, session)
     except MilestoneLocked as exc:
         raise HTTPException(409, str(exc)) from exc
     except (MilestoneNotFound, BudgetNotFound) as exc:
@@ -213,16 +213,16 @@ def put_hours_lock(project_id: int, milestone_id: int, person_id: int, body: Loc
 
 
 @router.put(
-    "/{project_id}/milestones/{milestone_id}/persons/{person_id}/estimated-absence",
+    "/{project_id}/milestones/{milestone_id}/budgets/{budget_id}/estimated-absence",
     response_model=MilestonePersonBudget,
 )
-def put_estimated_absence(project_id: int, milestone_id: int, person_id: int, body: EstimatedAbsenceUpdate, session: SessionDep):
-    """Set (or clear, days=null) the manual estimated-absence override for a person/month."""
+def put_estimated_absence(project_id: int, milestone_id: int, budget_id: int, body: EstimatedAbsenceUpdate, session: SessionDep):
+    """Set (or clear, days=null) the manual estimated-absence override for one budget row."""
     milestone = session.get(Milestone, milestone_id)
     if not milestone or milestone.project_id != project_id:
         raise HTTPException(404, "Milestone not found.")
     try:
-        return set_estimated_absence(milestone_id, person_id, body.days, session)
+        return set_estimated_absence(milestone_id, budget_id, body.days, session)
     except MilestoneLocked as exc:
         raise HTTPException(409, str(exc)) from exc
     except (MilestoneNotFound, BudgetNotFound) as exc:

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -260,7 +260,11 @@ def list_milestones_detail(project_id: int, session: SessionDep):
     memberships = session.exec(
         select(ProjectMembership).where(ProjectMembership.project_id == project_id)
     ).all()
-    membership_map: dict[int, ProjectMembership] = {m.person_id: m for m in memberships}
+    # Keyed by assignment (person, position) so a multi-assigned person resolves the
+    # right membership per budget row (WP2).
+    membership_map: dict[tuple[int, int | None], ProjectMembership] = {
+        (m.person_id, m.billing_position_id): m for m in memberships
+    }
     positions_by_id = project_positions(project_id, session)
 
     persons_map: dict[int, Person] = {}
@@ -277,20 +281,24 @@ def list_milestones_detail(project_id: int, session: SessionDep):
         month_start = date(ms.year, ms.month, 1)
         month_end = date(ms.year, ms.month, _monthrange(ms.year, ms.month)[1])
         booked_rows = session.exec(
-            select(TimeBooking.person_id, func.sum(TimeBooking.net_hours))
+            select(TimeBooking.person_id, TimeBooking.billing_position_id, func.sum(TimeBooking.net_hours))
             .where(
                 TimeBooking.project_id == project_id,
                 TimeBooking.booking_date >= month_start,
                 TimeBooking.booking_date <= month_end,
                 TimeBooking.is_excluded == False,  # noqa: E712
             )
-            .group_by(TimeBooking.person_id)
+            .group_by(TimeBooking.person_id, TimeBooking.billing_position_id)
         ).all()
-        booked_map: dict[int, float] = {pid: float(h) for pid, h in booked_rows}
+        # Booked hours per assignment (person, position); in simple mode both booking and
+        # budget carry billing_position_id = None, so this matches the person's row (WP2).
+        booked_map: dict[tuple[int, int | None], float] = {
+            (pid, bpid): float(h) for pid, bpid, h in booked_rows
+        }
         persons_out: list[MilestonePersonDetailOut] = []
         for budget in budgets:
             person = persons_map.get(budget.person_id)
-            membership = membership_map.get(budget.person_id)
+            membership = membership_map.get((budget.person_id, budget.billing_position_id))
             if person is None or membership is None:
                 continue
             stats = _person_available_hours(person, membership, project, ms.year, ms.month, session)
@@ -313,7 +321,7 @@ def list_milestones_detail(project_id: int, session: SessionDep):
                 holiday_days=stats.holiday_days,
                 billing_rate_per_hour=effective_rate(membership, positions_by_id),
                 billing_position_id=membership.billing_position_id,
-                booked_hours=booked_map.get(person.id, 0.0),
+                booked_hours=booked_map.get((person.id, budget.billing_position_id), 0.0),
                 is_manual_override=budget.is_manual_override,
                 estimated_absence_days_override=budget.estimated_absence_days_override,
             ))

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -72,6 +72,8 @@ class MilestonePersonDetailOut(SQLModel):
     booked_hours: float = 0.0
     is_manual_override: bool = False
     estimated_absence_days_override: float | None = None
+    # WP6 diagnostics: why this row is planned below its available capacity (else None).
+    cap_reason: str | None = None
 
 
 class MilestoneDetailOut(SQLModel):
@@ -304,6 +306,22 @@ def list_milestones_detail(project_id: int, session: SessionDep):
             stats = _person_available_hours(person, membership, project, ms.year, ms.month, session)
             pattern = _parse_work_week_pattern(person.work_week_pattern) if person.work_week_pattern else None
             days_per_week = float(sum(1 for h in pattern if h > 0)) if pattern else 5.0
+            # WP6: a non-override row planned below its available capacity was capped by a
+            # budget (capacity itself = available_hours). Name which budget bound it.
+            cap_reason: str | None = None
+            if not ms.is_locked and not budget.is_manual_override and stats.hours - budget.current_hours > 0.05:
+                if project.position_mode and membership.billing_position_id is not None:
+                    pos = positions_by_id.get(membership.billing_position_id)
+                    posnum = pos.position_number if pos else "?"
+                    cap_reason = (
+                        f"Nur {budget.current_hours:.1f} von {stats.hours:.1f} h verplant — "
+                        f"Budget von Posten '{posnum}' ausgeschöpft."
+                    )
+                else:
+                    cap_reason = (
+                        f"Nur {budget.current_hours:.1f} von {stats.hours:.1f} h verplant — "
+                        f"Projektbudget ausgeschöpft."
+                    )
             persons_out.append(MilestonePersonDetailOut(
                 person_id=person.id,
                 person_name=person.name,
@@ -324,6 +342,7 @@ def list_milestones_detail(project_id: int, session: SessionDep):
                 booked_hours=booked_map.get((person.id, budget.billing_position_id), 0.0),
                 is_manual_override=budget.is_manual_override,
                 estimated_absence_days_override=budget.estimated_absence_days_override,
+                cap_reason=cap_reason,
             ))
 
         # Milestone-level warnings (§8.1 / V11)

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -298,11 +298,21 @@ def list_milestones_detail(project_id: int, session: SessionDep):
             )
             .group_by(TimeBooking.person_id, TimeBooking.billing_position_id)
         ).all()
-        # Booked hours per assignment (person, position); in simple mode both booking and
-        # budget carry billing_position_id = None, so this matches the person's row (WP2).
-        booked_map: dict[tuple[int, int | None], float] = {
-            (pid, bpid): float(h) for pid, bpid, h in booked_rows
-        }
+        # Attribute booked hours to the per-(person, position) budget rows. Bookings that
+        # carry a position map to the matching row; bookings WITHOUT a position (NULL — e.g.
+        # imported in simple mode / before a level→position mapping existed) cannot be split
+        # across a person's positions, so they are attributed to that person's PRIMARY row
+        # (lowest budget id) — shown exactly once, so the milestone Ist total stays correct.
+        booked_pos: dict[tuple[int, int], float] = {}
+        booked_null: dict[int, float] = {}
+        for pid, bpid, h in booked_rows:
+            if bpid is None:
+                booked_null[pid] = booked_null.get(pid, 0.0) + float(h)
+            else:
+                booked_pos[(pid, bpid)] = booked_pos.get((pid, bpid), 0.0) + float(h)
+        primary_budget_by_person: dict[int, int] = {}
+        for b in sorted(budgets, key=lambda b: b.id):
+            primary_budget_by_person.setdefault(b.person_id, b.id)
         persons_out: list[MilestonePersonDetailOut] = []
         for budget in budgets:
             person = persons_map.get(budget.person_id)
@@ -317,6 +327,9 @@ def list_milestones_detail(project_id: int, session: SessionDep):
             days_per_week = float(sum(1 for h in pattern if h > 0)) if pattern else 5.0
             # WP6: a non-override row planned below its available capacity was capped by a
             # budget (capacity itself = available_hours). Name which budget bound it.
+            booked_hours = booked_pos.get((person.id, budget.billing_position_id), 0.0)
+            if primary_budget_by_person.get(person.id) == budget.id:
+                booked_hours += booked_null.get(person.id, 0.0)
             cap_reason: str | None = None
             if not ms.is_locked and not budget.is_manual_override and stats.hours - budget.current_hours > 0.05:
                 if project.position_mode and membership.billing_position_id is not None:
@@ -348,7 +361,7 @@ def list_milestones_detail(project_id: int, session: SessionDep):
                 holiday_days=stats.holiday_days,
                 billing_rate_per_hour=effective_rate(membership, positions_by_id),
                 billing_position_id=membership.billing_position_id,
-                booked_hours=booked_map.get((person.id, budget.billing_position_id), 0.0),
+                booked_hours=booked_hours,
                 is_manual_override=budget.is_manual_override,
                 estimated_absence_days_override=budget.estimated_absence_days_override,
                 cap_reason=cap_reason,

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -267,6 +267,12 @@ def list_milestones_detail(project_id: int, session: SessionDep):
     membership_map: dict[tuple[int, int | None], ProjectMembership] = {
         (m.person_id, m.billing_position_id): m for m in memberships
     }
+    # Fallback for LEGACY budget rows created before WP1 (billing_position_id = NULL) whose
+    # membership now carries a position: resolve by person so the row is still displayed
+    # instead of silently dropped (regression fix). First membership per person wins.
+    membership_by_person: dict[int, ProjectMembership] = {}
+    for m in memberships:
+        membership_by_person.setdefault(m.person_id, m)
     positions_by_id = project_positions(project_id, session)
 
     persons_map: dict[int, Person] = {}
@@ -300,7 +306,10 @@ def list_milestones_detail(project_id: int, session: SessionDep):
         persons_out: list[MilestonePersonDetailOut] = []
         for budget in budgets:
             person = persons_map.get(budget.person_id)
-            membership = membership_map.get((budget.person_id, budget.billing_position_id))
+            membership = (
+                membership_map.get((budget.person_id, budget.billing_position_id))
+                or membership_by_person.get(budget.person_id)
+            )
             if person is None or membership is None:
                 continue
             stats = _person_available_hours(person, membership, project, ms.year, ms.month, session)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -485,7 +485,9 @@ def update_membership(project_id: int, membership_id: int, body: MembershipUpdat
     # Referential action (V11): drop this member's budgets from open milestones that no
     # longer overlap the (possibly shrunk) membership range. Recomputing changed weekly
     # hours into remaining months is the resync path (WP4/WP5), not done here.
-    prune_member_budgets_to_range(project_id, m.person_id, m.from_date, m.to_date, session)
+    prune_member_budgets_to_range(
+        project_id, m.person_id, m.from_date, m.to_date, m.billing_position_id, session
+    )
     session.commit()
     warnings = _membership_overbooking_warnings(m, session)
     return MembershipWithWarnings(

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -46,6 +46,7 @@ class BillingPositionCreate(SQLModel):
     # None → default to the open (unallocated) difference (P3).
     budget_euros: float | None = Field(default=None, ge=0)
     billing_rate_per_hour: float = Field(default=0.0, ge=0)
+    overrunnable: bool = False  # doc 23 WP3: cheap position may exceed its budget
 
 
 class BillingPositionUpdate(SQLModel):
@@ -53,6 +54,7 @@ class BillingPositionUpdate(SQLModel):
     description: str = ""
     budget_euros: float = Field(ge=0)
     billing_rate_per_hour: float = Field(default=0.0, ge=0)
+    overrunnable: bool = False
 
 
 class BillingPositionBudgetState(SQLModel):
@@ -272,6 +274,7 @@ def create_billing_position(project_id: int, body: BillingPositionCreate, sessio
         description=body.description,
         budget_euros=budget,
         billing_rate_per_hour=body.billing_rate_per_hour,
+        overrunnable=body.overrunnable,
     )
     session.add(bp)
     session.commit()
@@ -300,6 +303,7 @@ def update_billing_position(
     bp.description = body.description
     bp.budget_euros = body.budget_euros
     bp.billing_rate_per_hour = body.billing_rate_per_hour
+    bp.overrunnable = body.overrunnable
     session.add(bp)
     session.commit()
     session.refresh(bp)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -445,7 +445,11 @@ def create_membership(project_id: int, body: MembershipCreate, session: SessionD
         session.refresh(membership)
     except IntegrityError:
         session.rollback()
-        raise HTTPException(409, "Membership already exists for this person and project.")
+        # Unique key is (project, person, billing_position): a person may be assigned to
+        # several positions, but not to the same position twice (doc 23, WP1).
+        raise HTTPException(
+            409, "Diese Person ist diesem Posten in diesem Projekt bereits zugewiesen."
+        )
     warnings = _membership_overbooking_warnings(membership, session)
     return MembershipWithWarnings(
         id=membership.id,

--- a/backend/app/services/importer.py
+++ b/backend/app/services/importer.py
@@ -32,6 +32,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 from thefuzz import process as fuzz_process
 
+from app.models.billing import BillingPosition
+from app.models.membership import ProjectMembership
 from app.models.person import Person
 from app.models.timebooking import (
     ImportBatch,
@@ -98,6 +100,8 @@ class ImportResult:
     batch_ids: list[int] = field(default_factory=list)
     inserted: int = 0
     skipped: int = 0
+    # doc 23 WP4: human-readable flags for bookings on a position the MA is not assigned to.
+    mismatches: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -398,6 +402,48 @@ def resolve_position_mappings(
     return result
 
 
+def detect_position_mismatches(batch_ids: list[int], session: Session) -> list[str]:
+    """Flag bookings whose (person, position) has no matching ProjectMembership (doc 23 WP4).
+
+    Only bookings with a resolved billing_position_id (i.e. position-mode projects) are
+    checked. A mismatch means a MA booked on a Projektposten they are not assigned to —
+    e.g. the plan needs the assignment added, or the booking's level mapping is wrong.
+    """
+    if not batch_ids:
+        return []
+    rows = session.exec(
+        select(TimeBooking).where(
+            TimeBooking.import_batch_id.in_(batch_ids),  # type: ignore[attr-defined]
+            TimeBooking.billing_position_id.is_not(None),  # type: ignore[union-attr]
+        )
+    ).all()
+    warnings: list[str] = []
+    seen: set[tuple[int, int, int]] = set()
+    for tb in rows:
+        key = (tb.project_id, tb.person_id, tb.billing_position_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        assigned = session.exec(
+            select(ProjectMembership).where(
+                ProjectMembership.project_id == tb.project_id,
+                ProjectMembership.person_id == tb.person_id,
+                ProjectMembership.billing_position_id == tb.billing_position_id,
+            )
+        ).first()
+        if assigned is not None:
+            continue
+        person = session.get(Person, tb.person_id)
+        pos = session.get(BillingPosition, tb.billing_position_id)
+        person_name = person.name if person else f"Person {tb.person_id}"
+        pos_label = pos.position_number if pos else f"Posten {tb.billing_position_id}"
+        warnings.append(
+            f"{person_name} hat auf Posten '{pos_label}' gebucht, "
+            f"ist ihm dort aber nicht zugewiesen."
+        )
+    return sorted(warnings)
+
+
 # ---------------------------------------------------------------------------
 # Main import entry point
 # ---------------------------------------------------------------------------
@@ -482,4 +528,5 @@ def import_bookings(
             result.skipped += 1
 
     session.commit()
+    result.mismatches = detect_position_mismatches(result.batch_ids, session)
     return result

--- a/backend/app/services/milestones.py
+++ b/backend/app/services/milestones.py
@@ -180,9 +180,12 @@ def _parse_work_week_pattern(pattern: str) -> list[float] | None:
 
 
 def _estimated_absence_override(
-    person_id: int, project_id: int, year: int, month: int, session: Session
+    person_id: int, project_id: int, year: int, month: int,
+    billing_position_id: int | None, session: Session,
 ) -> float | None:
-    """Return the manual estimated-absence override for this person/month, or None."""
+    """Return the manual estimated-absence override for this assignment/month, or None.
+
+    Keyed by (person, position) so a multi-assigned person's positions don't collide (WP2)."""
     ms = session.exec(
         select(Milestone).where(
             Milestone.project_id == project_id,
@@ -196,6 +199,7 @@ def _estimated_absence_override(
         select(MilestonePersonBudget).where(
             MilestonePersonBudget.milestone_id == ms.id,
             MilestonePersonBudget.person_id == person_id,
+            MilestonePersonBudget.billing_position_id == billing_position_id,
         )
     ).first()
     return row.estimated_absence_days_override if row else None
@@ -307,8 +311,10 @@ def _person_available_hours(
     )
     training_estimate = _estimated_pauschal_days(person.id, AbsenceType.training, annual_training, eff_start, eff_end, session)
 
-    # A manual (locked) override, if set for this person/month, replaces the whole estimate.
-    override = _estimated_absence_override(person.id, project.id, year, month, session)
+    # A manual (locked) override, if set for this assignment/month, replaces the whole estimate.
+    override = _estimated_absence_override(
+        person.id, project.id, year, month, membership.billing_position_id, session
+    )
     estimated_absence = override if override is not None else (vacation_estimate + sick_estimate + training_estimate)
     total_deduction = abs_days + estimated_absence
     net_hours = gross_hours - total_deduction * avg_daily_hours
@@ -329,25 +335,29 @@ def _person_available_hours(
 # ---------------------------------------------------------------------------
 
 
-SlotKey = tuple[int, tuple[int, int]]  # (person_id, (year, month))
+# WP2 (doc 23): the plan is keyed by ASSIGNMENT, not by person. An assignment key is
+# (person_id, billing_position_id) — a bijection to the ProjectMembership within a project
+# (billing_position_id is None in simple mode, where a person has exactly one membership).
+AssignmentKey = tuple[int, int | None]  # (person_id, billing_position_id)
+SlotKey = tuple[AssignmentKey, tuple[int, int]]  # ((person_id, position_id), (year, month))
 
 
 def distribute_budget(
     avail: dict[SlotKey, float],
-    rates: dict[int, float],
-    priorities: dict[int, int],
+    rates: dict[AssignmentKey, float],
+    priorities: dict[AssignmentKey, int],
     remaining_budget: float | None,
 ) -> dict[SlotKey, float]:
-    """Distribute a capped budget over (person, month) capacity slots.
+    """Distribute a capped budget over (assignment, month) capacity slots.
 
     See docs/implementation/20-milestone-review-and-rework.md §6.6.
 
     Args:
-        avail: {(person_id, (year, month)): available_net_hours}. The hard per-person
+        avail: {(assignment_key, (year, month)): available_net_hours}. The hard per-slot
                capacity cap — the result never exceeds these values.
-        rates: {person_id: euro_rate_per_hour}. Pass {pid: 1.0} to cap by HOURS instead
+        rates: {assignment_key: euro_rate_per_hour}. Pass {ak: 1.0} to cap by HOURS instead
                of euros (legacy total_budget_hours path).
-        priorities: {person_id: priority}; smaller = higher priority, equal = same tier,
+        priorities: {assignment_key: priority}; smaller = higher priority, equal = same tier,
                missing = 0. Higher tiers are funded to full capacity first (B6).
         remaining_budget: the cap in the same unit as (hours × rate). None => no cap,
                i.e. plan = full available capacity (global scale s = 1).
@@ -421,7 +431,10 @@ def _remaining_euro_budget(
         budgets = session.exec(
             select(MilestonePersonBudget).where(MilestonePersonBudget.milestone_id == ms.id)
         ).all()
-        open_cost += sum(b.current_hours * rate_map.get(b.person_id, 0.0) for b in budgets)
+        open_cost += sum(
+            b.current_hours * rate_map.get((b.person_id, b.billing_position_id), 0.0)
+            for b in budgets
+        )
 
     return max(0.0, total_budget_euros - invoiced - open_cost)
 
@@ -496,16 +509,18 @@ def set_position_mode(project_id: int, enabled: bool, session: Session) -> Proje
 
 def build_rate_map(
     memberships: list[ProjectMembership], positions_by_id: dict[int, BillingPosition]
-) -> dict[int, float]:
-    """person_id → effective hourly rate (position rate in position mode, else member rate)."""
-    return {m.person_id: effective_rate(m, positions_by_id) for m in memberships}
+) -> dict[AssignmentKey, float]:
+    """assignment_key → effective hourly rate (position rate in position mode, else member rate)."""
+    return {
+        (m.person_id, m.billing_position_id): effective_rate(m, positions_by_id)
+        for m in memberships
+    }
 
 
 def _remaining_position_euro_budget(
     project_id: int,
     pos: BillingPosition,
     exclude_months: set[tuple[int, int]],
-    position_pids: set[int],
     session: Session,
 ) -> float:
     """Budget still available for one line item (§21 P4), analogous to
@@ -543,7 +558,7 @@ def _remaining_position_euro_budget(
         open_cost += sum(
             b.current_hours * pos.billing_rate_per_hour
             for b in budgets
-            if b.person_id in position_pids
+            if b.billing_position_id == pos.id
         )
 
     return max(0.0, pos.budget_euros - invoiced - open_cost)
@@ -553,7 +568,7 @@ def distribute_over_positions(
     avail_map: dict[SlotKey, float],
     memberships: list[ProjectMembership],
     positions_by_id: dict[int, BillingPosition],
-    priorities: dict[int, int],
+    priorities: dict[AssignmentKey, int],
     override_rows: list[MilestonePersonBudget],
     exclude_months: set[tuple[int, int]],
     project_id: int,
@@ -561,27 +576,29 @@ def distribute_over_positions(
 ) -> dict[SlotKey, float]:
     """Position-mode distribution (§21 P4): one independent bucket per line item.
 
-    Each position distributes its own R_posten over only the members assigned to it, at the
+    Each position distributes its own R_posten over only the assignments bound to it, at the
     position's rate; buckets never borrow from one another (shifting hours between positions
-    = adjusting position budgets manually). Members not assigned to any position get 0 h
-    (WP4 makes assignment mandatory in position mode).
+    = adjusting position budgets manually). A person assigned to several positions has one
+    assignment slot per position (WP2). Members not assigned to any position get 0 h.
     """
-    memb_by_pid = {m.person_id: m for m in memberships}
     plan: dict[SlotKey, float] = dict.fromkeys(avail_map, 0.0)
     for pos_id, pos in positions_by_id.items():
-        position_pids = {m.person_id for m in memberships if m.billing_position_id == pos_id}
-        if not position_pids:
+        pos_keys = {
+            (m.person_id, m.billing_position_id)
+            for m in memberships if m.billing_position_id == pos_id
+        }
+        if not pos_keys:
             continue
-        sub_avail = {k: h for k, h in avail_map.items() if k[0] in position_pids}
+        sub_avail = {k: h for k, h in avail_map.items() if k[0] in pos_keys}
         if not sub_avail:
             continue
         rate = pos.billing_rate_per_hour
-        rates = {pid: rate for pid in position_pids}
-        base = _remaining_position_euro_budget(project_id, pos, exclude_months, position_pids, session)
+        rates = {ak: rate for ak in pos_keys}
+        base = _remaining_position_euro_budget(project_id, pos, exclude_months, session)
         override_cost = sum(
             b.current_hours * rate
             for b in override_rows
-            if (mb := memb_by_pid.get(b.person_id)) is not None and mb.billing_position_id == pos_id
+            if b.billing_position_id == pos_id
         )
         remaining = max(0.0, base - override_cost)
         plan.update(distribute_budget(sub_avail, rates, priorities, remaining))
@@ -643,7 +660,7 @@ def initialize_milestones(project_id: int, session: Session, force: bool = False
             "Add at least one member before initializing milestones."
         )
 
-    current_person_ids = {m.person_id for m in memberships}
+    current_keys = {(m.person_id, m.billing_position_id) for m in memberships}
     all_project_months = _months_in_range(project.start_date, project.end_date)
 
     # When force=True, delete all unlocked milestones so they get fully re-created below.
@@ -684,35 +701,36 @@ def initialize_milestones(project_id: int, session: Session, force: bool = False
                     MilestonePersonBudget.milestone_id == exists.id
                 )
             ).all()
-            existing_person_ids = {b.person_id for b in existing_budgets}
-            if current_person_ids - existing_person_ids:
+            existing_keys = {(b.person_id, b.billing_position_id) for b in existing_budgets}
+            if current_keys - existing_keys:
                 repair_milestones.append(exists)
 
     if not new_months and not repair_milestones:
         return []
 
-    # First pass: compute available capacity per person per month
-    month_capacity: dict[tuple[int, int], dict[int, float]] = {}
+    # First pass: compute available capacity per ASSIGNMENT (person × position) per month.
+    # Each membership is its own slot (WP2); a person on several positions yields several slots.
+    month_capacity: dict[tuple[int, int], dict[AssignmentKey, float]] = {}
     for year, month in new_months:
-        person_hours: dict[int, float] = {}
+        slot_hours: dict[AssignmentKey, float] = {}
         for m in memberships:
             person = _get_person(m.person_id)
             if person is None:
                 continue
             stats = _person_available_hours(person, m, project, year, month, session)
             if stats.hours > 0:
-                person_hours[m.person_id] = person_hours.get(m.person_id, 0.0) + stats.hours
-        month_capacity[(year, month)] = person_hours
+                slot_hours[(m.person_id, m.billing_position_id)] = stats.hours
+        month_capacity[(year, month)] = slot_hours
 
-    # Build the (person, month) availability map and distribute the budget across all new
+    # Build the (assignment, month) availability map and distribute the budget across all new
     # months jointly (§6.6). The budget cap is global, so a single distribution call spans
     # every new month; member priority (B6) funds higher tiers first.
     avail_map: dict[SlotKey, float] = {}
-    for (year, month), person_hours in month_capacity.items():
-        for pid, hours in person_hours.items():
-            avail_map[(pid, (year, month))] = hours
+    for (year, month), slot_hours in month_capacity.items():
+        for ak, hours in slot_hours.items():
+            avail_map[(ak, (year, month))] = hours
 
-    priorities = {m.person_id: m.priority for m in memberships}
+    priorities = {(m.person_id, m.billing_position_id): m.priority for m in memberships}
     new_month_set = set(new_months)
 
     budget_euros = project.total_budget_euros if project.total_budget_euros and project.total_budget_euros > 0 else 0.0
@@ -746,8 +764,8 @@ def initialize_milestones(project_id: int, session: Session, force: bool = False
     # Create new milestone rows from the distributed plan
     created: list[Milestone] = []
     for year, month in new_months:
-        person_hours = month_capacity[(year, month)]
-        month_plan = {pid: plan_map.get((pid, (year, month)), 0.0) for pid in person_hours}
+        slot_hours = month_capacity[(year, month)]
+        month_plan = {ak: plan_map.get((ak, (year, month)), 0.0) for ak in slot_hours}
         total = sum(month_plan.values())
 
         milestone = Milestone(
@@ -760,13 +778,14 @@ def initialize_milestones(project_id: int, session: Session, force: bool = False
         session.add(milestone)
         session.flush()
 
-        # Create a budget row for every active member this month (even 0 h, e.g. lower
-        # priority tiers not funded), so the per-person breakdown stays transparent.
-        for person_id in person_hours:
-            hours = month_plan.get(person_id, 0.0)
+        # Create a budget row for every active assignment this month (even 0 h, e.g. lower
+        # priority tiers not funded), so the per-(person, position) breakdown stays transparent.
+        for (pid, bpid) in slot_hours:
+            hours = month_plan.get((pid, bpid), 0.0)
             session.add(MilestonePersonBudget(
                 milestone_id=milestone.id,
-                person_id=person_id,
+                person_id=pid,
+                billing_position_id=bpid,
                 initial_hours=hours,
                 current_hours=hours,
             ))
@@ -893,7 +912,7 @@ def _projected_budget_after_edit(
             select(MilestonePersonBudget).where(MilestonePersonBudget.milestone_id == ms.id)
         ).all():
             hrs = new_hours if b.id == budget.id else b.current_hours
-            projected += hrs * rate_map.get(b.person_id, 0.0)
+            projected += hrs * rate_map.get((b.person_id, b.billing_position_id), 0.0)
 
     return projected, budget_euros
 
@@ -935,10 +954,13 @@ def manual_budget_update(
 
     # Soft capacity warning (B2 stays hard only for the automatic distribution, §9.2).
     project = session.get(Project, milestone.project_id)
+    # Resolve the membership by (person, position) so a multi-assigned person's positions
+    # don't collide (WP2). In simple mode billing_position_id is None → the single row.
     membership = session.exec(
         select(ProjectMembership).where(
             ProjectMembership.project_id == milestone.project_id,
             ProjectMembership.person_id == budget.person_id,
+            ProjectMembership.billing_position_id == budget.billing_position_id,
         )
     ).first()
     person = session.get(Person, budget.person_id)
@@ -1019,12 +1041,12 @@ def set_milestone_target_budget(
     ).all()
     positions_by_id = project_positions(project_id, session)
     rate_map = build_rate_map(memberships, positions_by_id)
-    priorities = {m.person_id: m.priority for m in memberships}
+    priorities = {(m.person_id, m.billing_position_id): m.priority for m in memberships}
 
     month_start, month_end = _month_bounds(milestone.year, milestone.month)
     active = [m for m in memberships if m.from_date <= month_end and m.to_date >= month_start]
 
-    # Available net capacity per active member this month.
+    # Available net capacity per active assignment this month.
     avail_map: dict[SlotKey, float] = {}
     for m in active:
         person = session.get(Person, m.person_id)
@@ -1032,24 +1054,26 @@ def set_milestone_target_budget(
             continue
         avail = _person_available_hours(person, m, project, milestone.year, milestone.month, session).hours
         if avail > 0:
-            avail_map[(m.person_id, (milestone.year, milestone.month))] = avail
+            avail_map[((m.person_id, m.billing_position_id), (milestone.year, milestone.month))] = avail
 
     plan = distribute_budget(avail_map, rate_map, priorities, target_euros)
-    achieved = sum(hours * rate_map.get(pid, 0.0) for (pid, _ym), hours in plan.items())
+    achieved = sum(hours * rate_map.get(ak, 0.0) for (ak, _ym), hours in plan.items())
 
-    # Apply the plan: upsert a manual-override row per active member.
+    # Apply the plan: upsert a manual-override row per active assignment.
     existing = {
-        b.person_id: b
+        (b.person_id, b.billing_position_id): b
         for b in session.exec(
             select(MilestonePersonBudget).where(MilestonePersonBudget.milestone_id == milestone_id)
         ).all()
     }
     for m in active:
-        hours = plan.get((m.person_id, (milestone.year, milestone.month)), 0.0)
-        row = existing.get(m.person_id)
+        ak = (m.person_id, m.billing_position_id)
+        hours = plan.get((ak, (milestone.year, milestone.month)), 0.0)
+        row = existing.get(ak)
         if row is None:
             session.add(MilestonePersonBudget(
                 milestone_id=milestone_id, person_id=m.person_id,
+                billing_position_id=m.billing_position_id,
                 initial_hours=hours, current_hours=hours, is_manual_override=True,
             ))
         else:
@@ -1219,11 +1243,14 @@ def prune_member_budgets_to_range(
     person_id: int,
     from_date: date,
     to_date: date,
+    billing_position_id: int | None,
     session: Session,
 ) -> list[Milestone]:
     """Remove a member's budget rows from OPEN milestones whose month no longer overlaps
     the member's [from_date, to_date] range (V11, membership date change).
 
+    Scoped to the assignment's position (WP2): only rows of this (person, position) are
+    pruned, so changing one assignment's dates never removes the person's other positions.
     Locked months are protected. Budgets for months still inside the range are left as
     they are — recomputing changed weekly hours into existing budgets is the resync path
     (WP4/WP5), not this referential cleanup. Does not commit.
@@ -1243,6 +1270,7 @@ def prune_member_budgets_to_range(
             select(MilestonePersonBudget).where(
                 MilestonePersonBudget.milestone_id == ms.id,
                 MilestonePersonBudget.person_id == person_id,
+                MilestonePersonBudget.billing_position_id == billing_position_id,
             )
         ).all()
         if not rows:
@@ -1323,7 +1351,7 @@ def _align_open_milestones(project: Project, session: Session) -> ResyncSummary:
     positions_by_id = project_positions(project_id, session)
     position_mode = is_position_mode(project)
     rate_map = build_rate_map(memberships, positions_by_id)
-    priorities = {m.person_id: m.priority for m in memberships}
+    priorities = {(m.person_id, m.billing_position_id): m.priority for m in memberships}
 
     person_cache: dict[int, Person] = {}
 
@@ -1343,7 +1371,7 @@ def _align_open_milestones(project: Project, session: Session) -> ResyncSummary:
     summary = ResyncSummary()
     changed: set[int] = set()
 
-    rows_by_ms: dict[int, dict[int, MilestonePersonBudget]] = {}
+    rows_by_ms: dict[int, dict[AssignmentKey, MilestonePersonBudget]] = {}
     recompute_avail: dict[SlotKey, float] = {}
     override_rows: list[MilestonePersonBudget] = []
     zero_avail_autos: list[MilestonePersonBudget] = []
@@ -1351,37 +1379,37 @@ def _align_open_milestones(project: Project, session: Session) -> ResyncSummary:
     for ms in open_ms:
         month_start, month_end = _month_bounds(ms.year, ms.month)
         active = [m for m in memberships if m.from_date <= month_end and m.to_date >= month_start]
-        active_pids = {m.person_id for m in active}
+        active_keys = {(m.person_id, m.billing_position_id) for m in active}
         rows = {
-            b.person_id: b
+            (b.person_id, b.billing_position_id): b
             for b in session.exec(
                 select(MilestonePersonBudget).where(MilestonePersonBudget.milestone_id == ms.id)
             ).all()
         }
         rows_by_ms[ms.id] = rows
 
-        # Remove rows for members no longer active this month (überzählig, BUG-7).
-        for pid, b in list(rows.items()):
-            if pid not in active_pids:
+        # Remove rows for assignments no longer active this month (überzählig, BUG-7).
+        for ak, b in list(rows.items()):
+            if ak not in active_keys:
                 session.delete(b)
-                del rows[pid]
+                del rows[ak]
                 summary.removed += 1
                 changed.add(ms.id)
 
         for m in active:
-            pid = m.person_id
-            b = rows.get(pid)
+            ak = (m.person_id, m.billing_position_id)
+            b = rows.get(ak)
             if b is not None and b.is_manual_override:
                 override_rows.append(b)  # fixed commitment, never recomputed
                 continue
-            person = _get_person(pid)
+            person = _get_person(m.person_id)
             if person is None:
                 continue
             avail = _person_available_hours(person, m, project, ms.year, ms.month, session).hours
             if avail > 0:
-                recompute_avail[(pid, (ms.year, ms.month))] = avail
+                recompute_avail[(ak, (ms.year, ms.month))] = avail
             elif b is not None:
-                zero_avail_autos.append(b)  # existing row, member now has no capacity
+                zero_avail_autos.append(b)  # existing row, assignment now has no capacity
 
     session.flush()
 
@@ -1396,7 +1424,10 @@ def _align_open_milestones(project: Project, session: Session) -> ResyncSummary:
             open_month_set, project_id, session,
         )
     elif budget_euros > 0:
-        override_cost = sum(b.current_hours * rate_map.get(b.person_id, 0.0) for b in override_rows)
+        override_cost = sum(
+            b.current_hours * rate_map.get((b.person_id, b.billing_position_id), 0.0)
+            for b in override_rows
+        )
         base_remaining = _remaining_euro_budget(project_id, budget_euros, open_month_set, rate_map, session)
         remaining = max(0.0, base_remaining - override_cost)
         plan = distribute_budget(recompute_avail, rate_map, priorities, remaining)
@@ -1414,13 +1445,13 @@ def _align_open_milestones(project: Project, session: Session) -> ResyncSummary:
         plan = distribute_budget(recompute_avail, rate_map, priorities, None)
 
     ms_by_ym = {(ms.year, ms.month): ms for ms in open_ms}
-    for (pid, ym), hours in plan.items():
+    for (ak, ym), hours in plan.items():
         ms = ms_by_ym[ym]
         rows = rows_by_ms[ms.id]
-        b = rows.get(pid)
+        b = rows.get(ak)
         if b is None:
             session.add(MilestonePersonBudget(
-                milestone_id=ms.id, person_id=pid,
+                milestone_id=ms.id, person_id=ak[0], billing_position_id=ak[1],
                 initial_hours=hours, current_hours=hours,  # baseline set at creation (V10)
             ))
             summary.added += 1

--- a/backend/app/services/milestones.py
+++ b/backend/app/services/milestones.py
@@ -1141,23 +1141,21 @@ def set_milestone_planning_lock(milestone_id: int, locked: bool, session: Sessio
 
 
 def set_budget_hours_lock(
-    milestone_id: int, person_id: int, locked: bool, session: Session
+    milestone_id: int, budget_id: int, locked: bool, session: Session
 ) -> MilestonePersonBudget:
-    """Lock/unlock a person's hours for a month. Locked rows are preserved by
-    resync/rebalance; unlocking keeps the current value until the next recompute."""
+    """Lock/unlock one budget row's hours for a month. Locked rows are preserved by
+    resync/rebalance; unlocking keeps the current value until the next recompute.
+
+    Keyed by budget_id (WP6 Nacharbeit) so a multi-assigned person's positions are
+    addressed individually."""
     milestone = session.get(Milestone, milestone_id)
     if not milestone:
         raise MilestoneNotFound(f"Milestone {milestone_id} not found.")
     if milestone.is_locked:
         raise MilestoneLocked(f"Milestone {milestone_id} is locked.")
-    budget = session.exec(
-        select(MilestonePersonBudget).where(
-            MilestonePersonBudget.milestone_id == milestone_id,
-            MilestonePersonBudget.person_id == person_id,
-        )
-    ).first()
-    if not budget:
-        raise BudgetNotFound(f"No budget for person {person_id} in milestone {milestone_id}.")
+    budget = session.get(MilestonePersonBudget, budget_id)
+    if not budget or budget.milestone_id != milestone_id:
+        raise BudgetNotFound(f"Budget {budget_id} not found in milestone {milestone_id}.")
     budget.is_manual_override = locked
     session.add(budget)
     session.commit()
@@ -1166,11 +1164,14 @@ def set_budget_hours_lock(
 
 
 def set_estimated_absence(
-    milestone_id: int, person_id: int, days: float | None, session: Session
+    milestone_id: int, budget_id: int, days: float | None, session: Session
 ) -> MilestonePersonBudget:
-    """Set (or clear, days=None) the manual estimated-absence override for a person/month.
+    """Set (or clear, days=None) the manual estimated-absence override for one budget row.
     Affects the availability calc. Rejected on locked (closed) months.
-    Raises ValueError on negative days."""
+    Raises ValueError on negative days.
+
+    Keyed by budget_id (WP6 Nacharbeit) so a multi-assigned person's positions are
+    addressed individually."""
     milestone = session.get(Milestone, milestone_id)
     if not milestone:
         raise MilestoneNotFound(f"Milestone {milestone_id} not found.")
@@ -1178,14 +1179,9 @@ def set_estimated_absence(
         raise MilestoneLocked(f"Milestone {milestone_id} is locked.")
     if days is not None and days < 0:
         raise ValueError("Estimated absence days cannot be negative.")
-    budget = session.exec(
-        select(MilestonePersonBudget).where(
-            MilestonePersonBudget.milestone_id == milestone_id,
-            MilestonePersonBudget.person_id == person_id,
-        )
-    ).first()
-    if not budget:
-        raise BudgetNotFound(f"No budget for person {person_id} in milestone {milestone_id}.")
+    budget = session.get(MilestonePersonBudget, budget_id)
+    if not budget or budget.milestone_id != milestone_id:
+        raise BudgetNotFound(f"Budget {budget_id} not found in milestone {milestone_id}.")
     budget.estimated_absence_days_override = days
     session.add(budget)
     session.commit()

--- a/backend/app/services/milestones.py
+++ b/backend/app/services/milestones.py
@@ -594,6 +594,12 @@ def distribute_over_positions(
             continue
         rate = pos.billing_rate_per_hour
         rates = {ak: rate for ak in pos_keys}
+        if pos.overrunnable:
+            # Cheap position (doc 23 WP3): no budget cap → fund to full capacity, so it
+            # can absorb the hours a hard (expensive) position cannot. The overrun itself
+            # is surfaced separately (WP6 diagnostics / Aufwand-nach-Posten panel).
+            plan.update(distribute_budget(sub_avail, rates, priorities, None))
+            continue
         base = _remaining_position_euro_budget(project_id, pos, exclude_months, session)
         override_cost = sum(
             b.current_hours * rate

--- a/backend/app/services/rebalancing.py
+++ b/backend/app/services/rebalancing.py
@@ -25,6 +25,7 @@ from app.models.milestone import Milestone, MilestonePersonBudget
 from app.models.person import Person
 from app.models.project import Project
 from app.services.milestones import (
+    AssignmentKey,
     SlotKey,
     _month_bounds,
     _person_available_hours,
@@ -48,6 +49,7 @@ class BudgetSuggestion:
     person_id: int
     current_hours: float
     suggested_hours: float
+    billing_position_id: int | None = None  # WP2: disambiguates a person's positions
 
 
 @dataclass
@@ -105,7 +107,7 @@ def preview_recalculation(project_id: int, session: Session) -> list[MilestoneSu
     positions_by_id = project_positions(project_id, session)
     position_mode = is_position_mode(project)
     rate_map = build_rate_map(memberships, positions_by_id)
-    priorities = {m.person_id: m.priority for m in memberships}
+    priorities = {(m.person_id, m.billing_position_id): m.priority for m in memberships}
     open_month_set = {(ms.year, ms.month) for ms in open_milestones}
 
     person_cache: dict[int, Person] = {}
@@ -115,7 +117,7 @@ def preview_recalculation(project_id: int, session: Session) -> list[MilestoneSu
             person_cache[pid] = session.get(Person, pid)
         return person_cache[pid]
 
-    rows_by_ms: dict[int, dict[int, MilestonePersonBudget]] = {}
+    rows_by_ms: dict[int, dict[AssignmentKey, MilestonePersonBudget]] = {}
     avail_map: dict[SlotKey, float] = {}
     override_rows: list[MilestonePersonBudget] = []
     override_cost = 0.0
@@ -124,24 +126,25 @@ def preview_recalculation(project_id: int, session: Session) -> list[MilestoneSu
         month_start, month_end = _month_bounds(ms.year, ms.month)
         active = [m for m in memberships if m.from_date <= month_end and m.to_date >= month_start]
         rows = {
-            b.person_id: b
+            (b.person_id, b.billing_position_id): b
             for b in session.exec(
                 select(MilestonePersonBudget).where(MilestonePersonBudget.milestone_id == ms.id)
             ).all()
         }
         rows_by_ms[ms.id] = rows
         for m in active:
-            b = rows.get(m.person_id)
+            ak = (m.person_id, m.billing_position_id)
+            b = rows.get(ak)
             if b is not None and b.is_manual_override:
                 override_rows.append(b)
-                override_cost += b.current_hours * rate_map.get(m.person_id, 0.0)
+                override_cost += b.current_hours * rate_map.get(ak, 0.0)
                 continue
             person = _get_person(m.person_id)
             if person is None:
                 continue
             avail = _person_available_hours(person, m, project, ms.year, ms.month, session).hours
             if avail > 0:
-                avail_map[(m.person_id, (ms.year, ms.month))] = avail
+                avail_map[(ak, (ms.year, ms.month))] = avail
 
     budget_euros = project.total_budget_euros if project.total_budget_euros and project.total_budget_euros > 0 else 0.0
     if position_mode:
@@ -160,16 +163,17 @@ def preview_recalculation(project_id: int, session: Session) -> list[MilestoneSu
     for ms in open_milestones:
         rows = rows_by_ms[ms.id]
         budget_suggestions: list[BudgetSuggestion] = []
-        for person_id, budget in rows.items():
+        for ak, budget in rows.items():
             if budget.is_manual_override:
                 suggested = budget.current_hours  # fixed commitment
             else:
-                suggested = plan.get((person_id, (ms.year, ms.month)), 0.0)
+                suggested = plan.get((ak, (ms.year, ms.month)), 0.0)
             budget_suggestions.append(BudgetSuggestion(
                 budget_id=budget.id,  # type: ignore[arg-type]
-                person_id=person_id,
+                person_id=budget.person_id,
                 current_hours=budget.current_hours,
                 suggested_hours=suggested,
+                billing_position_id=budget.billing_position_id,
             ))
         suggestions.append(MilestoneSuggestion(
             milestone_id=ms.id,  # type: ignore[arg-type]

--- a/backend/tests/unit/test_models_constraints.py
+++ b/backend/tests/unit/test_models_constraints.py
@@ -1,0 +1,90 @@
+"""DB-level uniqueness constraints for multi-assignment (doc 23, WP1).
+
+A person may be assigned to several line items (Projektposten) of the same
+project — one ProjectMembership and one MilestonePersonBudget per position —
+so the unique keys span billing_position_id.
+"""
+
+from datetime import date
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from app.models.membership import ProjectMembership
+from app.models.milestone import Milestone, MilestonePersonBudget
+
+
+@pytest.fixture
+def mem_session():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    SQLModel.metadata.drop_all(engine)
+
+
+def _mem(session, position_id):
+    return ProjectMembership(
+        project_id=1, person_id=1,
+        from_date=date(2026, 1, 1), to_date=date(2026, 12, 31),
+        weekly_capacity_hours=20.0, billing_rate_per_hour=100.0,
+        billing_position_id=position_id,
+    )
+
+
+# ── ProjectMembership ────────────────────────────────────────────────────────
+
+def test_membership_same_person_different_positions_allowed(mem_session):
+    """The whole point of WP1: one MA on two positions of the same project."""
+    mem_session.add(_mem(mem_session, 10))
+    mem_session.add(_mem(mem_session, 20))
+    mem_session.commit()
+    rows = mem_session.query(ProjectMembership).all()
+    assert {r.billing_position_id for r in rows} == {10, 20}
+
+
+def test_membership_same_person_same_position_rejected(mem_session):
+    mem_session.add(_mem(mem_session, 10))
+    mem_session.commit()
+    mem_session.add(_mem(mem_session, 10))
+    with pytest.raises(IntegrityError):
+        mem_session.commit()
+
+
+def test_membership_simple_mode_null_position_relies_on_app_logic(mem_session):
+    """SQLite treats NULLs as distinct, so the DB does not block two NULL-position
+    rows for one (person, project). Simple mode keeps a single membership at the
+    application layer; this test documents the DB behaviour."""
+    mem_session.add(_mem(mem_session, None))
+    mem_session.add(_mem(mem_session, None))
+    mem_session.commit()  # no IntegrityError
+    assert mem_session.query(ProjectMembership).count() == 2
+
+
+# ── MilestonePersonBudget ────────────────────────────────────────────────────
+
+def _mpb(position_id):
+    return MilestonePersonBudget(
+        milestone_id=1, person_id=1, initial_hours=10.0, current_hours=10.0,
+        billing_position_id=position_id,
+    )
+
+
+def test_mpb_same_person_different_positions_allowed(mem_session):
+    mem_session.add(Milestone(project_id=1, year=2026, month=6, initial_hours=0, current_hours=0))
+    mem_session.add(_mpb(10))
+    mem_session.add(_mpb(20))
+    mem_session.commit()
+    assert mem_session.query(MilestonePersonBudget).count() == 2
+
+
+def test_mpb_same_person_same_position_rejected(mem_session):
+    mem_session.add(_mpb(10))
+    mem_session.commit()
+    mem_session.add(_mpb(10))
+    with pytest.raises(IntegrityError):
+        mem_session.commit()

--- a/backend/tests/unit/test_models_person.py
+++ b/backend/tests/unit/test_models_person.py
@@ -68,6 +68,8 @@ def test_vacation_contingent_rejects_year_below_2000() -> None:
     (AbsenceType.vacation, AbsenceStatus.confirmed),
     (AbsenceType.training, AbsenceStatus.planned),
     (AbsenceType.training, AbsenceStatus.confirmed),
+    (AbsenceType.other, AbsenceStatus.planned),
+    (AbsenceType.other, AbsenceStatus.confirmed),
     (AbsenceType.sick, AbsenceStatus.ongoing),
     (AbsenceType.sick, AbsenceStatus.confirmed),
 ])
@@ -89,7 +91,7 @@ def test_person_absence_valid_type_status_combinations(
 # PersonAbsence — invalid combinations
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("absence_type", [AbsenceType.vacation, AbsenceType.training])
+@pytest.mark.parametrize("absence_type", [AbsenceType.vacation, AbsenceType.training, AbsenceType.other])
 def test_person_absence_ongoing_invalid_for_non_sick(absence_type: AbsenceType) -> None:
     with pytest.raises(ValidationError, match="ongoing"):
         PersonAbsence(
@@ -112,7 +114,7 @@ def test_person_absence_planned_invalid_for_sick() -> None:
         )
 
 
-@pytest.mark.parametrize("absence_type", [AbsenceType.vacation, AbsenceType.training])
+@pytest.mark.parametrize("absence_type", [AbsenceType.vacation, AbsenceType.training, AbsenceType.other])
 def test_person_absence_non_sick_requires_end_date(absence_type: AbsenceType) -> None:
     with pytest.raises(ValidationError, match="end_date"):
         PersonAbsence(

--- a/backend/tests/unit/test_routers_milestones.py
+++ b/backend/tests/unit/test_routers_milestones.py
@@ -151,27 +151,38 @@ def test_clear_target_budget_unlocks(client):
     assert r.json()["target_budget_euros"] is None
 
 
+def _budget_id(client, proj_id, ms_id, person_id) -> int:
+    detail = client.get(f"/projects/{proj_id}/milestones/detail").json()
+    return next(
+        p["budget_id"]
+        for m in detail if m["milestone"]["id"] == ms_id
+        for p in m["persons"] if p["person_id"] == person_id
+    )
+
+
 def test_hours_lock_toggle(client):
     proj_id, person_id = _setup(client)
     ms = client.post(f"/projects/{proj_id}/milestones/initialize").json()[0]
-    r = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/persons/{person_id}/lock", json={"locked": True})
+    bid = _budget_id(client, proj_id, ms["id"], person_id)
+    r = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/budgets/{bid}/lock", json={"locked": True})
     assert r.status_code == 200
     assert r.json()["is_manual_override"] is True
-    r2 = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/persons/{person_id}/lock", json={"locked": False})
+    r2 = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/budgets/{bid}/lock", json={"locked": False})
     assert r2.json()["is_manual_override"] is False
 
 
 def test_estimated_absence_override_endpoint(client):
     proj_id, person_id = _setup(client)
     ms = client.post(f"/projects/{proj_id}/milestones/initialize").json()[0]
-    r = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/persons/{person_id}/estimated-absence", json={"days": 4.0})
+    bid = _budget_id(client, proj_id, ms["id"], person_id)
+    r = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/budgets/{bid}/estimated-absence", json={"days": 4.0})
     assert r.status_code == 200
     assert r.json()["estimated_absence_days_override"] == 4.0
     # clear
-    r2 = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/persons/{person_id}/estimated-absence", json={"days": None})
+    r2 = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/budgets/{bid}/estimated-absence", json={"days": None})
     assert r2.json()["estimated_absence_days_override"] is None
     # negative → 422
-    r3 = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/persons/{person_id}/estimated-absence", json={"days": -2.0})
+    r3 = client.put(f"/projects/{proj_id}/milestones/{ms['id']}/budgets/{bid}/estimated-absence", json={"days": -2.0})
     assert r3.status_code == 422
 
 

--- a/backend/tests/unit/test_services_importer.py
+++ b/backend/tests/unit/test_services_importer.py
@@ -6,6 +6,7 @@ from hypothesis import given, settings as h_settings
 from hypothesis import strategies as st
 
 from app.models.billing import BillingPosition
+from app.models.membership import ProjectMembership
 from app.models.person import Person
 from app.models.project import Project
 from app.models.timebooking import SagePositionMapping, SageProjectMapping, TimeBooking
@@ -357,6 +358,44 @@ def test_import_links_booking_to_position(session):
     assert result.inserted == 1
     booking = session.exec(__import__("sqlmodel").select(TimeBooking)).first()
     assert booking.billing_position_id == bp.id
+
+
+def test_import_flags_booking_on_unassigned_position(session):
+    """WP4: MA books on a position they are not assigned to → mismatch flagged."""
+    _make_person(session)
+    proj = _make_project(session)
+    proj.position_mode = True
+    _make_mapping(session, "P00001 Analytics", proj.id)
+    bp = _priced_position(session, proj.id)
+    _position_mapping(session, proj.id, "Development", bp.id)
+    session.commit()  # no membership on bp
+
+    result = import_bookings(_csv([_ROW]), session)
+    assert result.inserted == 1
+    assert len(result.mismatches) == 1
+    assert "Max Mustermann" in result.mismatches[0]
+    assert bp.position_number in result.mismatches[0]
+
+
+def test_import_no_mismatch_when_assigned(session):
+    """WP4: no flag when the MA is assigned to the booked position."""
+    person = _make_person(session)
+    proj = _make_project(session)
+    proj.position_mode = True
+    _make_mapping(session, "P00001 Analytics", proj.id)
+    bp = _priced_position(session, proj.id)
+    _position_mapping(session, proj.id, "Development", bp.id)
+    session.add(ProjectMembership(
+        project_id=proj.id, person_id=person.id,
+        from_date=date(2026, 1, 1), to_date=date(2026, 12, 31),
+        weekly_capacity_hours=20.0, billing_rate_per_hour=0.0,
+        billing_position_id=bp.id,
+    ))
+    session.commit()
+
+    result = import_bookings(_csv([_ROW]), session)
+    assert result.inserted == 1
+    assert result.mismatches == []
 
 
 def test_import_position_mode_missing_mapping_raises(session):

--- a/backend/tests/unit/test_services_milestones_locks.py
+++ b/backend/tests/unit/test_services_milestones_locks.py
@@ -66,16 +66,16 @@ def test_estimated_absence_override_changes_availability(session):
     m = _membership(session, proj.id, a.id)
     session.commit()
     initialize_milestones(proj.id, session)
-    ms, _ = _ms_and_budget(session, proj.id, a.id)
+    ms, b = _ms_and_budget(session, proj.id, a.id)
 
     before = _person_available_hours(a, m, proj, ms.year, ms.month, session)
-    set_estimated_absence(ms.id, a.id, 10.0, session)
+    set_estimated_absence(ms.id, b.id, 10.0, session)
     after = _person_available_hours(a, m, proj, ms.year, ms.month, session)
 
     assert after.estimated_absence_days == pytest.approx(10.0)
     assert after.hours < before.hours  # more absence → less available
 
-    set_estimated_absence(ms.id, a.id, None, session)  # clear → back to auto
+    set_estimated_absence(ms.id, b.id, None, session)  # clear → back to auto
     reset = _person_available_hours(a, m, proj, ms.year, ms.month, session)
     assert reset.hours == pytest.approx(before.hours)
 
@@ -86,9 +86,9 @@ def test_estimated_absence_negative_raises(session):
     _membership(session, proj.id, a.id)
     session.commit()
     initialize_milestones(proj.id, session)
-    ms, _ = _ms_and_budget(session, proj.id, a.id)
+    ms, b = _ms_and_budget(session, proj.id, a.id)
     with pytest.raises(ValueError):
-        set_estimated_absence(ms.id, a.id, -1.0, session)
+        set_estimated_absence(ms.id, b.id, -1.0, session)
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +173,7 @@ def test_hours_lock_preserved_unlock_recomputed(session):
     assert b.is_manual_override is True
 
     # Unlock → value stays until recompute, then resync recomputes it.
-    set_budget_hours_lock(ms.id, a.id, False, session)
+    set_budget_hours_lock(ms.id, b.id, False, session)
     session.refresh(b)
     assert b.is_manual_override is False
     assert b.current_hours == pytest.approx(3.0)  # unchanged until an action runs

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -114,3 +114,26 @@ def test_cap_reason_names_exhausted_position(session):
     assert a_rows and all(r.cap_reason and pos_a.position_number in r.cap_reason for r in a_rows)
     # B is funded to full capacity → no cap reason.
     assert b_rows and all(r.cap_reason is None for r in b_rows)
+
+
+def test_detail_shows_legacy_null_position_budget_row(session):
+    """Regression: a legacy budget row (billing_position_id = NULL, created before WP1)
+    whose membership now carries a position must still appear in the detail view — it is
+    resolved via the person-level fallback instead of being silently dropped."""
+    from app.routers.milestones import list_milestones_detail
+
+    proj, pos_a, pos_b, person = _setup(session, budget_a=1_000_000.0, budget_b=1_000_000.0)
+    # A closed month with only a legacy NULL-position row for the person (as an old DB has).
+    ms = Milestone(project_id=proj.id, year=2026, month=1, initial_hours=10.0,
+                   current_hours=10.0, is_locked=True)
+    session.add(ms)
+    session.flush()
+    session.add(MilestonePersonBudget(
+        milestone_id=ms.id, person_id=person.id, billing_position_id=None,
+        initial_hours=10.0, current_hours=10.0,
+    ))
+    session.commit()
+
+    detail = list_milestones_detail(proj.id, session)
+    jan = next(m for m in detail if m.milestone.month == 1)
+    assert any(p.person_id == person.id for p in jan.persons)  # legacy row still shown

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -98,3 +98,19 @@ def test_overrunnable_position_funds_beyond_budget(session):
     assert row_b.current_hours > 2.0 + 1e-6
     # B's planned cost exceeds its nominal budget — the allowed overrun.
     assert row_b.current_hours * pos_b.billing_rate_per_hour > pos_b.budget_euros + 1e-6
+
+
+def test_cap_reason_names_exhausted_position(session):
+    """WP6: a row capped below its capacity carries a diagnostic naming the bound budget."""
+    from app.routers.milestones import list_milestones_detail
+
+    # Position A tiny (capped below capacity), B effectively uncapped (funded to full).
+    proj, pos_a, pos_b, person = _setup(session, budget_a=200.0, budget_b=1_000_000.0)
+    initialize_milestones(proj.id, session)
+
+    detail = list_milestones_detail(proj.id, session)
+    a_rows = [p for ms in detail for p in ms.persons if p.billing_position_id == pos_a.id]
+    b_rows = [p for ms in detail for p in ms.persons if p.billing_position_id == pos_b.id]
+    assert a_rows and all(r.cap_reason and pos_a.position_number in r.cap_reason for r in a_rows)
+    # B is funded to full capacity → no cap reason.
+    assert b_rows and all(r.cap_reason is None for r in b_rows)

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -1,0 +1,80 @@
+"""Multi-assignment (doc 23, WP2): one MA on several positions of one project.
+
+Verifies the engine keys budget rows by (person, position): one MilestonePersonBudget
+per assignment, each funded from its own position budget at the position's rate, with the
+milestone-total invariant preserved.
+"""
+from datetime import date
+
+from app.models.billing import BillingPosition
+from app.models.membership import ProjectMembership
+from app.models.milestone import Milestone, MilestonePersonBudget
+from app.models.person import Person
+from app.models.project import Project
+from app.services.milestones import initialize_milestones
+from sqlmodel import select
+
+
+def _setup(session, budget_a: float, budget_b: float):
+    """Position-mode project, one person assigned to two positions (20h each)."""
+    proj = Project(
+        project_number="P09001", name="Multi", start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 31), total_budget_euros=budget_a + budget_b,
+        total_budget_hours=None, position_mode=True,
+    )
+    session.add(proj)
+    session.flush()
+    pos_a = BillingPosition(project_id=proj.id, position_number="A", budget_euros=budget_a, billing_rate_per_hour=100.0)
+    pos_b = BillingPosition(project_id=proj.id, position_number="B", budget_euros=budget_b, billing_rate_per_hour=50.0)
+    session.add(pos_a)
+    session.add(pos_b)
+    session.flush()
+    person = Person(name="Multi MA", sage_employee_name="Multi MA", default_weekly_hours=40.0)
+    session.add(person)
+    session.flush()
+    for pos in (pos_a, pos_b):
+        session.add(ProjectMembership(
+            project_id=proj.id, person_id=person.id,
+            from_date=date(2026, 1, 1), to_date=date(2026, 1, 31),
+            weekly_capacity_hours=20.0, billing_rate_per_hour=0.0,
+            billing_position_id=pos.id,
+        ))
+    session.commit()
+    return proj, pos_a, pos_b, person
+
+
+def _budgets(session, project_id):
+    ms = session.exec(select(Milestone).where(Milestone.project_id == project_id)).first()
+    rows = session.exec(
+        select(MilestonePersonBudget).where(MilestonePersonBudget.milestone_id == ms.id)
+    ).all()
+    return ms, {b.billing_position_id: b for b in rows}
+
+
+def test_one_budget_row_per_position(session):
+    """A person on two positions gets one budget row per position, each tagged with it."""
+    proj, pos_a, pos_b, person = _setup(session, budget_a=1_000_000.0, budget_b=1_000_000.0)
+    initialize_milestones(proj.id, session)
+
+    ms, by_pos = _budgets(session, proj.id)
+    assert set(by_pos) == {pos_a.id, pos_b.id}
+    assert all(b.person_id == person.id for b in by_pos.values())
+    # Both positions have huge budgets → each row funded to full (equal) capacity.
+    assert by_pos[pos_a.id].current_hours > 0
+    assert abs(by_pos[pos_a.id].current_hours - by_pos[pos_b.id].current_hours) < 1e-6
+    # Milestone-total invariant holds across the two rows.
+    assert abs(ms.current_hours - sum(b.current_hours for b in by_pos.values())) < 1e-6
+
+
+def test_positions_capped_independently(session):
+    """Each position's budget caps its own row; buckets never borrow from one another."""
+    # Position A is tiny (200 € @ 100 €/h → 2 h fundable); B is effectively uncapped.
+    proj, pos_a, pos_b, person = _setup(session, budget_a=200.0, budget_b=1_000_000.0)
+    initialize_milestones(proj.id, session)
+
+    ms, by_pos = _budgets(session, proj.id)
+    row_a, row_b = by_pos[pos_a.id], by_pos[pos_b.id]
+    # A is capped by its own budget (cost ≤ 200 €), strictly below its full capacity (= B's hours).
+    assert row_a.current_hours * pos_a.billing_rate_per_hour <= pos_a.budget_euros + 1e-6
+    assert row_a.current_hours < row_b.current_hours
+    assert abs(row_a.current_hours - 2.0) < 1e-6  # 200 € / 100 €·h⁻¹

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -15,7 +15,7 @@ from app.services.milestones import initialize_milestones
 from sqlmodel import select
 
 
-def _setup(session, budget_a: float, budget_b: float):
+def _setup(session, budget_a: float, budget_b: float, b_overrunnable: bool = False):
     """Position-mode project, one person assigned to two positions (20h each)."""
     proj = Project(
         project_number="P09001", name="Multi", start_date=date(2026, 1, 1),
@@ -25,7 +25,10 @@ def _setup(session, budget_a: float, budget_b: float):
     session.add(proj)
     session.flush()
     pos_a = BillingPosition(project_id=proj.id, position_number="A", budget_euros=budget_a, billing_rate_per_hour=100.0)
-    pos_b = BillingPosition(project_id=proj.id, position_number="B", budget_euros=budget_b, billing_rate_per_hour=50.0)
+    pos_b = BillingPosition(
+        project_id=proj.id, position_number="B", budget_euros=budget_b,
+        billing_rate_per_hour=50.0, overrunnable=b_overrunnable,
+    )
     session.add(pos_a)
     session.add(pos_b)
     session.flush()
@@ -78,3 +81,20 @@ def test_positions_capped_independently(session):
     assert row_a.current_hours * pos_a.billing_rate_per_hour <= pos_a.budget_euros + 1e-6
     assert row_a.current_hours < row_b.current_hours
     assert abs(row_a.current_hours - 2.0) < 1e-6  # 200 € / 100 €·h⁻¹
+
+
+def test_overrunnable_position_funds_beyond_budget(session):
+    """WP3: a cheap OVERRUNNABLE position is funded to full capacity even past its budget,
+    while a hard position stays capped. So cheaper hours absorb what the expensive one can't."""
+    # A hard, tiny (2 h cap). B overrunnable with a tiny nominal budget (100 € @ 50/h = 2 h)
+    # but must fund to full capacity regardless.
+    proj, pos_a, pos_b, person = _setup(session, budget_a=200.0, budget_b=100.0, b_overrunnable=True)
+    initialize_milestones(proj.id, session)
+
+    ms, by_pos = _budgets(session, proj.id)
+    row_a, row_b = by_pos[pos_a.id], by_pos[pos_b.id]
+    # A hard-capped at its budget (2 h); B funded far beyond its 2 h nominal budget.
+    assert abs(row_a.current_hours - 2.0) < 1e-6
+    assert row_b.current_hours > 2.0 + 1e-6
+    # B's planned cost exceeds its nominal budget — the allowed overrun.
+    assert row_b.current_hours * pos_b.billing_rate_per_hour > pos_b.budget_euros + 1e-6

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -137,3 +137,29 @@ def test_detail_shows_legacy_null_position_budget_row(session):
     detail = list_milestones_detail(proj.id, session)
     jan = next(m for m in detail if m.milestone.month == 1)
     assert any(p.person_id == person.id for p in jan.persons)  # legacy row still shown
+
+
+def test_booked_without_position_attributed_to_primary_row(session):
+    """Regression: bookings without a position (NULL — simple-mode / unmapped import) must
+    still show as Ist. They can't be split across a person's positions, so they go to the
+    person's primary budget row exactly once (total preserved, not doubled, not lost)."""
+    from datetime import date as _date
+
+    from app.models.timebooking import TimeBooking
+    from app.routers.milestones import list_milestones_detail
+
+    proj, pos_a, pos_b, person = _setup(session, budget_a=1_000_000.0, budget_b=1_000_000.0)
+    initialize_milestones(proj.id, session)
+    session.add(TimeBooking(
+        booking_date=_date(2026, 1, 15), person_id=person.id, project_id=proj.id,
+        import_batch_id=1, sage_project_name="X", sage_project_level="Y",
+        billing_position_id=None, net_hours=8.0,
+    ))
+    session.commit()
+
+    detail = list_milestones_detail(proj.id, session)
+    jan = next(m for m in detail if m.milestone.month == 1)
+    mine = [p for p in jan.persons if p.person_id == person.id]
+    assert len(mine) == 2  # one row per position
+    assert abs(sum(p.booked_hours for p in mine) - 8.0) < 1e-6  # total preserved
+    assert sum(1 for p in mine if p.booked_hours > 0) == 1      # attributed to exactly one row

--- a/backend/tests/unit/test_services_milestones_referential.py
+++ b/backend/tests/unit/test_services_milestones_referential.py
@@ -131,7 +131,7 @@ def test_prune_removes_budgets_outside_new_range(session):
     initialize_milestones(proj.id, session)
 
     # Membership shrinks to February only.
-    prune_member_budgets_to_range(proj.id, a.id, date(2026, 2, 1), date(2026, 2, 28), session)
+    prune_member_budgets_to_range(proj.id, a.id, date(2026, 2, 1), date(2026, 2, 28), None, session)
     session.commit()
 
     ms = _milestones(session, proj.id)
@@ -156,7 +156,7 @@ def test_prune_protects_locked_month(session):
     session.commit()
 
     # New range excludes January, but it is locked → protected.
-    prune_member_budgets_to_range(proj.id, a.id, date(2026, 2, 1), date(2026, 3, 31), session)
+    prune_member_budgets_to_range(proj.id, a.id, date(2026, 2, 1), date(2026, 3, 31), None, session)
     session.commit()
 
     assert len(_budgets(session, jan.id)) == 1

--- a/backend/tests/unit/test_services_planning.py
+++ b/backend/tests/unit/test_services_planning.py
@@ -235,6 +235,17 @@ def test_absence_days_sick_confirmed_counts(mem_session):
     assert result == 3
 
 
+def test_absence_days_other_counts_like_any_absence(mem_session):
+    """'Sonstiges' (Elternzeit/Sabbatical) reduces availability like every concrete absence."""
+    p = _make_person(mem_session)
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5),
+        absence_type=AbsenceType.other, status=AbsenceStatus.confirmed,
+    )
+    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
+    assert result == 5
+
+
 # ---------------------------------------------------------------------------
 # estimated_vacation_days
 # ---------------------------------------------------------------------------
@@ -284,6 +295,23 @@ def test_estimated_vacation_already_has_concrete_absence(mem_session):
     # The 10 planned days reduce the remaining contingent;
     # estimate applies only to remaining days without concrete absences.
     assert result >= 0.0
+
+
+def test_estimated_vacation_ignores_other_type(mem_session):
+    """'Sonstiges' has no Pauschale: it must NOT deduct from the vacation contingent
+    (only AbsenceType.vacation does). The estimate stays at the full pro-rata value."""
+    p = _make_person(mem_session)
+    vc = VacationContingent(person_id=p.id, year=2026, total_days=20.0)
+    mem_session.add(vc)
+    mem_session.commit()
+    # A big 'other' absence in the year — must leave the vacation estimate untouched.
+    _make_absence(
+        mem_session, p.id, date(2026, 1, 5), date(2026, 3, 31),
+        absence_type=AbsenceType.other, status=AbsenceStatus.confirmed,
+    )
+    result = estimated_vacation_days(p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session)
+    expected = 20.0 * (31 / 184)  # identical to test_estimated_vacation_proportional
+    assert abs(result - expected) < 0.01
 
 
 # ---------------------------------------------------------------------------

--- a/docs/implementation/23-posten-multi-assignment.md
+++ b/docs/implementation/23-posten-multi-assignment.md
@@ -1,0 +1,112 @@
+# Mehrere Posten pro MA (Multi-Assignment) + UX für blockierende Limits
+
+_Status: 📋 Design & Implementierungsplan_
+_Datum: 2026-07-17_
+_Betrifft: `models/membership.py`, `models/milestone.py`, `models/billing.py`, `services/planning.py`, `services/milestones.py`, `services/rebalancing.py`, `services/importer.py`, `services/invoices.py`, `routers/projects.py`, `routers/milestones.py`, `routers/imports.py`, `frontend/src/pages/ProjectDetailPage.tsx`, Alembic_
+_Baut auf: [21-project-line-items.md](21-project-line-items.md)_
+
+---
+
+## 1. Ziel
+
+Ein Mitarbeiter (MA) soll im **Posten-Modus** auf **mehrere Projektposten** buchbar/planbar sein — jeder Posten mit **eigenem Stundensatz** und **eigenem Budget**. Damit wird derselbe MA je nach Posten unterschiedlich verrechnet.
+
+Motivation aus der Praxis (Nutzer, 2026-07-17):
+- **Ist-Daten erzwingen es bereits.** Beim Sage-Import buchen MA real auf verschiedene Projektebenen → verschiedene Posten. Dieser Zustand muss abgebildet werden.
+- **Asymmetrische Vertragsgrenzen.** Jeder Posten hat ein (meist vertraglich fixes) Budget. Posten mit **hohem** Satz dürfen i. d. R. **nicht überschritten** werden; Posten mit **niedrigem** Satz **schon** — man rechnet lieber mehr günstige statt teure Stunden ab. Dadurch wandert ein MA ggf. auf einen anderen Posten.
+- **Mismatch-Sichtbarkeit.** Bucht ein MA auf einen ihm nicht zugewiesenen Posten, oder wird eine Projektebene bei aktiven Posten nicht erkannt, soll das geflaggt werden.
+
+Verknüpft: **Punkt 3 „UX für blockierende Limits"** (§7) wird in denselben Umbau integriert, weil die Diagnose „warum wurde gekappt?" erst mit Posten-Granularität sauber möglich ist.
+
+## 2. Ist-Stand & das Kernproblem
+
+| Ebene | Granularität heute |
+|---|---|
+| **Ist** (`TimeBooking`) | **pro (MA, Projekt, Ebene/Posten, Tag)** — `billing_position_id` je Buchung (`models/timebooking.py:82`). Bildet Multi-Posten schon ab. |
+| **Plan** (`ProjectMembership`) | **pro (MA, Projekt)**, trägt **max. 1** Posten (`billing_position_id`, nullable, `models/membership.py:26`). |
+| **Plan-Split** (`MilestonePersonBudget`) | **genau 1 Zeile pro (Meilenstein, Person)** — `UniqueConstraint(milestone_id, person_id)` (`models/milestone.py:51`). |
+
+**Der Bruch:** Ist ist Posten-granular, Plan ist person-granular. Die Rechen-Engine ist durchgängig auf `person_id` gebaut:
+- `_person_available_hours` / `capacity_hours` lösen **eine** Membership via `.first()` auf (`planning.py:198`).
+- `build_rate_map` / `effective_rate` keyen Sätze per `person_id` (`milestones.py:497,84`).
+- `distribute_over_positions` gruppiert `{m.person_id … if billing_position_id == pos_id}` und `memb_by_pid = {m.person_id: m}` (`milestones.py:569–572`) → jede Person landet in **genau einem** Posten-Topf.
+
+**Naive Freigabe = Doppelzählung:** Käme dieselbe Person in zwei Posten-Töpfen vor, ginge ihr *voller* Monats-Kapazitätspool in *beide* Töpfe → Verplanung auf bis zu das Doppelte der realen Stunden. Deshalb ist die Lösung nicht „Constraint entfernen", sondern „Verteil-Schlüssel und Kapazitäts-Wächter neu definieren".
+
+## 3. Optionen (mit Bewertung)
+
+### Option A — Zuweisungseinheit = (MA, Posten)  ✅ GEWÄHLT
+Mehrere `ProjectMembership`-Zeilen pro (MA, Projekt), **jede mit genau einem** Posten, eigener `weekly_capacity_hours`, eigener `priority`, eigenem Zeitfenster. `MilestonePersonBudget` wird auf `(milestone, membership)` bzw. `(milestone, person, billing_position)` umgeschlüsselt.
+- **Pro:** Plan-Granularität = Ist-Granularität → Plan-vs-Ist, Posten-Prognose und Mismatch-Flag natürlich; Satz/Kapazität/Priorität sauber *pro Posten* ausdrückbar (Voraussetzung für die asymmetrischen Überschreitungsregeln).
+- **Contra:** Re-Keying zieht sich durch Engine, Rebalancing, Invoicing, Frontend; neuer **Kapazitäts-Wächter** nötig (Σ Kapazität eines MA ≤ reale Verfügbarkeit).
+- **Risiko:** mittel-hoch. **Komplexität:** hoch.
+
+### Option B — eine Membership + prozentualer Split (verworfen)
+Eine Membership pro (MA, Projekt) + Join-Tabelle `MembershipPositionAllocation(membership_id, billing_position_id, share%)`; der Monats-Pool wird nach `share` zerlegt.
+- **Contra:** Der Split ist eine **Planungsannahme**, matcht die real gebuchte Verteilung nicht → Plan-vs-Ist bleibt unscharf; Kapazität/Priorität bleiben *gemeinsam* (keine posten-spezifische Priorität). `MilestonePersonBudget` muss **trotzdem** pro Posten aufgeschlüsselt werden → die schwierigste Migration fällt genauso an. B spart nur genau die Teile, die A korrekt machen.
+- **Risiko:** mittel. **Komplexität:** mittel. **Verworfen** (Nutzer: „ungenau/hingemogelt" — bestätigt).
+
+### Option C — manuelle Posten-Stunden für geteilte MA (verworfen)
+Auto-Verteilung bleibt „1 Posten pro MA"; für geteilte MA werden Posten-Stunden manuell je Monat gesetzt.
+- **Contra:** löst den Automatik-Wunsch nur halb; laufende Handarbeit. **Verworfen.**
+
+**Entscheidung:** **Option A** — „Aufwand ist kein Faktor, gewünscht ist eine saubere & stabile Lösung" (Nutzer), und die Ist-Daten sind bereits Posten-granular.
+
+## 4. Betroffene bestehende Logik
+
+**Angefasst:**
+- Membership-Uniqueness + defensiver 409-Dedup (`routers/projects.py:446`) → Uniqueness = (person, project, billing_position_id).
+- `MilestonePersonBudget`-Schema (`models/milestone.py:51`) → Re-Key + Migration; Invariante `Σ MPB.current_hours == Milestone.current_hours` bleibt gültig (nur mehr Zeilen).
+- Kapazität (`planning.py:198` `.first()`, `milestones.py:228`) → pro Zuweisung; **neuer Σ-Kapazitäts-Wächter**.
+- Verteilung (`distribute_budget`/`distribute_over_positions`, `milestones.py:335,552`) → Keying person→Zuweisung.
+- Satz-Auflösung (`build_rate_map`/`effective_rate`, `milestones.py:497,84`).
+- Posten-Restbudget (`_remaining_position_euro_budget`, `milestones.py:504`) → + asymmetrische Überschreitung (§6).
+- Rebalancing/Preview (`rebalancing.py:106,147`).
+- Import (`importer.py`) → + Mismatch-Check (§6).
+- Frontend (`ProjectDetailPage.tsx`) → MA erscheint je Posten; Zuweisungs-Formulare; Plan-vs-Ist.
+
+**Nicht betroffen (Stabilitätsanker):**
+- **Simple-Modus (`position_mode = false`) bleibt vollständig unverändert.** Der Multi-Posten-Pfad lebt ausschließlich im Posten-Modus; die Änderung ist dort additiv.
+- Abwesenheits-/Feiertags-/Netto-Kapazitätsberechnung pro MA (`net_hours`) — unverändert; nur ihre *Aufteilung auf Zuweisungen* ist neu.
+- Σ-Budget-Invarianten der Posten (`line_items.py`) — unverändert.
+- Rechnungsstellung ist bereits Posten-basiert (`invoices.py:151`) — profitiert.
+
+## 5. Kapazitäts-Wächter (Korrektheits-Kern)
+
+Da ein MA nun mehrere Kapazitäts-Zeilen hat, muss geprüft werden:
+
+> Σ `weekly_capacity_hours` aller Zuweisungen eines MA (pro Zeitfenster, über alle Projekte) ≤ reale Verfügbarkeit (aus `default_weekly_hours`/`work_week_pattern` abzüglich Abwesenheiten/Feiertage).
+
+Bei Überschreitung: **Flag/Warnung** (kein harter Block, da kurzfristige Über-100 %-Planung fachlich vorkommen kann), sichtbar in Team-Ansicht und Meilenstein-Diagnose.
+
+## 6. Asymmetrische Posten-Überschreitung (Evolution von P4)
+
+Doc 21 **P4** legt heute fest: Posten-Budget = **harte** Teil-Obergrenze; Verschiebung zwischen Posten nur **manuell**. Neu:
+
+- Pro Posten ein Flag `cap_mode` (bzw. `overrunnable: bool`): **hart** (teuer, nie überschreiten) | **überschreitbar** (günstig, darf über Budget).
+- Verteil-Logik: Läuft ein harter (teurer) Posten voll und hat der MA noch Kapazität, wird der Rest auf einen **überschreitbaren** (günstigeren) Posten desselben MA umgelenkt, statt still auf 0 h zu kappen.
+- **Mismatch-Flagging (Import):**
+  - *Unbekannte Projektebene bei aktiven Posten* → existiert bereits als harter `UnresolvedPositionsError` (`importer.py:395`); optional zu „Flag statt Abbruch" aufweichen.
+  - *MA auf nicht-zugewiesenem Posten gebucht* → **neu**: Nachlauf-Check `TimeBooking.billing_position_id` vs. Zuweisungs-Set des MA; Treffer werden geflaggt.
+
+## 7. UX für blockierende Limits (Punkt 3, integriert)
+
+**Befund:** `distribute_budget`/`distribute_over_positions` liefern nur Zahlen und **verwerfen den Grund** der Kappung (Kapazität vs. Projektbudget vs. Posten-Budget). Einzige Warnung feuert nur, wenn der **ganze Monat** 0 h ist (`milestones.py:321–334`). Szenario „Posten aktiv, MA hat Zeit, aber sein Posten-Topf leer → still 0 h" bleibt unsichtbar.
+
+**Lösung (in denselben Umbau):**
+1. **Bindende Randbedingung pro Slot mitführen** — Verteil-Funktionen geben zusätzlich zurück, *was* gekappt hat (`capacity` | `project_budget` | `position_budget`). Pro Zuweilung im Klartext: „0 h — Posten ‚X' aufgebraucht, obwohl N h Kapazität frei".
+2. **Posten-Ampel** in Team-/Meilenstein-Blick: Posten mit Rest(€) ≈ 0 rot + „bindet N MA auf 0 h".
+3. **Neuberechnungs-Zusammenfassung** statt nur Änderungs-Zähler (`ResyncResultOut`): „X MA wegen Posten-Budget, Y wegen Projektbudget, Z wegen Kapazität gekappt".
+
+API-Erweiterung: `MilestonePersonDetailOut` (`milestones.py:55`) um ein Grund-Feld; `MilestoneDetailOut.warnings` / `ResyncResultOut` um strukturierte Gründe.
+
+## 8. Arbeitspakete (phasenweise, je 1 Sub-Issue)
+
+- **WP1 — Datenmodell + Migration.** Mehrere Memberships pro (MA, Projekt); Uniqueness (person, project, posten); `MilestonePersonBudget` Re-Key auf (milestone, membership/posten) + Alembic-Migration; 409-Dedup anpassen.
+- **WP2 — Engine Re-Keying + Kapazitäts-Wächter.** `capacity`, `distribute_*`, `rate_map`, Rebalancing/Preview auf Zuweisungs-Keying; Σ-Kapazitäts-Wächter (§5).
+- **WP3 — Asymmetrische Posten-Überschreitung.** `cap_mode` je Posten; Umverteilung teuer→günstig in `distribute_over_positions` (§6).
+- **WP4 — Import-Mismatch-Flagging.** MA↔Posten-Check; Behandlung unbekannter Ebenen (§6).
+- **WP5 — Frontend.** MA je Posten in Team-Ansicht; Zuweisungs-Formulare; Plan-vs-Ist je Posten; Kapazitäts-/Mismatch-Warnungen.
+- **WP6 — UX-Diagnose blockierende Limits (Punkt 3).** Grund pro Slot durchreichen; Klartext, Posten-Ampel, Neuberechnungs-Zusammenfassung (§7).
+
+Reihenfolge: WP1 → WP2 → (WP3 ∥ WP4 ∥ WP6) → WP5. Simple-Modus bleibt in jeder Phase unberührt.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -339,12 +339,12 @@ export const projects = {
     req<MilestoneTargetResult>('PUT', `/projects/${projectId}/milestones/${milestoneId}/target-budget`, { target_euros: targetEuros }),
   clearMilestoneTargetBudget: (projectId: number, milestoneId: number) =>
     req<Milestone>('DELETE', `/projects/${projectId}/milestones/${milestoneId}/target-budget`),
-  setHoursLock: (projectId: number, milestoneId: number, personId: number, locked: boolean) =>
-    req<MilestonePersonBudget>('PUT', `/projects/${projectId}/milestones/${milestoneId}/persons/${personId}/lock`, { locked }),
-  setEstimatedAbsence: (projectId: number, milestoneId: number, personId: number, days: number | null) =>
-    req<MilestonePersonBudget>('PUT', `/projects/${projectId}/milestones/${milestoneId}/persons/${personId}/estimated-absence`, { days }),
-  updatePersonBudget: (projectId: number, milestoneId: number, personId: number, hours: number, confirm?: boolean) =>
-    req<BudgetUpdateResult>('PUT', `/projects/${projectId}/milestones/${milestoneId}/persons/${personId}${confirm ? '?confirm=true' : ''}`, { current_hours: hours }),
+  setHoursLock: (projectId: number, milestoneId: number, budgetId: number, locked: boolean) =>
+    req<MilestonePersonBudget>('PUT', `/projects/${projectId}/milestones/${milestoneId}/budgets/${budgetId}/lock`, { locked }),
+  setEstimatedAbsence: (projectId: number, milestoneId: number, budgetId: number, days: number | null) =>
+    req<MilestonePersonBudget>('PUT', `/projects/${projectId}/milestones/${milestoneId}/budgets/${budgetId}/estimated-absence`, { days }),
+  updatePersonBudget: (projectId: number, milestoneId: number, budgetId: number, hours: number, confirm?: boolean) =>
+    req<BudgetUpdateResult>('PUT', `/projects/${projectId}/milestones/${milestoneId}/budgets/${budgetId}${confirm ? '?confirm=true' : ''}`, { current_hours: hours }),
   recommendations: (id: number) => req<UtilizationRecommendation[]>('GET', `/projects/${id}/milestones/recommendations`),
   recalcPreview: (id: number) => req<MilestoneSuggestion[]>('GET', `/projects/${id}/milestones/recalc-preview`),
   setPlanningLock: (projectId: number, milestoneId: number, locked: boolean) =>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -364,7 +364,7 @@ export interface PersonAbsence {
   person_id: number;
   start_date: string;
   end_date: string | null;
-  absence_type: 'vacation' | 'sick' | 'training';
+  absence_type: 'vacation' | 'sick' | 'training' | 'other';
   status: 'planned' | 'confirmed' | 'ongoing';
   note: string;
 }
@@ -457,7 +457,7 @@ export interface CalendarAbsence {
   id: number;
   start_date: string;
   end_date: string | null;
-  absence_type: 'vacation' | 'sick' | 'training';
+  absence_type: 'vacation' | 'sick' | 'training' | 'other';
   status: 'planned' | 'confirmed' | 'ongoing';
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -106,6 +106,8 @@ export interface BillingPosition {
   budget_euros: number;
   /** Hourly rate of the line item (Projektposten). 0 = no rate (simple invoicing position). */
   billing_rate_per_hour: number;
+  /** WP3: false = hard cap (never planned past budget); true = cheap position, may exceed budget. */
+  overrunnable: boolean;
 }
 
 /** Aggregate €-budget state across a project's line items (doc 21 §P3). */
@@ -190,6 +192,7 @@ export interface BudgetSuggestion {
   person_id: number;
   current_hours: number;
   suggested_hours: number;
+  billing_position_id: number | null;
 }
 
 export interface MilestoneSuggestion {
@@ -314,12 +317,12 @@ export const projects = {
     req<BillingPositionBudgetState>('GET', `/projects/${id}/billing-positions/budget-state`),
   addBillingPosition: (
     id: number,
-    d: { position_number: string; description?: string; budget_euros?: number | null; billing_rate_per_hour?: number },
+    d: { position_number: string; description?: string; budget_euros?: number | null; billing_rate_per_hour?: number; overrunnable?: boolean },
   ) => req<BillingPosition>('POST', `/projects/${id}/billing-positions`, d),
   updateBillingPosition: (
     projectId: number,
     bpId: number,
-    d: { position_number: string; description?: string; budget_euros: number; billing_rate_per_hour?: number },
+    d: { position_number: string; description?: string; budget_euros: number; billing_rate_per_hour?: number; overrunnable?: boolean },
   ) => req<BillingPosition>('PUT', `/projects/${projectId}/billing-positions/${bpId}`, d),
   deleteBillingPosition: (projectId: number, bpId: number) =>
     req<void>('DELETE', `/projects/${projectId}/billing-positions/${bpId}`),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -179,6 +179,7 @@ export interface MilestonePersonDetail {
   booked_hours: number;
   is_manual_override: boolean;
   estimated_absence_days_override: number | null;
+  cap_reason?: string | null;
 }
 
 export interface MilestoneDetail {

--- a/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
+++ b/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
@@ -4,10 +4,10 @@ import { persons as personsApi } from '../../api'
 import Modal from '../Modal'
 import { TYPE_LABELS, STATUS_LABELS } from '../../lib/absenceColors'
 
-type AbsenceType = 'vacation' | 'sick' | 'training'
+type AbsenceType = 'vacation' | 'sick' | 'training' | 'other'
 type AbsenceStatus = 'planned' | 'confirmed' | 'ongoing'
 
-const TYPES: AbsenceType[] = ['vacation', 'training', 'sick']
+const TYPES: AbsenceType[] = ['vacation', 'training', 'sick', 'other']
 
 function allowedStatuses(type: AbsenceType): AbsenceStatus[] {
   return type === 'sick' ? ['confirmed', 'ongoing'] : ['planned', 'confirmed']

--- a/frontend/src/lib/absenceColors.ts
+++ b/frontend/src/lib/absenceColors.ts
@@ -10,21 +10,23 @@
 
 import type { PersonAbsence } from '../api'
 
-type AbsenceType = PersonAbsence['absence_type'] // 'vacation' | 'sick' | 'training'
+type AbsenceType = PersonAbsence['absence_type'] // 'vacation' | 'sick' | 'training' | 'other'
 type AbsenceStatus = PersonAbsence['status'] // 'planned' | 'confirmed' | 'ongoing'
 
-/** Long German labels (Urlaub / Krank / Fortbildung). */
+/** Long German labels (Urlaub / Krank / Fortbildung / Sonstiges). */
 export const TYPE_LABELS: Record<AbsenceType, string> = {
   vacation: 'Urlaub',
   sick: 'Krank',
   training: 'Fortbildung',
+  other: 'Sonstiges',
 }
 
-/** Single-letter codes for compact inline tags (U / K / F). */
+/** Single-letter codes for compact inline tags (U / K / F / S). */
 export const TYPE_SHORT: Record<AbsenceType, string> = {
   vacation: 'U',
   sick: 'K',
   training: 'F',
+  other: 'S',
 }
 
 /** Light badge classes (bg + text) — tables, legends, chips. */
@@ -32,6 +34,7 @@ export const TYPE_BADGE: Record<AbsenceType, string> = {
   vacation: 'bg-blue-100 text-blue-700',
   sick: 'bg-yellow-100 text-yellow-700',
   training: 'bg-emerald-100 text-emerald-700',
+  other: 'bg-purple-100 text-purple-700',
 }
 
 /** Stronger fill classes — per-day overlays / bars in the month calendar. */
@@ -39,6 +42,7 @@ export const TYPE_BAR_BG: Record<AbsenceType, string> = {
   vacation: 'bg-blue-200',
   sick: 'bg-yellow-200',
   training: 'bg-emerald-200',
+  other: 'bg-purple-200',
 }
 
 export const STATUS_LABELS: Record<AbsenceStatus, string> = {

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -12,6 +12,7 @@ interface ImportResultOut {
   batch_ids: number[]
   inserted: number
   skipped: number
+  mismatches?: string[]
 }
 
 interface ParseErrorRow {
@@ -637,6 +638,18 @@ export default function ImportPage() {
                   <p className="text-xs text-green-700 mt-0.5">
                     {state.result.inserted} Buchungen importiert · {state.result.skipped} bereits vorhanden (übersprungen)
                   </p>
+                  {state.result.mismatches && state.result.mismatches.length > 0 && (
+                    <div className="mt-2 border-t border-green-200 pt-2">
+                      <p className="text-xs font-medium text-amber-700">
+                        {state.result.mismatches.length} Posten-Zuordnung(en) prüfen:
+                      </p>
+                      <ul className="mt-1 list-disc list-inside space-y-0.5">
+                        {state.result.mismatches.map((m, i) => (
+                          <li key={i} className="text-xs text-amber-700">{m}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -120,6 +120,7 @@ function AbsenceForm({
             <option value="vacation">Urlaub</option>
             <option value="training">Fortbildung</option>
             <option value="sick">Krank</option>
+            <option value="other">Sonstiges</option>
           </select>
         </div>
         <div>

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -11,8 +11,8 @@ import { personColor, TYPE_LABELS, TYPE_SHORT } from '../lib/absenceColors'
 import { regionKey, regionLabel, regionShade } from '../lib/holidayRegions'
 import RegionOverrideSelect from '../components/absence/RegionOverrideSelect'
 
-type AbsenceType = 'vacation' | 'sick' | 'training'
-const ALL_TYPES: AbsenceType[] = ['vacation', 'training', 'sick']
+type AbsenceType = 'vacation' | 'sick' | 'training' | 'other'
+const ALL_TYPES: AbsenceType[] = ['vacation', 'training', 'sick', 'other']
 
 const WORK_WEEK_PRESETS = [
   { label: '40 h (5×8)', value: '8,8,8,8,8' },

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -568,14 +568,14 @@ export default function ProjectDetailPage() {
   const [confirmReopenId, setConfirmReopenId] = useState<number | null>(null)
   const [confirmReopenMilestone, setConfirmReopenMilestone] = useState<{ year: number; month: number } | null>(null)
   const [expandedMilestones, setExpandedMilestones] = useState<Set<number>>(new Set())
-  const [editBudget, setEditBudget] = useState<{ milestoneId: number; personId: number; personName: string; currentHours: number } | null>(null)
+  const [editBudget, setEditBudget] = useState<{ milestoneId: number; budgetId: number; personName: string; currentHours: number } | null>(null)
   const [editHours, setEditHours] = useState(0)
   const [budgetWarnings, setBudgetWarnings] = useState<string[]>([])   // manual-edit warnings (V6)
   const [budgetNeedsConfirm, setBudgetNeedsConfirm] = useState(false)  // budget overrun awaiting confirm
   const [editTarget, setEditTarget] = useState<{ milestoneId: number; year: number; month: number } | null>(null)  // edit monthly € target
   const [editTargetAmount, setEditTargetAmount] = useState(0)
   const [targetWarnings, setTargetWarnings] = useState<string[]>([])
-  const [editAbsence, setEditAbsence] = useState<{ milestoneId: number; personId: number; personName: string } | null>(null)  // edit estimated absence
+  const [editAbsence, setEditAbsence] = useState<{ milestoneId: number; budgetId: number; personName: string } | null>(null)  // edit estimated absence
   const [editAbsenceDays, setEditAbsenceDays] = useState(0)
   const [closeForm, setCloseForm] = useState({ year: new Date().getFullYear(), month: new Date().getMonth() + 1, billing_position_id: 0 })
   const [addMemberForm, setAddMemberForm] = useState({ person_id: 0, from_date: '', to_date: '', weekly_capacity_hours: 40, billing_rate_per_hour: 90, priority: 0, vacation_days_taken: 0, billing_position_id: null as number | null })
@@ -626,8 +626,8 @@ export default function ProjectDetailPage() {
   })
 
   const updatePersonBudget = useMutation({
-    mutationFn: ({ milestoneId, personId, hours, confirm }: { milestoneId: number; personId: number; hours: number; confirm?: boolean }) =>
-      projects.updatePersonBudget(projectId, milestoneId, personId, hours, confirm),
+    mutationFn: ({ milestoneId, budgetId, hours, confirm }: { milestoneId: number; budgetId: number; hours: number; confirm?: boolean }) =>
+      projects.updatePersonBudget(projectId, milestoneId, budgetId, hours, confirm),
     onSuccess: () => {
       invalidateMilestones()
       setEditBudget(null)
@@ -666,14 +666,14 @@ export default function ProjectDetailPage() {
     onError: (e: Error) => setError(e.message),
   })
   const toggleHoursLock = useMutation({
-    mutationFn: ({ milestoneId, personId, locked }: { milestoneId: number; personId: number; locked: boolean }) =>
-      projects.setHoursLock(projectId, milestoneId, personId, locked),
+    mutationFn: ({ milestoneId, budgetId, locked }: { milestoneId: number; budgetId: number; locked: boolean }) =>
+      projects.setHoursLock(projectId, milestoneId, budgetId, locked),
     onSuccess: () => { invalidateMilestones(); setError(null) },
     onError: (e: Error) => setError(e.message),
   })
   const setEstAbsence = useMutation({
-    mutationFn: ({ milestoneId, personId, days }: { milestoneId: number; personId: number; days: number | null }) =>
-      projects.setEstimatedAbsence(projectId, milestoneId, personId, days),
+    mutationFn: ({ milestoneId, budgetId, days }: { milestoneId: number; budgetId: number; days: number | null }) =>
+      projects.setEstimatedAbsence(projectId, milestoneId, budgetId, days),
     onSuccess: () => { invalidateMilestones(); setEditAbsence(null); setError(null) },
     onError: (e: Error) => setError(e.message),
   })
@@ -1201,7 +1201,7 @@ export default function ProjectDetailPage() {
                                             <span>{fmtH(cur)} <span className="text-[10px] text-gray-400">(Soll)</span></span>
                                             {editable && (
                                               <button
-                                                onClick={() => { setEditBudget({ milestoneId: ms.id, personId: p.person_id, personName: p.person_name, currentHours: p.current_hours }); setEditHours(p.current_hours) }}
+                                                onClick={() => { setEditBudget({ milestoneId: ms.id, budgetId: p.budget_id, personName: p.person_name, currentHours: p.current_hours }); setEditHours(p.current_hours) }}
                                                 title="Soll-Stunden dieser Person anpassen"
                                                 className="p-0.5 text-gray-400 hover:text-blue-600">
                                                 <Pencil size={11} />
@@ -1209,7 +1209,7 @@ export default function ProjectDetailPage() {
                                             )}
                                             {editable && (
                                               <button
-                                                onClick={() => toggleHoursLock.mutate({ milestoneId: ms.id, personId: p.person_id, locked: !p.is_manual_override })}
+                                                onClick={() => toggleHoursLock.mutate({ milestoneId: ms.id, budgetId: p.budget_id, locked: !p.is_manual_override })}
                                                 title={p.is_manual_override ? 'Stunden gesperrt — bleiben bei Neuberechnung erhalten. Klicken zum Entsperren.' : 'Stunden entsperrt — Neuberechnung darf anpassen. Klicken zum Sperren.'}
                                                 className={`p-0.5 ${p.is_manual_override ? 'text-purple-500 hover:text-purple-700' : 'text-gray-300 hover:text-gray-500'}`}>
                                                 {p.is_manual_override ? <Lock size={11} /> : <Unlock size={11} />}
@@ -1257,7 +1257,7 @@ export default function ProjectDetailPage() {
                                           </span>
                                           {editable && (
                                             <button
-                                              onClick={() => { setEditAbsence({ milestoneId: ms.id, personId: p.person_id, personName: p.person_name }); setEditAbsenceDays(Math.round(estAbs * 10) / 10) }}
+                                              onClick={() => { setEditAbsence({ milestoneId: ms.id, budgetId: p.budget_id, personName: p.person_name }); setEditAbsenceDays(Math.round(estAbs * 10) / 10) }}
                                               title="Geschätzte Abwesenheit (Tage) manuell setzen"
                                               className="p-0.5 text-gray-400 hover:text-blue-600">
                                               <Pencil size={11} />
@@ -1265,7 +1265,7 @@ export default function ProjectDetailPage() {
                                           )}
                                           {editable && absOverride != null && (
                                             <button
-                                              onClick={() => setEstAbsence.mutate({ milestoneId: ms.id, personId: p.person_id, days: null })}
+                                              onClick={() => setEstAbsence.mutate({ milestoneId: ms.id, budgetId: p.budget_id, days: null })}
                                               title="Geschätzte Abwesenheit gesperrt (manuell) — klicken zum Entsperren (zurück auf automatische Schätzung)"
                                               className="p-0.5 text-purple-500 hover:text-purple-700">
                                               <Lock size={11} />
@@ -1945,7 +1945,7 @@ export default function ProjectDetailPage() {
         const closeEdit = () => { setEditBudget(null); setBudgetWarnings([]); setBudgetNeedsConfirm(false) }
         return (
         <Modal title={`Stunden anpassen — ${editBudget.personName}`} onClose={closeEdit}>
-          <form onSubmit={(e) => { e.preventDefault(); updatePersonBudget.mutate({ milestoneId: editBudget.milestoneId, personId: editBudget.personId, hours: editHours }) }} className="space-y-3">
+          <form onSubmit={(e) => { e.preventDefault(); updatePersonBudget.mutate({ milestoneId: editBudget.milestoneId, budgetId: editBudget.budgetId, hours: editHours }) }} className="space-y-3">
             <div>
               <label className="block text-xs font-medium text-gray-600 mb-1">Aktuelle Stunden</label>
               <input
@@ -1970,7 +1970,7 @@ export default function ProjectDetailPage() {
                 className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
               {budgetNeedsConfirm ? (
                 <button type="button"
-                  onClick={() => updatePersonBudget.mutate({ milestoneId: editBudget.milestoneId, personId: editBudget.personId, hours: editHours, confirm: true })}
+                  onClick={() => updatePersonBudget.mutate({ milestoneId: editBudget.milestoneId, budgetId: editBudget.budgetId, hours: editHours, confirm: true })}
                   className="px-4 py-1.5 text-sm bg-orange-600 text-white rounded hover:bg-orange-700">Trotzdem speichern</button>
               ) : (
                 <button type="submit"
@@ -2026,7 +2026,7 @@ export default function ProjectDetailPage() {
       {/* Edit estimated absence (days) — manual override */}
       {editAbsence && (
         <Modal title={`Geschätzte Abwesenheit — ${editAbsence.personName}`} onClose={() => setEditAbsence(null)}>
-          <form onSubmit={(e) => { e.preventDefault(); setEstAbsence.mutate({ milestoneId: editAbsence.milestoneId, personId: editAbsence.personId, days: editAbsenceDays }) }} className="space-y-3">
+          <form onSubmit={(e) => { e.preventDefault(); setEstAbsence.mutate({ milestoneId: editAbsence.milestoneId, budgetId: editAbsence.budgetId, days: editAbsenceDays }) }} className="space-y-3">
             <p className="text-xs text-gray-500">
               Manuell angenommene Abwesenheitstage (nicht verplanter Resturlaub, pauschal Krank/Fortbildung).
               Ein gesetzter Wert ersetzt die automatische Schätzung, ist gesperrt und fließt in die Verfügbarkeit ein.

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ChevronLeft, RefreshCw, Lock, Unlock, FileText, Plus, Trash2, ChevronDown, ChevronRight, Pencil, Flag, RotateCcw, Mail, Copy } from 'lucide-react'
+import { ChevronLeft, RefreshCw, Lock, Unlock, FileText, Plus, Trash2, ChevronDown, ChevronRight, Pencil, Flag, RotateCcw, Mail, Copy, AlertTriangle } from 'lucide-react'
 import {
   projects, persons, programs, invoices as invoiceApi, bookings as bookingsApi, ApiError,
   type Project, type Program, type ProjectMembership, type MonthlyInvoice, type MilestoneDetail, type TimeBooking, type ExclusionReason, type BillingPosition,
@@ -1186,6 +1186,12 @@ export default function ProjectDetailPage() {
                                         {showPRebal && (
                                           <div className="text-[11px] text-indigo-600" title="Vorschlag aus „Neu berechnen“ für diese Person.">
                                             → {fmtH(pSug!)} ({pRebalDelta > 0 ? '+' : ''}{pRebalDelta.toFixed(2)})
+                                          </div>
+                                        )}
+                                        {p.cap_reason && (
+                                          <div className="mt-0.5 flex items-center gap-1 text-[11px] text-amber-600 whitespace-normal max-w-[12rem]" title={p.cap_reason}>
+                                            <AlertTriangle size={11} className="shrink-0" />
+                                            <span>{p.cap_reason}</span>
                                           </div>
                                         )}
                                       </td>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ChevronLeft, RefreshCw, Lock, Unlock, FileText, Plus, Trash2, ChevronDown, ChevronRight, Pencil, Flag, RotateCcw, Mail, Copy, AlertTriangle } from 'lucide-react'
@@ -552,6 +552,178 @@ const STATUS_LABELS: Record<MonthlyInvoice['status'], string> = {
   paid: 'Bezahlt',
 }
 
+interface AssignRow {
+  key: string
+  membershipId: number | null
+  billing_position_id: number | null
+  weekly_capacity_hours: number
+  priority: number
+  billing_rate_per_hour: number
+  vacation_days_taken: number
+}
+
+/** Manage ALL Posten-assignments of one MA in a project as an editable list — each row is
+ *  one ProjectMembership. Saving diffs against the existing memberships (create/update/delete).
+ *  Shared Von/Bis apply to every row (the common case; date ranges per Posten are rare). */
+function MemberAssignmentsModal({
+  projectId, person, memberships, positions, positionMode, onClose, onSaved,
+}: {
+  projectId: number
+  person: { id: number; name: string }
+  memberships: ProjectMembership[]
+  positions: BillingPosition[]
+  positionMode: boolean
+  onClose: () => void
+  onSaved: (warnings: string[]) => void
+}) {
+  const mine = memberships.filter((m) => m.person_id === person.id)
+  const posById = new Map(positions.map((p) => [p.id, p]))
+  const seq = useRef(0)
+  const [fromDate, setFromDate] = useState(mine[0]?.from_date ?? '')
+  const [toDate, setToDate] = useState(mine[0]?.to_date ?? '')
+  const [rows, setRows] = useState<AssignRow[]>(
+    mine.map((m) => ({
+      key: 'm' + m.id, membershipId: m.id, billing_position_id: m.billing_position_id,
+      weekly_capacity_hours: m.weekly_capacity_hours, priority: m.priority,
+      billing_rate_per_hour: m.billing_rate_per_hour, vacation_days_taken: m.vacation_days_taken,
+    })),
+  )
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const rowRate = (r: AssignRow) => {
+    const p = r.billing_position_id != null ? posById.get(r.billing_position_id) : undefined
+    return p && p.billing_rate_per_hour > 0 ? p.billing_rate_per_hour : r.billing_rate_per_hour
+  }
+  const setRow = (key: string, patch: Partial<AssignRow>) =>
+    setRows((rs) => rs.map((r) => (r.key === key ? { ...r, ...patch } : r)))
+  const addRow = () => {
+    const used = new Set(rows.map((r) => r.billing_position_id))
+    const free = positions.find((p) => !used.has(p.id))
+    setRows((rs) => [...rs, {
+      key: 'n' + (seq.current++), membershipId: null,
+      billing_position_id: free?.id ?? null, weekly_capacity_hours: 0, priority: 0,
+      billing_rate_per_hour: 0, vacation_days_taken: 0,
+    }])
+  }
+
+  const save = async () => {
+    setErr(null)
+    if (!fromDate || !toDate) return setErr('Von und Bis sind erforderlich.')
+    if (rows.length === 0) return setErr('Mindestens eine Zuweisung erforderlich.')
+    if (positionMode && rows.some((r) => r.billing_position_id == null))
+      return setErr('Im Posten-Modus muss jede Zeile einen Posten haben.')
+    const posIds = rows.map((r) => r.billing_position_id)
+    if (new Set(posIds).size !== posIds.length)
+      return setErr('Jeder Posten darf diesem MA nur einmal zugewiesen sein.')
+    if (rows.some((r) => !(r.weekly_capacity_hours > 0)))
+      return setErr('h/Woche muss größer als 0 sein.')
+    setSaving(true)
+    try {
+      const keptIds = new Set(rows.filter((r) => r.membershipId != null).map((r) => r.membershipId!))
+      for (const m of mine) if (!keptIds.has(m.id)) await projects.deleteMembership(projectId, m.id)
+      const warnings: string[] = []
+      for (const r of rows) {
+        const payload = {
+          from_date: fromDate, to_date: toDate, weekly_capacity_hours: r.weekly_capacity_hours,
+          billing_rate_per_hour: rowRate(r), priority: r.priority,
+          vacation_days_taken: r.vacation_days_taken, billing_position_id: r.billing_position_id,
+        }
+        const res = r.membershipId != null
+          ? await projects.updateMembership(projectId, r.membershipId, payload)
+          : await projects.addMembership(projectId, { person_id: person.id, ...payload })
+        if (res.warnings) warnings.push(...res.warnings)
+      }
+      onSaved(warnings)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Modal title={`Posten-Zuweisungen — ${person.name}`} onClose={onClose}>
+      <div className="space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Von</label>
+            <input type="date" className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">Bis</label>
+            <input type="date" className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              value={toDate} onChange={(e) => setToDate(e.target.value)} />
+          </div>
+        </div>
+        <p className="text-xs text-gray-500">Zeitraum gilt für alle Posten-Zuweisungen dieses MA.</p>
+
+        <div className="border border-gray-200 rounded overflow-hidden">
+          <div className="grid grid-cols-[1fr_5rem_5rem_2rem] gap-2 px-2 py-1.5 bg-gray-50 text-[11px] font-medium text-gray-500">
+            <span>Posten</span><span>h/Woche</span><span>Priorität</span><span></span>
+          </div>
+          {rows.length === 0 && (
+            <div className="px-2 py-3 text-xs text-gray-400">Noch keine Zuweisung — „+ Posten" klicken.</div>
+          )}
+          {rows.map((r) => {
+            const pos = r.billing_position_id != null ? posById.get(r.billing_position_id) : undefined
+            const rateFromPos = pos != null && pos.billing_rate_per_hour > 0
+            return (
+              <div key={r.key} className="grid grid-cols-[1fr_5rem_5rem_2rem] gap-2 px-2 py-1.5 items-center border-t border-gray-100">
+                <div>
+                  <select className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
+                    value={r.billing_position_id ?? ''}
+                    onChange={(e) => setRow(r.key, { billing_position_id: e.target.value === '' ? null : parseInt(e.target.value) })}>
+                    {!positionMode && <option value="">— kein Posten —</option>}
+                    {positions.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.position_number}{p.description ? ` – ${p.description}` : ''}{p.billing_rate_per_hour > 0 ? ` (${p.billing_rate_per_hour} €)` : ''}
+                      </option>
+                    ))}
+                  </select>
+                  {!rateFromPos && (
+                    <input type="number" min={0} step={0.01} placeholder="Satz €/Std."
+                      className="mt-1 w-full border border-gray-300 rounded px-2 py-1 text-xs"
+                      value={r.billing_rate_per_hour || ''}
+                      onChange={(e) => setRow(r.key, { billing_rate_per_hour: parseFloat(e.target.value) || 0 })} />
+                  )}
+                </div>
+                <input type="number" min={0} step={0.01}
+                  className="border border-gray-300 rounded px-2 py-1 text-sm"
+                  value={r.weekly_capacity_hours || ''}
+                  onChange={(e) => setRow(r.key, { weekly_capacity_hours: parseFloat(e.target.value) || 0 })} />
+                <input type="number" step={1}
+                  className="border border-gray-300 rounded px-2 py-1 text-sm"
+                  value={r.priority}
+                  onChange={(e) => setRow(r.key, { priority: parseInt(e.target.value) || 0 })} />
+                <button type="button" title="Zuweisung entfernen"
+                  className="text-gray-400 hover:text-red-600"
+                  onClick={() => setRows((rs) => rs.filter((x) => x.key !== r.key))}>
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+        <button type="button" onClick={addRow}
+          className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800">
+          <Plus size={14} /> Posten
+        </button>
+
+        {err && <p className="text-sm text-red-600">{err}</p>}
+        <div className="flex justify-end gap-2 pt-1">
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
+          <button type="button" onClick={save} disabled={saving}
+            className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+            {saving ? 'Speichern…' : 'Speichern'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
 type Tab = 'milestones' | 'invoices' | 'members' | 'bookings' | 'settings'
 
 export default function ProjectDetailPage() {
@@ -565,6 +737,7 @@ export default function ProjectDetailPage() {
   const [showAddMember, setShowAddMember] = useState(false)
   const [editMember, setEditMember] = useState<ProjectMembership | null>(null)
   const [editMemberForm, setEditMemberForm] = useState({ from_date: '', to_date: '', weekly_capacity_hours: 40, billing_rate_per_hour: 90, priority: 0, vacation_days_taken: 0, billing_position_id: null as number | null })
+  const [editAssign, setEditAssign] = useState<{ personId: number; personName: string } | null>(null)  // Posten-Zuweisungs-Liste eines MA
   const [confirmReopenId, setConfirmReopenId] = useState<number | null>(null)
   const [confirmReopenMilestone, setConfirmReopenMilestone] = useState<{ year: number; month: number } | null>(null)
   const [expandedMilestones, setExpandedMilestones] = useState<Set<number>>(new Set())
@@ -1675,7 +1848,7 @@ export default function ProjectDetailPage() {
                     render: (m: ProjectMembership) => (
                       <div className="flex items-center gap-2">
                         <button
-                          onClick={() => { setEditMember(m); setEditMemberForm({ from_date: m.from_date, to_date: m.to_date, weekly_capacity_hours: m.weekly_capacity_hours, billing_rate_per_hour: m.billing_rate_per_hour, priority: m.priority, vacation_days_taken: m.vacation_days_taken, billing_position_id: m.billing_position_id }); setError(null) }}
+                          onClick={() => { setEditAssign({ personId: m.person_id, personName: personName(m.person_id) }); setError(null) }}
                           className="text-gray-400 hover:text-blue-500" aria-label="Bearbeiten"
                         ><Pencil size={14} /></button>
                         <button onClick={() => removeMember.mutate(m.id)}
@@ -2188,7 +2361,25 @@ export default function ProjectDetailPage() {
         </Modal>
       )}
 
-      {/* Edit membership modal */}
+      {/* Posten-Zuweisungs-Liste eines MA (mehrere Posten je MA) */}
+      {editAssign && (
+        <MemberAssignmentsModal
+          projectId={projectId}
+          person={{ id: editAssign.personId, name: editAssign.personName }}
+          memberships={memberships}
+          positions={billingPositions}
+          positionMode={positionMode}
+          onClose={() => setEditAssign(null)}
+          onSaved={(warnings) => {
+            qc.invalidateQueries({ queryKey: ['memberships', projectId] })
+            invalidateMilestones()
+            setEditAssign(null)
+            if (warnings.length > 0) setMemberWarnings(warnings)
+          }}
+        />
+      )}
+
+      {/* Edit membership modal (legacy single-Posten — nur noch als Fallback) */}
       {editMember && (
         <Modal title="Zuweisung bearbeiten" onClose={() => { setEditMember(null); setError(null) }}>
           <p className="text-xs text-gray-500 mb-3">Person: <strong>{personName(editMember.person_id)}</strong></p>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -273,6 +273,7 @@ interface PositionFormValue {
   description: string
   billing_rate_per_hour: number
   budget_euros: number
+  overrunnable: boolean
 }
 
 /** Inline form used both for adding and editing a line item. Shows the derived
@@ -313,6 +314,12 @@ function PositionFields({
           value={value.budget_euros || ''}
           onChange={(e) => onChange({ ...value, budget_euros: parseFloat(e.target.value) || 0 })} />
       </div>
+      <label className="flex items-center gap-1.5 text-xs text-gray-600 pb-1.5" title="Günstiger Posten: darf bei der Neuberechnung über sein Budget hinaus geplant werden (teure Posten bleiben hart begrenzt).">
+        <input type="checkbox"
+          checked={value.overrunnable}
+          onChange={(e) => onChange({ ...value, overrunnable: e.target.checked })} />
+        überschreitbar
+      </label>
     </div>
   )
 }
@@ -377,7 +384,7 @@ function BillingPositionsSection({
   const EPS = 1e-6
   const isOver = allocated > totalBudget + EPS
   const isComplete = Math.abs(open) <= EPS
-  const startAdd = () => setAdding({ position_number: '', description: '', billing_rate_per_hour: 0, budget_euros: Math.max(0, open) })
+  const startAdd = () => setAdding({ position_number: '', description: '', billing_rate_per_hour: 0, budget_euros: Math.max(0, open), overrunnable: false })
 
   return (
     <div className="mt-8 pt-6 border-t border-gray-200">
@@ -427,6 +434,12 @@ function BillingPositionsSection({
                 <div className="min-w-0">
                   <span className="font-medium text-gray-700">{bp.position_number}</span>
                   {bp.description && <><span className="mx-1.5 text-gray-300">·</span><span className="text-gray-600">{bp.description}</span></>}
+                  {bp.overrunnable && (
+                    <span className="ml-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-700"
+                      title="Überschreitbar: darf bei der Neuberechnung über sein Budget hinaus geplant werden.">
+                      überschreitbar
+                    </span>
+                  )}
                   <span className="ml-2 text-xs text-gray-400">
                     {EUR2(bp.budget_euros)}
                     {bp.billing_rate_per_hour > 0 && <> · {EUR2(bp.billing_rate_per_hour)}/Std.{hours != null && <> · {hours.toFixed(1)} Std.</>}</>}
@@ -434,7 +447,7 @@ function BillingPositionsSection({
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
                   <button
-                    onClick={() => { setAdding(null); setErr(null); setEditing({ id: bp.id, value: { position_number: bp.position_number, description: bp.description, billing_rate_per_hour: bp.billing_rate_per_hour, budget_euros: bp.budget_euros } }) }}
+                    onClick={() => { setAdding(null); setErr(null); setEditing({ id: bp.id, value: { position_number: bp.position_number, description: bp.description, billing_rate_per_hour: bp.billing_rate_per_hour, budget_euros: bp.budget_euros, overrunnable: bp.overrunnable } }) }}
                     title="Bearbeiten"
                     className="p-1 text-gray-300 hover:text-blue-500 transition-colors"><Pencil size={13} /></button>
                   <button
@@ -988,7 +1001,8 @@ export default function ProjectDetailPage() {
                       const eurBarColor = eurPct > 100 ? 'bg-red-500' : eurPct >= 80 ? 'bg-orange-400' : 'bg-blue-500'
                       const sug = suggestionByMs.get(ms.id)
                       const rebalDelta = sug ? sug.suggested_total_hours - ms.current_hours : 0
-                      const sugByPid = sug ? new Map(sug.budgets.map((b) => [b.person_id, b.suggested_hours])) : null
+                      // Keyed by budget_id (WP5): a person may have several rows (one per Posten).
+                      const sugByBudget = sug ? new Map(sug.budgets.map((b) => [b.budget_id, b.suggested_hours])) : null
                       const rebalSuggestedEuros = sug ? sug.budgets.reduce((s, b) => s + b.suggested_hours * (rateByPid.get(b.person_id) ?? 0), 0) : 0
                       const rebalDeltaEuros = sug ? rebalSuggestedEuros - plannedEuros : 0
                       const showRebal = sug && !ms.is_locked && !ms.is_planning_locked && Math.abs(rebalDelta) > 0.1
@@ -1149,7 +1163,7 @@ export default function ProjectDetailPage() {
                                     const editable = ms.status === 'open' && !ms.is_locked
                                     const absOverride = p.estimated_absence_days_override
                                     // Per-member rebalance hint (share of the "Neu berechnen" preview for this person).
-                                    const pSug = sugByPid ? sugByPid.get(p.person_id) : undefined
+                                    const pSug = sugByBudget ? sugByBudget.get(p.budget_id) : undefined
                                     const pRebalDelta = pSug != null ? pSug - cur : 0
                                     const showPRebal = showRebal && pSug != null && Math.abs(pRebalDelta) > 0.1
                                     // PWS gauge: target vs effective (Ist) as vertical markers, delta as a segment.
@@ -1158,9 +1172,14 @@ export default function ProjectDetailPage() {
                                     const iPos = effPws !== null ? Math.min(100, effPws / pwsMax * 100) : null
                                     const deltaColor = deltaPws === null ? '' : deltaPws > 0.05 ? 'text-orange-600' : deltaPws < -0.05 ? 'text-blue-600' : 'text-green-600'
                                     return (
-                                    <tr key={p.person_id} className="text-sm border-b border-slate-100 last:border-0">
+                                    <tr key={p.budget_id} className="text-sm border-b border-slate-100 last:border-0">
                                       <td className="pl-12 pr-4 py-2 text-gray-700 whitespace-nowrap">
                                         {p.person_name}
+                                        {p.billing_position_id != null && (
+                                          <span className="ml-1.5 text-[11px] text-gray-400">
+                                            ({posById.get(p.billing_position_id)?.position_number ?? '?'})
+                                          </span>
+                                        )}
                                       </td>
                                       <td className="px-4 py-2 text-gray-400 whitespace-nowrap">
                                         {avail !== null ? fmtH(avail) : <span className="text-gray-300">–</span>}


### PR DESCRIPTION
## Zusammenfassung
Zwei Anpassungspakete aus der Anfrage vom 2026-07-17:

### Abwesenheitskategorie "Sonstiges"
Neue `AbsenceType.other` fuer geplante Abwesenheiten ohne Pauschale/Kontingent
(z. B. Elternzeit, Sabbatical). Reduziert die Verfuegbarkeit, ohne in eine
Richtwert-/Kontingent-Schaetzung einzugehen.

### Mehrere Posten pro MA (Multi-Assignment, Option A)
Ein Mitarbeiter kann im Posten-Modus auf mehrere Projektposten geplant/gebucht
werden, jeder Posten mit eigenem Satz und Budget. Plan-Seite jetzt zuweisungs-
granular `(person_id, billing_position_id)` — deckungsgleich mit den Ist-Daten.

- **WP1** Datenmodell + Migration (Mehrfach-Membership; MilestonePersonBudget re-key)
- **WP2** Engine-Re-Keying auf Assignment-Ebene + Kapazitaets-Waechter
- **WP3** asymmetrische Posten-Ueberschreitung (`overrunnable`: teuer = hart, guenstig = ueberschreitbar)
- **WP4** Import-Mismatch-Flagging (MA auf nicht-zugewiesenem Posten)
- **WP5** Frontend (Zeilen je Posten, ueberschreitbar-Schalter, Mismatch-Anzeige)
- **WP6** UX-Diagnose blockierender Limits (`cap_reason`) + Nacharbeit: per-Zeilen-Edit auf `budget_id`

**Simple-Modus (`position_mode=false`) bit-identisch** — alle Bestandstests unveraendert
gruen. 512 Tests, 91 % Coverage. Design: `docs/implementation/23-posten-multi-assignment.md`.

**Deploy-Hinweis:** Schema-Migrationen `b2d9f4a17c60` + `c3e0a6b28d71` anwenden
(`alembic upgrade head`).

Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
