### PR TITLE
Import: Projektebene→Posten mappen + Konflikte aufloesen (Epic #29)

### DIFF
--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -21,6 +21,7 @@ from app.services.importer import (
     UnmatchedPersonsError,
     UnresolvedPositionsError,
     UnresolvedProjectsError,
+    backfill_bookings_for_level,
     import_bookings,
 )
 
@@ -322,6 +323,8 @@ def create_position_mapping(body: PositionMappingCreate, session: SessionDep):
     except IntegrityError:
         session.rollback()
         raise HTTPException(409, "Mapping for this project and level already exists.")
+    # doc 24 IP4: apply the new mapping to already-imported bookings of this level.
+    backfill_bookings_for_level(mapping.project_id, mapping.sage_project_level, mapping.billing_position_id, session)
     return mapping
 
 
@@ -330,6 +333,7 @@ def update_position_mapping(mapping_id: int, body: PositionMappingCreate, sessio
     mapping = session.get(SagePositionMapping, mapping_id)
     if not mapping:
         raise HTTPException(404, "Mapping not found.")
+    old_level = mapping.sage_project_level
     mapping.project_id = body.project_id
     mapping.sage_project_level = body.sage_project_level
     mapping.billing_position_id = body.billing_position_id
@@ -340,6 +344,10 @@ def update_position_mapping(mapping_id: int, body: PositionMappingCreate, sessio
     except IntegrityError:
         session.rollback()
         raise HTTPException(409, "Mapping for this project and level already exists.")
+    # doc 24 IP4: re-resolve bookings. If the level was renamed, clear the old level's bookings.
+    if old_level != mapping.sage_project_level:
+        backfill_bookings_for_level(mapping.project_id, old_level, None, session)
+    backfill_bookings_for_level(mapping.project_id, mapping.sage_project_level, mapping.billing_position_id, session)
     return mapping
 
 
@@ -348,5 +356,8 @@ def delete_position_mapping(mapping_id: int, session: SessionDep):
     mapping = session.get(SagePositionMapping, mapping_id)
     if not mapping:
         raise HTTPException(404, "Mapping not found.")
+    project_id, level = mapping.project_id, mapping.sage_project_level
     session.delete(mapping)
     session.commit()
+    # doc 24 IP4: bookings of this level become unresolved again.
+    backfill_bookings_for_level(project_id, level, None, session)

--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -61,16 +61,18 @@ class PositionMappingCreate(SQLModel):
 
 
 @router.post("/imports", response_model=ImportResultOut, status_code=201)
-async def post_import(file: UploadFile, session: SessionDep):
+async def post_import(file: UploadFile, session: SessionDep, force: bool = False):
     """Upload a Sage ERP CSV export and persist the time bookings.
 
-    Returns 422 with `detail` + `unresolved_projects` / `unmatched_persons` lists
-    when the file references unknown project names or unmatched persons.
+    Returns 422 with `detail` + `unresolved_projects` / `unmatched_persons` /
+    `unresolved_positions` lists when the file references unknown project names, unmatched
+    persons, or unmapped position-mode Projektebenen. Pass `?force=true` to import despite
+    unmapped Projektebenen (those bookings stay unresolved and are flagged — doc 24 IP2).
     """
     content = await file.read()
     try:
         result: ImportResult = import_bookings(
-            content, session, source_filename=file.filename
+            content, session, source_filename=file.filename, force=force
         )
     except ParseError as exc:
         if exc.details:

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -328,7 +328,10 @@ def list_milestones_detail(project_id: int, session: SessionDep):
             # WP6: a non-override row planned below its available capacity was capped by a
             # budget (capacity itself = available_hours). Name which budget bound it.
             booked_hours = booked_pos.get((person.id, budget.billing_position_id), 0.0)
-            if primary_budget_by_person.get(person.id) == budget.id:
+            # NULL-position bookings: in simple mode attribute to the person's primary row;
+            # in POSITION mode they are UNRESOLVED (no posten) → excluded from any posten row
+            # and surfaced as a milestone warning (doc 24 IP5), never silently placed.
+            if not project.position_mode and primary_budget_by_person.get(person.id) == budget.id:
                 booked_hours += booked_null.get(person.id, 0.0)
             cap_reason: str | None = None
             if not ms.is_locked and not budget.is_manual_override and stats.hours - budget.current_hours > 0.05:
@@ -381,6 +384,15 @@ def list_milestones_detail(project_id: int, session: SessionDep):
             warnings.append(
                 "Gesperrter Meilenstein liegt außerhalb des aktuellen Projektzeitraums."
             )
+        # doc 24 IP5: in position mode, bookings without a resolved Posten are unresolved —
+        # excluded from the per-Posten Ist above; flag their existence here.
+        if project.position_mode:
+            unresolved_h = sum(booked_null.values())
+            if unresolved_h > 0.05:
+                warnings.append(
+                    f"{unresolved_h:.1f} h gebuchte Ist-Stunden ohne Posten-Zuordnung — nicht in "
+                    f"der Posten-Berechnung berücksichtigt. Projektebene→Posten-Mapping prüfen."
+                )
 
         result.append(MilestoneDetailOut(milestone=ms, persons=persons_out, warnings=warnings))
 

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -304,15 +304,30 @@ def list_milestones_detail(project_id: int, session: SessionDep):
         # across a person's positions, so they are attributed to that person's PRIMARY row
         # (lowest budget id) — shown exactly once, so the milestone Ist total stays correct.
         booked_pos: dict[tuple[int, int], float] = {}
-        booked_null: dict[int, float] = {}
+        total_booked_by_person: dict[int, float] = {}
         for pid, bpid, h in booked_rows:
-            if bpid is None:
-                booked_null[pid] = booked_null.get(pid, 0.0) + float(h)
-            else:
+            total_booked_by_person[pid] = total_booked_by_person.get(pid, 0.0) + float(h)
+            if bpid is not None:
                 booked_pos[(pid, bpid)] = booked_pos.get((pid, bpid), 0.0) + float(h)
+        # "Matched" = booked hours whose position has a budget row this month. "Leftover" per
+        # person = everything else (NULL-position bookings AND bookings tagged with a position
+        # that has no budget row here — e.g. a closed month whose legacy row is (person, NULL)
+        # while the booking was later backfilled to a posten). Leftover is attributed to the
+        # person's PRIMARY row in simple mode and in closed (locked) months (Ist is history and
+        # must always show); in OPEN position-mode months it is UNRESOLVED (excluded + warned).
+        budget_pos_by_person: dict[int, set[int | None]] = {}
         primary_budget_by_person: dict[int, int] = {}
         for b in sorted(budgets, key=lambda b: b.id):
             primary_budget_by_person.setdefault(b.person_id, b.id)
+            budget_pos_by_person.setdefault(b.person_id, set()).add(b.billing_position_id)
+        matched_by_person: dict[int, float] = {}
+        for (pid, bpid), h in booked_pos.items():
+            if bpid in budget_pos_by_person.get(pid, set()):
+                matched_by_person[pid] = matched_by_person.get(pid, 0.0) + h
+        leftover_by_person: dict[int, float] = {
+            pid: total - matched_by_person.get(pid, 0.0)
+            for pid, total in total_booked_by_person.items()
+        }
         persons_out: list[MilestonePersonDetailOut] = []
         for budget in budgets:
             person = persons_map.get(budget.person_id)
@@ -328,11 +343,8 @@ def list_milestones_detail(project_id: int, session: SessionDep):
             # WP6: a non-override row planned below its available capacity was capped by a
             # budget (capacity itself = available_hours). Name which budget bound it.
             booked_hours = booked_pos.get((person.id, budget.billing_position_id), 0.0)
-            # NULL-position bookings: in simple mode attribute to the person's primary row;
-            # in POSITION mode they are UNRESOLVED (no posten) → excluded from any posten row
-            # and surfaced as a milestone warning (doc 24 IP5), never silently placed.
-            if not project.position_mode and primary_budget_by_person.get(person.id) == budget.id:
-                booked_hours += booked_null.get(person.id, 0.0)
+            if (not project.position_mode or ms.is_locked) and primary_budget_by_person.get(person.id) == budget.id:
+                booked_hours += leftover_by_person.get(person.id, 0.0)
             cap_reason: str | None = None
             if not ms.is_locked and not budget.is_manual_override and stats.hours - budget.current_hours > 0.05:
                 if project.position_mode and membership.billing_position_id is not None:
@@ -385,9 +397,10 @@ def list_milestones_detail(project_id: int, session: SessionDep):
                 "Gesperrter Meilenstein liegt außerhalb des aktuellen Projektzeitraums."
             )
         # doc 24 IP5: in position mode, bookings without a resolved Posten are unresolved —
-        # excluded from the per-Posten Ist above; flag their existence here.
-        if project.position_mode:
-            unresolved_h = sum(booked_null.values())
+        # excluded from the per-Posten Ist above; flag their existence here. Closed months
+        # are excluded: their Ist is historical and is shown (not treated as unresolved).
+        if project.position_mode and not ms.is_locked:
+            unresolved_h = sum(leftover_by_person.values())
             if unresolved_h > 0.05:
                 warnings.append(
                     f"{unresolved_h:.1f} h gebuchte Ist-Stunden ohne Posten-Zuordnung — nicht in "

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -536,6 +536,7 @@ class BookingOut(BaseModel):
     import_batch_id: int
     sage_project_name: str
     sage_project_level: str
+    billing_position_id: int | None  # resolved Posten (doc 24 IP3); None = nicht zugeordnet
     net_hours: float
     duration_raw: str
     break_duration: str
@@ -601,6 +602,7 @@ def list_project_bookings(
             import_batch_id=b.import_batch_id,
             sage_project_name=b.sage_project_name,
             sage_project_level=b.sage_project_level,
+            billing_position_id=b.billing_position_id,
             net_hours=b.net_hours,
             duration_raw=b.duration_raw,
             break_duration=b.break_duration,

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -15,7 +15,7 @@ from app.models.membership import ProjectMembership
 from app.models.milestone import Milestone
 from app.models.person import Person
 from app.models.project import Project
-from app.models.timebooking import ImportBatch, TimeBooking
+from app.models.timebooking import ImportBatch, SagePositionMapping, TimeBooking
 from app.services.line_items import (
     default_new_position_budget,
     position_budget_state,
@@ -326,6 +326,18 @@ def delete_billing_position(project_id: int, bp_id: int, session: SessionDep):
     ).first()
     if invoiced:
         raise HTTPException(409, "Posten hat Abrechnungen und kann nicht gelöscht werden.")
+    # doc 24 IP4: also block while a level→position mapping or a booking references it,
+    # otherwise those would dangle (mapping) / silently unresolve (bookings).
+    mapped = session.exec(
+        select(SagePositionMapping).where(SagePositionMapping.billing_position_id == bp_id)
+    ).first()
+    if mapped:
+        raise HTTPException(409, "Posten ist einer Projektebene zugeordnet (Mapping) und kann nicht gelöscht werden.")
+    booked = session.exec(
+        select(TimeBooking).where(TimeBooking.billing_position_id == bp_id)
+    ).first()
+    if booked:
+        raise HTTPException(409, "Posten hat zugeordnete Buchungen und kann nicht gelöscht werden.")
     session.delete(bp)
     session.commit()
 

--- a/backend/app/services/importer.py
+++ b/backend/app/services/importer.py
@@ -372,12 +372,15 @@ def resolve_position_mappings(
     pairs: list[tuple[int, str]],
     position_project_ids: set[int],
     session: Session,
+    raise_unresolved: bool = True,
 ) -> dict[tuple[int, str], int]:
     """Map (project_id, sage_project_level) → billing_position_id via SagePositionMapping,
     but only for position-mode projects. Simple-mode projects need no mapping (their pairs
     are skipped and their bookings keep billing_position_id = None).
 
-    Raises UnresolvedPositionsError for position-mode pairs with no mapping entry.
+    With raise_unresolved=True (default) raises UnresolvedPositionsError for position-mode
+    pairs with no mapping entry. With raise_unresolved=False (forced import, doc 24 IP2) the
+    unresolved pairs are simply absent from the result → those bookings stay NULL (unresolved).
     """
     result: dict[tuple[int, str], int] = {}
     unresolved: list[tuple[int, str]] = []
@@ -396,7 +399,7 @@ def resolve_position_mappings(
         else:
             unresolved.append((project_id, level))
 
-    if unresolved:
+    if unresolved and raise_unresolved:
         raise UnresolvedPositionsError(sorted(unresolved))
 
     return result
@@ -491,16 +494,23 @@ def import_bookings(
     content: str | bytes,
     session: Session,
     source_filename: str | None = None,
+    force: bool = False,
 ) -> ImportResult:
     """Parse a Sage CSV export and persist time bookings.
 
     Creates one ImportBatch per distinct project found in the file.
     Duplicate bookings (matching the UNIQUE constraint) are silently skipped.
 
+    With force=False (default), position-mode projects with an unmapped Projektebene abort
+    with UnresolvedPositionsError so the caller can resolve them (doc 24 IP2). With force=True
+    the import proceeds and those bookings stay unresolved (billing_position_id=None), flagged
+    downstream (IP5) — a deliberate override.
+
     Raises:
         ParseError: malformed file content (carries .details list for row-level errors)
         UnmatchedPersonsError: employee names with no fuzzy match
         UnresolvedProjectsError: sage_project_names with no SageProjectMapping
+        UnresolvedPositionsError: position-mode (project, level) with no mapping (unless force)
     """
     rows = parse_rows(content)
 
@@ -518,6 +528,7 @@ def import_bookings(
         [(project_map[r["sage_project_name"]], r["sage_project_level"]) for r in rows],
         position_ids,
         session,
+        raise_unresolved=not force,
     )
 
     # Compute last booking date per project for the ImportBatch records.

--- a/backend/app/services/importer.py
+++ b/backend/app/services/importer.py
@@ -444,6 +444,44 @@ def detect_position_mismatches(batch_ids: list[int], session: Session) -> list[s
     return sorted(warnings)
 
 
+def backfill_bookings_for_level(
+    project_id: int, sage_project_level: str, billing_position_id: int | None, session: Session
+) -> int:
+    """Re-assign existing bookings of a (project, Projektebene) to a Posten (doc 24 IP4).
+
+    Needed because a re-import would NOT update existing rows (billing_position_id is not part
+    of the dedup key), so a mapping created/changed after import must be applied explicitly.
+    Pass billing_position_id=None to clear (e.g. mapping deleted). Returns the number of rows
+    changed. Commits.
+    """
+    rows = session.exec(
+        select(TimeBooking).where(
+            TimeBooking.project_id == project_id,
+            TimeBooking.sage_project_level == sage_project_level,
+        )
+    ).all()
+    changed = 0
+    for tb in rows:
+        if tb.billing_position_id != billing_position_id:
+            tb.billing_position_id = billing_position_id
+            session.add(tb)
+            changed += 1
+    if changed:
+        session.commit()
+    return changed
+
+
+def backfill_bookings_from_mappings(project_id: int, session: Session) -> int:
+    """Apply ALL of a project's Ebene→Posten mappings to its existing bookings (doc 24 IP4).
+    Used when enabling position mode so previously-imported bookings get their Posten."""
+    total = 0
+    for m in session.exec(
+        select(SagePositionMapping).where(SagePositionMapping.project_id == project_id)
+    ).all():
+        total += backfill_bookings_for_level(project_id, m.sage_project_level, m.billing_position_id, session)
+    return total
+
+
 # ---------------------------------------------------------------------------
 # Main import entry point
 # ---------------------------------------------------------------------------

--- a/backend/app/services/milestones.py
+++ b/backend/app/services/milestones.py
@@ -504,6 +504,11 @@ def set_position_mode(project_id: int, enabled: bool, session: Session) -> Proje
     session.add(project)
     session.commit()
     session.refresh(project)
+    if enabled:
+        # doc 24 IP4: apply existing Ebene→Posten mappings to already-imported bookings so the
+        # switch is seamless. Unmapped levels stay NULL (unresolved) and are flagged (IP5).
+        from app.services.importer import backfill_bookings_from_mappings
+        backfill_bookings_from_mappings(project_id, session)
     return project
 
 

--- a/backend/tests/unit/test_services_importer.py
+++ b/backend/tests/unit/test_services_importer.py
@@ -411,6 +411,24 @@ def test_import_position_mode_missing_mapping_raises(session):
     assert (proj.id, "Development") in exc.value.pairs
 
 
+def test_import_force_imports_unresolved_as_null(session):
+    """IP2: force=True imports despite an unmapped position-mode level; the booking stays
+    unresolved (billing_position_id=None) rather than aborting."""
+    from sqlmodel import select
+
+    _make_person(session)
+    proj = _make_project(session)
+    proj.position_mode = True
+    _make_mapping(session, "P00001 Analytics", proj.id)
+    _priced_position(session, proj.id)  # position mode, no level mapping
+    session.commit()
+
+    result = import_bookings(_csv([_ROW]), session, force=True)
+    assert result.inserted == 1
+    booking = session.exec(select(TimeBooking)).first()
+    assert booking.billing_position_id is None
+
+
 def test_position_mapping_is_project_scoped(session):
     # Two projects with an identically-named level ("Development") must resolve to their
     # OWN position — no cross-project mixing (finding 2026-07-16).

--- a/backend/tests/unit/test_services_importer.py
+++ b/backend/tests/unit/test_services_importer.py
@@ -450,6 +450,32 @@ def test_import_simple_mode_leaves_position_null(session):
     assert booking.billing_position_id is None
 
 
+def test_backfill_bookings_for_level(session):
+    """IP4: applying a mapping re-assigns existing bookings of that level (re-import wouldn't)."""
+    from sqlmodel import select
+
+    from app.services.importer import backfill_bookings_for_level
+
+    def _tb(level, day):
+        return TimeBooking(
+            booking_date=date(2026, 1, day), person_id=1, project_id=1, import_batch_id=1,
+            sage_project_name="X", sage_project_level=level, billing_position_id=None, net_hours=1.0,
+        )
+    session.add(_tb("Dev", 1))
+    session.add(_tb("Dev", 2))
+    session.add(_tb("Ops", 3))
+    session.commit()
+
+    n = backfill_bookings_for_level(1, "Dev", 42, session)
+    assert n == 2
+    rows = session.exec(select(TimeBooking)).all()
+    assert sorted((r.sage_project_level, r.billing_position_id) for r in rows) == [
+        ("Dev", 42), ("Dev", 42), ("Ops", None),
+    ]
+    # clearing (mapping deleted) sets them back to NULL
+    assert backfill_bookings_for_level(1, "Dev", None, session) == 2
+
+
 # ---------------------------------------------------------------------------
 # Hypothesis: parse_rows is stable under date format variation
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -194,3 +194,35 @@ def test_position_mode_unresolved_booking_excluded_and_warned(session):
     assert all(p.booked_hours == 0 for p in jan.persons if p.person_id == person.id)
     # ...and its existence is flagged
     assert any("ohne Posten" in w for w in jan.warnings)
+
+
+def test_closed_milestone_shows_ist_in_position_mode(session):
+    """Regression (Feedback): even in position mode, a CLOSED month's Ist is historical and
+    must always show — NULL-position bookings are attributed (not treated as unresolved)."""
+    from datetime import date as _date
+
+    from app.models.timebooking import TimeBooking
+    from app.routers.milestones import list_milestones_detail
+
+    proj, pos_a, pos_b, person = _setup(session, budget_a=1_000_000.0, budget_b=1_000_000.0)
+    assert proj.position_mode is True
+    ms = Milestone(project_id=proj.id, year=2026, month=1, initial_hours=10.0,
+                   current_hours=10.0, is_locked=True)
+    session.add(ms)
+    session.flush()
+    session.add(MilestonePersonBudget(
+        milestone_id=ms.id, person_id=person.id, billing_position_id=pos_a.id,
+        initial_hours=10.0, current_hours=10.0,
+    ))
+    session.add(TimeBooking(
+        booking_date=_date(2026, 1, 10), person_id=person.id, project_id=proj.id,
+        import_batch_id=1, sage_project_name="X", sage_project_level="Y",
+        billing_position_id=None, net_hours=7.0,
+    ))
+    session.commit()
+
+    detail = list_milestones_detail(proj.id, session)
+    jan = next(m for m in detail if m.milestone.month == 1)
+    mine = [p for p in jan.persons if p.person_id == person.id]
+    assert abs(sum(p.booked_hours for p in mine) - 7.0) < 1e-6   # Ist shown despite position mode
+    assert not any("ohne Posten" in w for w in jan.warnings)      # no unresolved warning on closed month

--- a/backend/tests/unit/test_services_milestones_multiassign.py
+++ b/backend/tests/unit/test_services_milestones_multiassign.py
@@ -140,9 +140,10 @@ def test_detail_shows_legacy_null_position_budget_row(session):
 
 
 def test_booked_without_position_attributed_to_primary_row(session):
-    """Regression: bookings without a position (NULL — simple-mode / unmapped import) must
-    still show as Ist. They can't be split across a person's positions, so they go to the
-    person's primary budget row exactly once (total preserved, not doubled, not lost)."""
+    """Regression: in SIMPLE mode, bookings without a position (NULL) must still show as Ist.
+    They can't be split across a person's positions, so they go to the person's primary
+    budget row exactly once (total preserved, not doubled, not lost). (In position mode they
+    are instead treated as unresolved — see test_position_mode_unresolved_booking_*.)"""
     from datetime import date as _date
 
     from app.models.timebooking import TimeBooking
@@ -150,6 +151,10 @@ def test_booked_without_position_attributed_to_primary_row(session):
 
     proj, pos_a, pos_b, person = _setup(session, budget_a=1_000_000.0, budget_b=1_000_000.0)
     initialize_milestones(proj.id, session)
+    # Simple mode: NULL-position bookings are attributed (not "unresolved").
+    proj.position_mode = False
+    session.add(proj)
+    session.commit()
     session.add(TimeBooking(
         booking_date=_date(2026, 1, 15), person_id=person.id, project_id=proj.id,
         import_batch_id=1, sage_project_name="X", sage_project_level="Y",
@@ -163,3 +168,29 @@ def test_booked_without_position_attributed_to_primary_row(session):
     assert len(mine) == 2  # one row per position
     assert abs(sum(p.booked_hours for p in mine) - 8.0) < 1e-6  # total preserved
     assert sum(1 for p in mine if p.booked_hours > 0) == 1      # attributed to exactly one row
+
+
+def test_position_mode_unresolved_booking_excluded_and_warned(session):
+    """IP5: in position mode a booking without a Posten is unresolved — it must NOT count
+    toward any posten's Ist and its existence is flagged as a milestone warning."""
+    from datetime import date as _date
+
+    from app.models.timebooking import TimeBooking
+    from app.routers.milestones import list_milestones_detail
+
+    proj, pos_a, pos_b, person = _setup(session, budget_a=1_000_000.0, budget_b=1_000_000.0)
+    assert proj.position_mode is True
+    initialize_milestones(proj.id, session)
+    session.add(TimeBooking(
+        booking_date=_date(2026, 1, 15), person_id=person.id, project_id=proj.id,
+        import_batch_id=1, sage_project_name="X", sage_project_level="Y",
+        billing_position_id=None, net_hours=8.0,
+    ))
+    session.commit()
+
+    detail = list_milestones_detail(proj.id, session)
+    jan = next(m for m in detail if m.milestone.month == 1)
+    # unresolved NULL-position booking not attributed to any posten row
+    assert all(p.booked_hours == 0 for p in jan.persons if p.person_id == person.id)
+    # ...and its existence is flagged
+    assert any("ohne Posten" in w for w in jan.warnings)

--- a/docs/implementation/24-import-level-position-mapping.md
+++ b/docs/implementation/24-import-level-position-mapping.md
@@ -1,0 +1,96 @@
+# Import: Projektebene → Posten mappen, Konflikte auflösen, Ist konsistent halten
+
+_Status: 📋 Design & Implementierungsplan_
+_Datum: 2026-07-20_
+_Betrifft: `services/importer.py`, `routers/imports.py`, `routers/projects.py`, `services/milestones.py`,
+`models/timebooking.py`, `frontend/src/pages/ImportPage.tsx`, `ProjectDetailPage.tsx`, `MappingsPage.tsx`_
+_Baut auf: [23-posten-multi-assignment.md](23-posten-multi-assignment.md) (WP4)_
+
+---
+
+## 1. Ziel
+Jede importierte Buchung trägt den korrekten **Posten**, sobald das Projekt Posten hat. Nicht
+eindeutig auflösbare Buchungen werden **beim Import sichtbar und dort auflösbar** (blockierend, mit
+Prompt), sind aber auf Wunsch mit **starker Warnung erzwingbar** — dann als **unaufgelöst geflaggt**,
+aus den Posten-Berechnungen ausgenommen und in der Meilensteinansicht klar signalisiert. Die
+Buchungstabelle zeigt die Zuordnung; Modus-Wechsel und spätere Mapping-Änderungen halten alles
+konsistent.
+
+## 2. Grundsatz (bestätigt)
+Die Ebene→Posten-Zuordnung ist **projektweit** (eine Projektebene = ein Posten). Sie wird **nicht**
+aus dem (evtl. einzigen) Posten *einer* Person abgeleitet — das wäre für andere Bucher derselben
+Ebene ggf. falsch. Beobachtete Projektebenen aus Buchungen geben aber Hinweise auf das Projekt und
+dienen als **Vorschläge** im Resolver/Editor.
+
+## 3. Auflösungsregel (deterministisch, pro Buchung)
+| Projekt-Situation | Ergebnis |
+|---|---|
+| 0 Posten | `billing_position_id = NULL`, keine Warnung (echter Simple-Fall) |
+| Mapping (Projekt, Ebene) vorhanden | → dieser Posten (gewinnt immer, **unabhängig vom Modus**) |
+| Kein Mapping, genau 1 Posten | Vorschlag im Resolver → **einmalige Bestätigung** (kein stilles Persistieren, s. §4a) |
+| Kein Mapping, ≥ 2 Posten | **ungelöst → Resolver** (Ebene einem Posten zuordnen → erzeugt Mapping) |
+
+Auflösung läuft **immer, wenn das Projekt ≥ 1 Posten hat** (nicht nur im Posten-Modus), damit ein
+späteres Aktivieren des Posten-Modus nahtlos ist.
+
+## 4. Import-Ablauf
+- **Blockierend + Prompt:** ungelöste `(Projekt, Ebene)` werden — analog zum bestehenden Projekt-/
+  Personen-Resolver — vor dem Import abgefragt. Der Nutzer weist die Ebene einem **vorhandenen**
+  Posten zu (oder legt zuvor einen Posten an). Daraus wird ein `SagePositionMapping` abgeleitet.
+- **(a) Einmalige Bestätigung auch im 1-Posten-Fall:** Der Resolver schlägt den einzigen Posten vor,
+  persistiert das Mapping aber erst nach Bestätigung. Grund: Enthält ein Import nur eine Ebene,
+  obwohl später weitere dazukommen, wäre eine stille Auto-Zuweisung ggf. falsch.
+- **Erzwingen möglich:** Mit **starker Warnung** kann der Import trotz ungelöster Ebenen erzwungen
+  werden — **nur wenn dadurch nichts kaputtgeht**. Die betroffenen Buchungen werden importiert, aber
+  **unaufgelöst** (siehe §6).
+
+## 5. Buchungstabelle (Projekt) + Inline-Mapping-Editor
+- Neue Spalte **Posten** (aufgelöst) neben `Projektebene`; **unaufgelöste** Buchungen rot markiert.
+  Dazu `billing_position_id`/Posten-Label in `BookingOut`/`TimeBookingOut` ergänzen.
+- **Inline-Editor**: direkt in den Projekt-Buchungen die Zuordnung *Projektebene → Posten* bearbeiten
+  (erzeugt/ändert `SagePositionMapping`), mit Vorschlägen (vorhandene Ebenen via `sageLevels()`,
+  vorhandene Posten). Änderung wirkt per Backfill auf bestehende Buchungen der Ebene (§7).
+
+## 6. Unaufgelöste Buchungen (erzwungener Import / Posten-Modus)
+- Definition: **Posten-Modus aktiv** (bzw. Projekt hat Posten) **und** `billing_position_id = NULL`.
+- Diese Buchungen **gehen nicht in Posten-Berechnungen ein** (kein eindeutiger Posten → keine
+  Ist-Zuordnung, keine Abrechnung je Posten).
+- Sie erscheinen in den Projekt-Buchungen **geflaggt**.
+- **Meilensteinansicht** zeigt eine klare Warnung, dass unaufgelöste Buchungen existieren (mit Anzahl).
+- Abgrenzung: Im **Simple-Modus** ist `NULL` normal (kein Posten-Konzept) → dann der Personen-primär-
+  Zeile zugeordnet (doc 23 Ist-Fix), **nicht** „unaufgelöst".
+
+## 7. Konsistenz-Hooks (Backfill)
+- **Mapping angelegt/geändert** (Resolver, Inline-Editor, MappingsPage): bestehende Buchungen der
+  betroffenen Ebene neu auflösen. Nötig, weil Re-Import sie wegen des Dedup-Schlüssels überspringt
+  (`billing_position_id` ist nicht Teil des Unique-Keys).
+- **Posten-Modus aktivieren**: bestehende NULL-Buchungen aus den vorhandenen Mappings (bzw. dem
+  einzigen, bestätigten Posten) nachziehen; verbleibende unaufgelöste melden.
+- **Posten gelöscht**: Mappings, die darauf zeigen, würden verwaisen → Löschen blockieren, solange
+  ein Mapping/Buchung referenziert (analog zur bestehenden Membership-Prüfung).
+
+## 8. Warnungs-Taxonomie (nach Auflösung, weich)
+1. **Person-Mismatch** (WP4, vorhanden): Buchung auf Posten X, MA ist X nicht zugewiesen.
+2. **Verifizieren bei Mehrdeutigkeit**: MA nur einem Posten zugewiesen, es gibt aber mehrere → Hinweis
+   „gebucht auf X — bitte prüfen".
+- `is_excluded`-Buchungen aus allen Warnungen ausnehmen.
+
+## 9. Zusätzlich betrachtete Fälle (über die ursprüngliche Liste hinaus)
+- Modus *aus* + ≥ 2 Posten + kein Mapping → ebenfalls Resolver (nicht nur der 1-Posten-Fall).
+- Mapping *später* geändert → Backfill (Re-Import repariert nicht, §7).
+- Verwaistes Mapping (Posten gelöscht) → Löschsperre/Warnung.
+- Ausgeschlossene Buchungen von Warnungen ausnehmen.
+
+## 10. Arbeitspakete
+- **IP1** Backend-Auflösung: `billing_position_id` bei jedem Projekt mit Posten auflösen; Import liefert
+  strukturierte „ungelöste Ebenen" + Warnungen (kein stiller Hard-Abort mehr).
+- **IP2** Import-Resolver + Erzwingen: Inline-Auflösung ungelöster Ebenen (1-Posten mit Bestätigung;
+  Posten anlegen möglich); Force-Import mit starker Warnung → geflaggte unaufgelöste Buchungen.
+- **IP3** Buchungstabelle: Posten-Spalte + Unaufgelöst-Flag + Inline-Mapping-Editor mit Vorschlägen.
+- **IP4** Backfill-Hooks: Mapping-Anlegen/-Ändern und Posten-Modus-Aktivieren ziehen bestehende
+  Buchungen nach; Löschsperre für referenzierte Posten.
+- **IP5** Berechnungen + Meilenstein-Warnung: unaufgelöste Buchungen aus Posten-Berechnungen
+  ausnehmen; Meilensteinansicht signalisiert deren Existenz.
+
+Reihenfolge: IP1 → IP5 → IP3 → IP2 → IP4 (Fundament + Korrektheits-Schutz zuerst, dann Sichtbarkeit,
+dann Import-UX, zuletzt die Konsistenz-Automatik).

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,7 +1,7 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Upload, CheckCircle, AlertCircle, FileText, RefreshCw, ChevronDown, ChevronRight, Flag, RotateCcw } from 'lucide-react'
-import { projects, mappings, persons, imports as importsApi, bookings as bookingsApi, type ImportBatch, type TimeBooking, type ExclusionReason } from '../api'
+import { projects, mappings, persons, positionMappings, imports as importsApi, bookings as bookingsApi, type ImportBatch, type TimeBooking, type ExclusionReason, type BillingPosition } from '../api'
 import PageHeader from '../components/PageHeader'
 
 const BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? '/api'
@@ -21,9 +21,15 @@ interface ParseErrorRow {
   message: string
 }
 
+interface UnresolvedPosition {
+  project_id: number
+  sage_project_level: string
+}
+
 interface ImportError422 {
   unresolved_projects?: string[]
   unmatched_persons?: string[]
+  unresolved_positions?: UnresolvedPosition[]
   detail?: string
   parse_errors?: ParseErrorRow[]
 }
@@ -33,20 +39,21 @@ type PageState =
   | { kind: 'uploading' }
   | { kind: 'unresolved'; names: string[]; file: File | string }
   | { kind: 'unmatched'; names: string[]; file: File | string }
+  | { kind: 'positions_unresolved'; pairs: UnresolvedPosition[]; file: File | string }
   | { kind: 'parse_error'; message: string; errors: ParseErrorRow[] }
   | { kind: 'success'; result: ImportResultOut }
   | { kind: 'error'; message: string }
 
 // ─── Upload helper ────────────────────────────────────────────────────────────
 
-async function postImport(source: File | string): Promise<{ ok: true; result: ImportResultOut } | { ok: false; error: ImportError422 }> {
+async function postImport(source: File | string, force = false): Promise<{ ok: true; result: ImportResultOut } | { ok: false; error: ImportError422 }> {
   const form = new FormData()
   if (typeof source === 'string') {
     form.append('file', new Blob([source], { type: 'text/csv' }), 'paste.csv')
   } else {
     form.append('file', source)
   }
-  const res = await fetch(`${BASE}/imports`, { method: 'POST', body: form })
+  const res = await fetch(`${BASE}/imports${force ? '?force=true' : ''}`, { method: 'POST', body: form })
   if (res.status === 201) {
     return { ok: true, result: await res.json() as ImportResultOut }
   }
@@ -458,6 +465,140 @@ function PersonResolver({
   )
 }
 
+// ─── Position (Projektebene → Posten) resolver ─────────────────────────────────
+
+function PositionResolver({
+  pairs, onResolved, onCancel, onForce,
+}: {
+  pairs: UnresolvedPosition[]
+  onResolved: () => void
+  onCancel: () => void
+  onForce: () => void
+}) {
+  const qc = useQueryClient()
+  const { data: projectList = [] } = useQuery({ queryKey: ['projects'], queryFn: projects.list })
+  const projectIds = [...new Set(pairs.map((p) => p.project_id))]
+  const { data: posByProject = {} } = useQuery({
+    queryKey: ['positions-for-resolve', projectIds],
+    queryFn: async () => {
+      const entries = await Promise.all(
+        projectIds.map(async (pid) => [pid, await projects.billingPositions(pid)] as const),
+      )
+      return Object.fromEntries(entries) as Record<number, BillingPosition[]>
+    },
+  })
+  const key = (p: UnresolvedPosition) => `${p.project_id}|${p.sage_project_level}`
+  const projLabel = (pid: number) => {
+    const p = projectList.find((x) => x.id === pid)
+    return p ? p.project_number : `#${pid}`
+  }
+  const [sel, setSel] = useState<Record<string, number>>({})
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Pre-select the sole Posten of a project (still requires confirmation via Save) — a level
+  // that only appears in this import must not silently persist a mapping (doc 24 IP2).
+  useEffect(() => {
+    setSel((prev) => {
+      const next = { ...prev }
+      for (const p of pairs) {
+        const k = key(p)
+        if (next[k] == null) {
+          const list = posByProject[p.project_id] ?? []
+          next[k] = list.length === 1 ? list[0].id : 0
+        }
+      }
+      return next
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [posByProject])
+
+  const allMapped = pairs.every((p) => (sel[key(p)] ?? 0) > 0)
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    try {
+      for (const p of pairs) {
+        const posId = sel[key(p)] ?? 0
+        if (posId > 0)
+          await positionMappings.create({ project_id: p.project_id, sage_project_level: p.sage_project_level, billing_position_id: posId })
+      }
+      qc.invalidateQueries({ queryKey: ['sage-position-mappings'] })
+      onResolved()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+      <div className="flex items-start gap-2 mb-3">
+        <AlertCircle size={16} className="text-yellow-600 mt-0.5 flex-shrink-0" />
+        <div>
+          <p className="text-sm font-medium text-yellow-800">Projektebenen ohne Posten-Zuordnung</p>
+          <p className="text-xs text-yellow-700 mt-0.5">
+            Im Posten-Modus muss jede Projektebene einem Posten zugeordnet sein. Bitte zuordnen
+            (oder in den Projekteinstellungen einen Posten anlegen), dann erneut importieren.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2 mb-4">
+        {pairs.map((p) => {
+          const list = posByProject[p.project_id] ?? []
+          return (
+            <div key={key(p)} className="flex items-center gap-3">
+              <span className="text-sm text-gray-700 min-w-[16rem] truncate">
+                <span className="font-mono">{projLabel(p.project_id)}</span>
+                <span className="text-gray-400"> · </span>
+                <span className="font-mono">{p.sage_project_level}</span>
+              </span>
+              <span className="text-gray-400">→</span>
+              <select
+                className="flex-1 border border-gray-300 rounded px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                value={sel[key(p)] ?? 0}
+                onChange={(e) => setSel((s) => ({ ...s, [key(p)]: parseInt(e.target.value) }))}
+              >
+                <option value={0} disabled>— Posten wählen —</option>
+                {list.map((bp) => (
+                  <option key={bp.id} value={bp.id}>{bp.position_number}{bp.description ? ` – ${bp.description}` : ''}</option>
+                ))}
+              </select>
+            </div>
+          )
+        })}
+      </div>
+
+      {error && <p className="text-xs text-red-600 mb-3">{error}</p>}
+
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => { if (window.confirm('Import ERZWINGEN? Die betroffenen Buchungen bleiben ohne Posten (unaufgelöst), gehen NICHT in die Posten-Berechnung ein und werden im Meilenstein gewarnt. Erst nach nachträglicher Zuordnung fließen sie ein.')) onForce() }}
+          className="text-xs text-red-600 hover:text-red-800 underline"
+        >
+          Trotzdem importieren (erzwingen)
+        </button>
+        <div className="flex gap-2">
+          <button type="button" onClick={onCancel} className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
+          <button
+            type="button"
+            disabled={!allMapped || saving}
+            onClick={handleSave}
+            className="flex items-center gap-1.5 px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? <RefreshCw size={14} className="animate-spin" /> : <CheckCircle size={14} />}
+            Zuordnen &amp; erneut importieren
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function ImportPage() {
@@ -474,10 +615,10 @@ export default function ImportPage() {
     },
   })
 
-  async function runImport(source: File | string) {
+  async function runImport(source: File | string, force = false) {
     setState({ kind: 'uploading' })
     try {
-      const outcome = await postImport(source)
+      const outcome = await postImport(source, force)
       if (outcome.ok) {
         setState({ kind: 'success', result: outcome.result })
         void refetchBatches()
@@ -489,6 +630,8 @@ export default function ImportPage() {
           setState({ kind: 'unresolved', names: error.unresolved_projects, file: source })
         } else if (error.unmatched_persons?.length) {
           setState({ kind: 'unmatched', names: error.unmatched_persons, file: source })
+        } else if (error.unresolved_positions?.length) {
+          setState({ kind: 'positions_unresolved', pairs: error.unresolved_positions, file: source })
         } else {
           setState({ kind: 'error', message: error.detail ?? 'Unbekannter Fehler.' })
         }
@@ -619,6 +762,15 @@ export default function ImportPage() {
                 unmatchedNames={state.names}
                 onResolved={() => void runImport(state.file)}
                 onCancel={() => setState({ kind: 'idle' })}
+              />
+            )}
+
+            {state.kind === 'positions_unresolved' && (
+              <PositionResolver
+                pairs={state.pairs}
+                onResolved={() => void runImport(state.file)}
+                onCancel={() => setState({ kind: 'idle' })}
+                onForce={() => void runImport(state.file, true)}
               />
             )}
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -112,6 +112,9 @@ function BookingsTab({ projectId, memberships }: { projectId: number; membership
   const [sortKey, setSortKey] = useState<SortKey>('booking_date')
   const [sortAsc, setSortAsc] = useState(false)
   const { data: allPersons = [] } = useQuery({ queryKey: ['persons'], queryFn: persons.list })
+  const { data: positions = [] } = useQuery({ queryKey: ['billingPositions', projectId], queryFn: () => projects.billingPositions(projectId) })
+  const posById = new Map(positions.map((p) => [p.id, p]))
+  const hasPositions = positions.length > 0
 
   const filters = {
     ...(filterPerson > 0 && { person_id: filterPerson }),
@@ -219,6 +222,7 @@ function BookingsTab({ projectId, memberships }: { projectId: number; membership
               <SortTh k="booking_date" label="Datum" />
               <SortTh k="person_name" label="Person" />
               <SortTh k="sage_project_level" label="Projektebene" title="Sage-Projektebene 1" />
+              {hasPositions && <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase" title="Aufgelöster Projektposten (aus dem Projektebene→Posten-Mapping)">Posten</th>}
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Dauer (roh)</th>
               <SortTh k="net_hours" label="Std." />
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bemerkung</th>
@@ -227,13 +231,20 @@ function BookingsTab({ projectId, memberships }: { projectId: number; membership
           </thead>
           <tbody className="divide-y divide-gray-100">
             {!isLoading && sorted.length === 0 && (
-              <tr><td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">Keine Buchungen für diesen Filter.</td></tr>
+              <tr><td colSpan={hasPositions ? 8 : 7} className="px-4 py-8 text-center text-sm text-gray-400">Keine Buchungen für diesen Filter.</td></tr>
             )}
             {sorted.map(b => (
               <tr key={b.id} className={b.is_excluded ? 'bg-red-50' : 'hover:bg-gray-50'}>
                 <td className={`px-4 py-2.5 text-sm font-mono ${b.is_excluded ? 'text-red-400 line-through' : 'text-gray-700'}`}>{b.booking_date}</td>
                 <td className={`px-4 py-2.5 text-sm ${b.is_excluded ? 'text-red-400 line-through' : 'text-gray-700'}`}>{b.person_name}</td>
                 <td className={`px-4 py-2.5 text-sm ${b.is_excluded ? 'text-red-300 line-through' : 'text-gray-600'}`}>{b.sage_project_level}</td>
+                {hasPositions && (
+                  <td className="px-4 py-2.5 text-sm">
+                    {b.billing_position_id != null
+                      ? <span className="text-gray-700">{posById.get(b.billing_position_id)?.position_number ?? `#${b.billing_position_id}`}</span>
+                      : <span className="px-1.5 py-0.5 rounded text-[11px] font-medium bg-red-100 text-red-700" title="Keinem Posten zugeordnet – Projektebene→Posten-Mapping prüfen">nicht zugeordnet</span>}
+                  </td>
+                )}
                 <td className={`px-4 py-2.5 text-sm font-mono ${b.is_excluded ? 'text-red-300 line-through' : 'text-gray-500'}`}>{b.duration_raw || '–'}</td>
                 <td className={`px-4 py-2.5 text-sm font-mono text-right ${b.is_excluded ? 'text-red-400 line-through' : 'text-gray-800'}`}>{b.net_hours.toFixed(2)}</td>
                 <td className="px-4 py-2.5 text-xs text-gray-400 max-w-[8rem] truncate">{b.note || ''}</td>
@@ -244,7 +255,7 @@ function BookingsTab({ projectId, memberships }: { projectId: number; membership
           {sorted.length > 0 && (
             <tfoot className="bg-gray-50 font-medium text-gray-700">
               <tr>
-                <td colSpan={4} className="px-4 py-2.5 text-sm">Gesamt (aktiv)</td>
+                <td colSpan={hasPositions ? 5 : 4} className="px-4 py-2.5 text-sm">Gesamt (aktiv)</td>
                 <td className="px-4 py-2.5 text-sm font-mono text-right">{totalHours.toFixed(2)}</td>
                 <td colSpan={2} />
               </tr>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ChevronLeft, RefreshCw, Lock, Unlock, FileText, Plus, Trash2, ChevronDown, ChevronRight, Pencil, Flag, RotateCcw, Mail, Copy, AlertTriangle } from 'lucide-react'
 import {
-  projects, persons, programs, invoices as invoiceApi, bookings as bookingsApi, ApiError,
+  projects, persons, programs, invoices as invoiceApi, bookings as bookingsApi, positionMappings, ApiError,
   type Project, type Program, type ProjectMembership, type MonthlyInvoice, type MilestoneDetail, type TimeBooking, type ExclusionReason, type BillingPosition,
 } from '../api'
 import Modal from '../components/Modal'
@@ -104,7 +104,67 @@ function FlagCell({ booking, queryKey }: { booking: TimeBooking; queryKey: unkno
 
 type SortKey = 'booking_date' | 'person_name' | 'net_hours' | 'sage_project_level'
 
+/** Inline editor for the project's Projektebene→Posten mappings, shown above the bookings
+ *  table (doc 24 IP3/IP4). Changing a mapping backfills existing bookings server-side. */
+function LevelMappingEditor({ projectId, positions, onChanged }: {
+  projectId: number; positions: BillingPosition[]; onChanged: () => void
+}) {
+  const qc = useQueryClient()
+  const { data: levels = [] } = useQuery({ queryKey: ['sage-levels', projectId], queryFn: () => projects.sageLevels(projectId) })
+  const { data: maps = [] } = useQuery({ queryKey: ['sage-position-mappings', projectId], queryFn: () => positionMappings.list(projectId) })
+  const [err, setErr] = useState<string | null>(null)
+  const mapByLevel = new Map(maps.map((m) => [m.sage_project_level, m]))
+
+  const setMapping = useMutation({
+    mutationFn: async ({ level, posId }: { level: string; posId: number | null }) => {
+      const existing = mapByLevel.get(level)
+      if (posId == null) {
+        if (existing) await positionMappings.delete(existing.id)
+        return
+      }
+      if (existing) {
+        if (existing.billing_position_id !== posId)
+          await positionMappings.update(existing.id, { project_id: projectId, sage_project_level: level, billing_position_id: posId })
+      } else {
+        await positionMappings.create({ project_id: projectId, sage_project_level: level, billing_position_id: posId })
+      }
+    },
+    onSuccess: () => { setErr(null); qc.invalidateQueries({ queryKey: ['sage-position-mappings', projectId] }); onChanged() },
+    onError: (e: Error) => setErr(errText(e)),
+  })
+
+  if (positions.length === 0 || levels.length === 0) return null
+  return (
+    <div className="mb-4 bg-white rounded-lg border border-gray-200 p-3">
+      <div className="text-xs font-medium text-gray-600 mb-2">Projektebene → Posten Zuordnung</div>
+      <div className="space-y-1.5">
+        {levels.map((level) => {
+          const m = mapByLevel.get(level)
+          return (
+            <div key={level} className="flex items-center gap-2 text-sm">
+              <span className="w-56 truncate text-gray-700" title={level}>{level}</span>
+              <span className="text-gray-300">→</span>
+              <select className="border border-gray-300 rounded px-2 py-1 text-sm min-w-[12rem]"
+                value={m?.billing_position_id ?? ''}
+                onChange={(e) => setMapping.mutate({ level, posId: e.target.value === '' ? null : parseInt(e.target.value) })}>
+                <option value="">— nicht zugeordnet —</option>
+                {positions.map((p) => (
+                  <option key={p.id} value={p.id}>{p.position_number}{p.description ? ` – ${p.description}` : ''}</option>
+                ))}
+              </select>
+              {!m && <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-100 text-red-700">offen</span>}
+            </div>
+          )
+        })}
+      </div>
+      {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
+      <p className="mt-2 text-[11px] text-gray-400">Änderungen wirken sofort auf bestehende Buchungen dieser Ebene.</p>
+    </div>
+  )
+}
+
 function BookingsTab({ projectId, memberships }: { projectId: number; memberships: ProjectMembership[] }) {
+  const qc = useQueryClient()
   const [filterPerson, setFilterPerson] = useState(0)
   const [filterYear, setFilterYear] = useState(new Date().getFullYear())
   const [filterMonth, setFilterMonth] = useState(0)   // 0 = all months
@@ -213,6 +273,10 @@ function BookingsTab({ projectId, memberships }: { projectId: number; membership
           {isLoading ? 'Lade…' : <><span className="font-medium text-gray-800">{activeBookings.length}</span> Buchungen · <span className="font-medium text-gray-800">{totalHours.toFixed(2)} h</span>{bookings.length > activeBookings.length && <span className="text-red-400 ml-1">({bookings.length - activeBookings.length} ausgeschlossen)</span>}</>}
         </div>
       </div>
+
+      {/* Projektebene → Posten mapping editor (doc 24 IP3/IP4) */}
+      <LevelMappingEditor projectId={projectId} positions={positions}
+        onChanged={() => qc.invalidateQueries({ queryKey: ['project-bookings', projectId] })} />
 
       {/* Table */}
       <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">


### PR DESCRIPTION
## Zusammenfassung
Import: Sage-Projektebene → Posten sauber zuordnen, Konflikte beim Import aufloesen, und die
Zuordnung/Ist ueberall konsistent halten. Plan: `docs/implementation/24-import-level-position-mapping.md`.

### Was drin ist (IP1-IP5)
- **IP3** Buchungstabelle zeigt je Buchung den aufgeloesten Posten; unzugeordnete rot als
  "nicht zugeordnet".
- **IP4** Inline-Editor "Projektebene -> Posten" ueber der Buchungstabelle (anlegen/aendern/
  loeschen) mit Vorschlaegen; Backfill bestehender Buchungen bei Mapping-Aenderung und beim
  Aktivieren des Posten-Modus; Posten-Loeschung gesperrt solange Mapping/Buchung referenziert.
- **IP5** Im Posten-Modus zaehlen posten-lose Buchungen nicht in die Posten-Berechnung und
  werden im Meilenstein gewarnt; abgeschlossene Monate zeigen ihr Ist immer (Historie).
- **IP1/IP2** Import-Resolver: ungeloeste (Projekt, Ebene) blockieren den Import und werden
  inline einem Posten zugeordnet (einziger Posten vorgeschlagen, aber mit Bestaetigung);
  "Trotzdem importieren (erzwingen)" mit starker Warnung -> unaufgeloest importiert.

Grundsatz: Ebene->Posten ist projektweit; nicht aus dem Posten einer einzelnen Person abgeleitet.

Keine Schema-Migration noetig (nutzt bestehende Spalten). 518 Tests gruen, Frontend tsc sauber.

Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
