### PR TITLE
Nacharbeiten + App-Versionierung + Posten-Modus Hilfetexte (#8)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing / Versionierung
+
+Die App-Version folgt **SemVer** und lebt in `frontend/package.json` (Single Source of Truth).
+Die UI zeigt sie via `__APP_VERSION__` (Vite `define`) an — nie hartkodieren.
+
+## Prozess (Conventional Commits + commit-and-tag-version)
+
+Commits werden im **Conventional-Commits**-Format geschrieben (machen wir bereits):
+`feat: …`, `fix: …`, `docs: …`, `refactor: …`, `perf: …`, `chore: …`, `test: …`,
+Breaking Change via `feat!: …` oder `BREAKING CHANGE:` im Body.
+
+Der Versionssprung wird daraus **automatisch** abgeleitet:
+- `fix` → Patch (0.2.0 → 0.2.1)
+- `feat` → Minor (0.2.0 → 0.3.0)
+- `feat!` / `BREAKING CHANGE` → Major (0.2.0 → 1.0.0)
+
+### Release durchführen
+Vor (oder direkt nach) dem `dev → main`-Merge, im Ordner `frontend/`:
+
+```bash
+npm run release:dry   # Vorschau: welcher Bump, welche Changelog-Einträge (ändert nichts)
+npm run release       # bumpt package.json, schreibt CHANGELOG.md, committet, setzt Git-Tag vX.Y.Z
+git push --follow-tags
+```
+
+`commit-and-tag-version` bestimmt den Bump aus den Commits seit dem letzten Tag,
+aktualisiert `package.json` + `package-lock.json`, pflegt `frontend/CHANGELOG.md`,
+erstellt den Release-Commit (`chore(release): X.Y.Z`) und den Tag `vX.Y.Z`.
+
+Bump bei Bedarf erzwingen: `npm run release -- --release-as minor` (bzw. `patch`/`major`).
+
+### Erste Ausführung (Baseline)
+Es existiert noch **kein** Git-Tag. Beim ersten `npm run release` scannt das Tool die
+gesamte Historie und schlägt daher einen Versionssprung vor, der die Vergangenheit
+mit einschließt (im Dry-Run z. B. `v0.2.1`). Zwei saubere Optionen:
+- **Baseline explizit setzen:** `npm run release -- --release-as 0.2.0` erstellt Tag `v0.2.0`
+  als Startpunkt; alle folgenden Releases bumpen dann korrekt ab diesem Tag.
+- **Oder** den vorgeschlagenen ersten Release einfach übernehmen — ab dann wird pro Tag
+  sauber weitergezählt.
+
+Ab dem ersten Tag ist der Prozess vollautomatisch aus den Commits abgeleitet.
+
+## Warum so
+- Kein CI nötig (läuft lokal), passt zum Workflow `feature → dev → (PR) → main`.
+- Nutzt die bereits gelebten Conventional Commits → keine zusätzliche Disziplin.
+- Kein erzwingender commit-msg-Hook (bewusst weggelassen) — die Commit-Konvention bleibt
+  Verabredung. Falls später Strenge gewünscht: husky + commitlint als commit-msg-Hook ergänzen.

--- a/frontend/.versionrc.json
+++ b/frontend/.versionrc.json
@@ -1,0 +1,15 @@
+{
+  "header": "# Changelog\n\nAlle nennenswerten Änderungen dieses Projekts. Format nach Conventional Commits / SemVer.\n",
+  "tagPrefix": "v",
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bugfixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactoring" },
+    { "type": "docs", "section": "Dokumentation" },
+    { "type": "chore", "hidden": true },
+    { "type": "test", "hidden": true },
+    { "type": "ci", "hidden": true },
+    { "type": "style", "hidden": true }
+  ]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query": "^5.99.2",
@@ -29,6 +29,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.5",
+        "commit-and-tag-version": "^13.0.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -382,6 +383,56 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.0.tgz",
+      "integrity": "sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^2.0.0",
+        "@simple-libs/stream-utils": "^2.0.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^6.0.1",
+        "conventional-commits-parser": "^7.0.1"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@conventional-changelog/git-client/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -859,6 +910,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.126.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
@@ -1168,6 +1232,78 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+      "integrity": "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/hosted-git-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-2.0.0.tgz",
+      "integrity": "sha512-55XwK/GYgV58PuN8lZFhI1qRxdKoMLJocXl/yM1EPqazFDmM4QWY7q6BxPCPDNKTNunj794DSD4h0H7SrqUdMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/normalize-package-data": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/normalize-package-data/-/normalize-package-data-1.0.0.tgz",
+      "integrity": "sha512-/EOmFBekV9tGee8gac/k+5Ox3twkypNqh5TfxA9vTkmcJkjm6f1xqrlstDNOrEhTvnYyVtU6Du2ZhY/IV1+9GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/hosted-git-info": "^2.0.0",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/normalize-package-data/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+      "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2214,7 +2350,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2235,12 +2370,38 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2424,6 +2585,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2453,12 +2629,266 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commit-and-tag-version": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/commit-and-tag-version/-/commit-and-tag-version-13.0.0.tgz",
+      "integrity": "sha512-iwd9fukyvUVzOFHJrqLwEhWZxxkxauUoF7inkReGFzb0YtglX/53PZ774AcJvekhlNkrKNgmtXWJf5WVafassw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/git-client": "3.1.0",
+        "chalk": "^2.4.2",
+        "conventional-changelog": "8.1.0",
+        "conventional-changelog-config-spec": "2.1.0",
+        "conventional-changelog-conventionalcommits": "10.2.1",
+        "conventional-recommended-bump": "12.1.0",
+        "detect-indent": "^6.1.0",
+        "detect-newline": "^3.1.0",
+        "dotgitignore": "^2.1.0",
+        "fast-xml-parser": "^5.5.6",
+        "figures": "^3.2.0",
+        "find-up": "^5.0.0",
+        "semver": "^7.7.2",
+        "yaml": "^2.6.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "commit-and-tag-version": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commit-and-tag-version/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/commit-and-tag-version/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/conventional-changelog": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-8.1.0.tgz",
+      "integrity": "sha512-idt1JK+3+Nt7gqH/d/sEYWdDeR+5XPov/jssmFN6XxmYSRlonTWSDWhWUPkmm0zbwYjtVdt+4My5aiPkKyvocw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^3.1.0",
+        "@simple-libs/hosted-git-info": "^2.0.0",
+        "@simple-libs/normalize-package-data": "^1.0.0",
+        "argue-cli": "^3.1.0",
+        "conventional-changelog-preset-loader": "^6.0.1",
+        "conventional-changelog-writer": "^9.2.0",
+        "conventional-commits-parser": "^7.1.0",
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-config-spec": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz",
+      "integrity": "sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-6.0.1.tgz",
+      "integrity": "sha512-GZ8E3RQzXQb3JFy0pKl8oeSf7ENIhvAMvJr+PlWkavZOesLHHdhkfNJ4SvW35eo1Fu2+EyVxWQ1tVvtzAG2iWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-9.2.0.tgz",
+      "integrity": "sha512-eACD5BaAQCYjeI3RExkCZopNaaIuXzCP4kaAb2lEFXcGa/KOuxJfj8v/SnjhvF6377pYn0A2Gji+6GhwUK8rEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1",
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0",
+        "conventional-commits-filter": "^6.0.1",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-recommended-bump": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-12.1.0.tgz",
+      "integrity": "sha512-HTNG3kEZXOOfKwrEx54ljURU9bG4nVPQzXMyCSeUcA/PE8EpNpQNujSrbXNBI8QZyN35zM+pVw+FuQk4KqHSHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^3.1.0",
+        "argue-cli": "^3.1.0",
+        "conventional-changelog-preset-loader": "^6.0.1",
+        "conventional-commits-filter": "^6.0.1",
+        "conventional-commits-parser": "^7.1.0"
+      },
+      "bin": {
+        "conventional-recommended-bump": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2706,11 +3136,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2723,12 +3173,99 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotgitignore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",
+      "integrity": "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dotgitignore/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dotgitignore/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dotgitignore/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotgitignore/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dotgitignore/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.343",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
       "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -3027,6 +3564,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3042,6 +3630,32 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3117,6 +3731,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob-parent": {
@@ -3274,6 +3898,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3292,6 +3926,19 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3973,6 +4620,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4007,6 +4664,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -4317,6 +4990,16 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4470,6 +5153,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4494,6 +5205,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/supports-color": {
@@ -4970,6 +5697,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -5048,6 +5785,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -5058,6 +5813,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -5065,12 +5836,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "release": "commit-and-tag-version",
+    "release:dry": "commit-and-tag-version --dry-run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.4",
@@ -36,6 +38,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
+    "commit-and-tag-version": "^13.0.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,7 @@ export default function App() {
             <Settings size={15} />
             Einstellungen
           </NavLink>
-          <p className="text-xs text-slate-400 px-3 pt-2">v0.2.0</p>
+          <p className="text-xs text-slate-400 px-3 pt-2">v{__APP_VERSION__}</p>
         </div>
       </aside>
 

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react'
 interface Column<T> {
   key: string
   header: string
+  /** Optional native tooltip shown on the column header (title attribute). */
+  headerTitle?: string
   render?: (row: T) => ReactNode
   className?: string
 }
@@ -25,7 +27,8 @@ export default function Table<T>({ columns, rows, onRowClick, keyFn, emptyMessag
               <th
                 key={col.key}
                 scope="col"
-                className={`px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider ${col.className ?? ''}`}
+                title={col.headerTitle}
+                className={`px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider ${col.headerTitle ? 'cursor-help' : ''} ${col.className ?? ''}`}
               >
                 {col.header}
               </th>

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -495,6 +495,34 @@ function PositionResolver({
   const [sel, setSel] = useState<Record<string, number>>({})
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Inline "create a Posten" (doc 24 IP2) — keyed by the row currently in create mode.
+  const [creatingFor, setCreatingFor] = useState<string | null>(null)
+  const [newPos, setNewPos] = useState({ position_number: '', billing_rate_per_hour: 0, budget_euros: 0 })
+  const [createErr, setCreateErr] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  async function createPosten(p: UnresolvedPosition) {
+    setCreating(true)
+    setCreateErr(null)
+    try {
+      const bp = await projects.addBillingPosition(p.project_id, {
+        position_number: newPos.position_number,
+        billing_rate_per_hour: newPos.billing_rate_per_hour,
+        budget_euros: newPos.budget_euros,
+      })
+      qc.invalidateQueries({ queryKey: ['positions-for-resolve'] })
+      setSel((s) => ({ ...s, [key(p)]: bp.id }))
+      setCreatingFor(null)
+      setNewPos({ position_number: '', billing_rate_per_hour: 0, budget_euros: 0 })
+    } catch (e) {
+      const msg = e instanceof Error && 'body' in e && typeof (e as { body?: unknown }).body === 'object'
+        ? String(((e as { body?: { detail?: unknown } }).body?.detail) ?? (e as Error).message)
+        : (e as Error).message
+      setCreateErr(msg)
+    } finally {
+      setCreating(false)
+    }
+  }
 
   // Pre-select the sole Posten of a project (still requires confirmation via Save) — a level
   // that only appears in this import must not silently persist a mapping (doc 24 IP2).
@@ -549,24 +577,60 @@ function PositionResolver({
       <div className="space-y-2 mb-4">
         {pairs.map((p) => {
           const list = posByProject[p.project_id] ?? []
+          const creatingHere = creatingFor === key(p)
           return (
-            <div key={key(p)} className="flex items-center gap-3">
-              <span className="text-sm text-gray-700 min-w-[16rem] truncate">
-                <span className="font-mono">{projLabel(p.project_id)}</span>
-                <span className="text-gray-400"> · </span>
-                <span className="font-mono">{p.sage_project_level}</span>
-              </span>
-              <span className="text-gray-400">→</span>
-              <select
-                className="flex-1 border border-gray-300 rounded px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                value={sel[key(p)] ?? 0}
-                onChange={(e) => setSel((s) => ({ ...s, [key(p)]: parseInt(e.target.value) }))}
-              >
-                <option value={0} disabled>— Posten wählen —</option>
-                {list.map((bp) => (
-                  <option key={bp.id} value={bp.id}>{bp.position_number}{bp.description ? ` – ${bp.description}` : ''}</option>
-                ))}
-              </select>
+            <div key={key(p)}>
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-gray-700 min-w-[16rem] truncate">
+                  <span className="font-mono">{projLabel(p.project_id)}</span>
+                  <span className="text-gray-400"> · </span>
+                  <span className="font-mono">{p.sage_project_level}</span>
+                </span>
+                <span className="text-gray-400">→</span>
+                <select
+                  className="flex-1 border border-gray-300 rounded px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={sel[key(p)] ?? 0}
+                  onChange={(e) => setSel((s) => ({ ...s, [key(p)]: parseInt(e.target.value) }))}
+                >
+                  <option value={0} disabled>— Posten wählen —</option>
+                  {list.map((bp) => (
+                    <option key={bp.id} value={bp.id}>{bp.position_number}{bp.description ? ` – ${bp.description}` : ''}</option>
+                  ))}
+                </select>
+                <button type="button"
+                  className="text-xs text-blue-600 hover:text-blue-800 whitespace-nowrap"
+                  onClick={() => { setCreateErr(null); setCreatingFor(creatingHere ? null : key(p)) }}>
+                  {creatingHere ? 'Abbrechen' : '＋ neuer Posten'}
+                </button>
+              </div>
+              {creatingHere && (
+                <div className="mt-2 ml-[17rem] flex flex-wrap items-end gap-2 bg-white border border-gray-200 rounded p-2">
+                  <div>
+                    <label className="block text-[10px] text-gray-500">Positionsnr.</label>
+                    <input className="border border-gray-300 rounded px-2 py-1 text-sm w-24" placeholder="z.B. AP1"
+                      value={newPos.position_number}
+                      onChange={(e) => setNewPos((n) => ({ ...n, position_number: e.target.value }))} />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] text-gray-500">Satz (€/Std.)</label>
+                    <input type="number" min={0} step={0.01} className="border border-gray-300 rounded px-2 py-1 text-sm w-24"
+                      value={newPos.billing_rate_per_hour || ''}
+                      onChange={(e) => setNewPos((n) => ({ ...n, billing_rate_per_hour: parseFloat(e.target.value) || 0 }))} />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] text-gray-500">Budget (€)</label>
+                    <input type="number" min={0} step={0.01} className="border border-gray-300 rounded px-2 py-1 text-sm w-28"
+                      value={newPos.budget_euros || ''}
+                      onChange={(e) => setNewPos((n) => ({ ...n, budget_euros: parseFloat(e.target.value) || 0 }))} />
+                  </div>
+                  <button type="button" disabled={!newPos.position_number || creating}
+                    onClick={() => void createPosten(p)}
+                    className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+                    {creating ? '…' : 'Anlegen'}
+                  </button>
+                  {createErr && <span className="text-xs text-red-600 w-full">{createErr}</span>}
+                </div>
+              )}
             </div>
           )
         })}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -639,7 +639,6 @@ interface AssignRow {
   weekly_capacity_hours: number
   priority: number
   billing_rate_per_hour: number
-  vacation_days_taken: number
 }
 
 /** Manage ALL Posten-assignments of one MA in a project as an editable list — each row is
@@ -661,11 +660,17 @@ function MemberAssignmentsModal({
   const seq = useRef(0)
   const [fromDate, setFromDate] = useState(mine[0]?.from_date ?? '')
   const [toDate, setToDate] = useState(mine[0]?.to_date ?? '')
+  // vacation_days_taken is a per-MA fact (already-taken vacation for this project), not per Posten.
+  // Initialize from the largest value across the MA's rows (guards against legacy rows that were
+  // filled inconsistently) and write it back to every row on save.
+  const [vacationTaken, setVacationTaken] = useState(
+    mine.reduce((mx, m) => Math.max(mx, m.vacation_days_taken), 0),
+  )
   const [rows, setRows] = useState<AssignRow[]>(
     mine.map((m) => ({
       key: 'm' + m.id, membershipId: m.id, billing_position_id: m.billing_position_id,
       weekly_capacity_hours: m.weekly_capacity_hours, priority: m.priority,
-      billing_rate_per_hour: m.billing_rate_per_hour, vacation_days_taken: m.vacation_days_taken,
+      billing_rate_per_hour: m.billing_rate_per_hour,
     })),
   )
   const [saving, setSaving] = useState(false)
@@ -683,7 +688,7 @@ function MemberAssignmentsModal({
     setRows((rs) => [...rs, {
       key: 'n' + (seq.current++), membershipId: null,
       billing_position_id: free?.id ?? null, weekly_capacity_hours: 0, priority: 0,
-      billing_rate_per_hour: 0, vacation_days_taken: 0,
+      billing_rate_per_hour: 0,
     }])
   }
 
@@ -707,7 +712,7 @@ function MemberAssignmentsModal({
         const payload = {
           from_date: fromDate, to_date: toDate, weekly_capacity_hours: r.weekly_capacity_hours,
           billing_rate_per_hour: rowRate(r), priority: r.priority,
-          vacation_days_taken: r.vacation_days_taken, billing_position_id: r.billing_position_id,
+          vacation_days_taken: vacationTaken, billing_position_id: r.billing_position_id,
         }
         const res = r.membershipId != null
           ? await projects.updateMembership(projectId, r.membershipId, payload)
@@ -739,10 +744,21 @@ function MemberAssignmentsModal({
         </div>
         <p className="text-xs text-gray-500">Zeitraum gilt für alle Posten-Zuweisungen dieses MA.</p>
 
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Bereits genommener Urlaub (Tage)
+            <span className="ml-1 font-normal text-gray-400">— pro Mitarbeiter, gilt für alle Posten</span>
+          </label>
+          <input type="number" min={0} step={0.5}
+            title="Bereits genommene Urlaubstage dieses MA für dieses Projekt. Reduziert die Rest-Urlaubsschätzung in der Kapazitätsberechnung — einmal pro Mitarbeiter, nicht je Posten."
+            className="w-32 border border-gray-300 rounded px-3 py-1.5 text-sm"
+            value={vacationTaken || ''}
+            onChange={(e) => setVacationTaken(parseFloat(e.target.value) || 0)} />
+        </div>
+
         <div className="border border-gray-200 rounded overflow-hidden">
-          <div className="grid grid-cols-[1fr_5rem_5rem_5rem_2rem] gap-2 px-2 py-1.5 bg-gray-50 text-[11px] font-medium text-gray-500">
+          <div className="grid grid-cols-[1fr_6rem_6rem_2rem] gap-2 px-2 py-1.5 bg-gray-50 text-[11px] font-medium text-gray-500">
             <span>Posten</span><span>h/Woche</span><span>Priorität</span>
-            <span title="Bereits genommener Urlaub für dieses Projekt (Tage) — reduziert die Rest-Urlaubsschätzung.">Url. gen.</span>
             <span></span>
           </div>
           {rows.length === 0 && (
@@ -752,7 +768,7 @@ function MemberAssignmentsModal({
             const pos = r.billing_position_id != null ? posById.get(r.billing_position_id) : undefined
             const rateFromPos = pos != null && pos.billing_rate_per_hour > 0
             return (
-              <div key={r.key} className="grid grid-cols-[1fr_5rem_5rem_5rem_2rem] gap-2 px-2 py-1.5 items-center border-t border-gray-100">
+              <div key={r.key} className="grid grid-cols-[1fr_6rem_6rem_2rem] gap-2 px-2 py-1.5 items-center border-t border-gray-100">
                 <div>
                   <select className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
                     value={r.billing_position_id ?? ''}
@@ -779,10 +795,6 @@ function MemberAssignmentsModal({
                   className="border border-gray-300 rounded px-2 py-1 text-sm"
                   value={r.priority}
                   onChange={(e) => setRow(r.key, { priority: parseInt(e.target.value) || 0 })} />
-                <input type="number" min={0} step={0.5} title="Bereits genommener Urlaub (Tage) für dieses Projekt"
-                  className="border border-gray-300 rounded px-2 py-1 text-sm"
-                  value={r.vacation_days_taken || ''}
-                  onChange={(e) => setRow(r.key, { vacation_days_taken: parseFloat(e.target.value) || 0 })} />
                 <button type="button" title="Zuweisung entfernen"
                   className="text-gray-400 hover:text-red-600"
                   onClick={() => setRows((rs) => rs.filter((x) => x.key !== r.key))}>
@@ -1900,11 +1912,11 @@ export default function ProjectDetailPage() {
             <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
               <Table
                 columns={[
-                  { key: 'person_id', header: 'Person', render: (m: ProjectMembership) => personName(m.person_id) },
-                  { key: 'from_date', header: 'Von' },
-                  { key: 'to_date', header: 'Bis' },
-                  { key: 'weekly_capacity_hours', header: 'h/Woche', render: (m: ProjectMembership) => `${m.weekly_capacity_hours} h` },
-                  { key: 'billing_rate_per_hour', header: 'Stundensatz', render: (m: ProjectMembership) => (
+                  { key: 'person_id', header: 'Person', headerTitle: 'Zugewiesener Mitarbeiter. Im Posten-Modus kann eine Person mehrere Zeilen haben — eine je Posten.', render: (m: ProjectMembership) => personName(m.person_id) },
+                  { key: 'from_date', header: 'Von', headerTitle: 'Beginn der Projektzugehörigkeit (gilt für alle Posten-Zuweisungen dieses MA).' },
+                  { key: 'to_date', header: 'Bis', headerTitle: 'Ende der Projektzugehörigkeit (gilt für alle Posten-Zuweisungen dieses MA).' },
+                  { key: 'weekly_capacity_hours', header: 'h/Woche', headerTitle: 'Wöchentliche Kapazität dieses MA für diese Zeile. Bei mehreren Posten teilt sich die Gesamtkapazität auf die Zeilen auf.', render: (m: ProjectMembership) => `${m.weekly_capacity_hours} h` },
+                  { key: 'billing_rate_per_hour', header: 'Stundensatz', headerTitle: 'Abrechnungssatz (€/Std.). Ist ein Posten zugewiesen, kommt der Satz vom Posten.', render: (m: ProjectMembership) => (
                     <span title={m.billing_position_id != null ? 'Satz vom zugewiesenen Posten' : undefined}>
                       {memberRate(m)} €{m.billing_position_id != null && <span className="ml-1 text-gray-300">(Posten)</span>}
                     </span>
@@ -1923,6 +1935,7 @@ export default function ProjectDetailPage() {
                   }] : []),
                   {
                     key: 'priority', header: 'Priorität',
+                    headerTitle: 'Budget-Priorität für die Verteilung: kleiner = höher, gleicher Wert = gleiche Stufe, 0 = neutral. Bei knappem Budget werden höher priorisierte Zeilen zuerst gedeckt.',
                     render: (m: ProjectMembership) => (
                       <span title="Budget-Priorität: kleiner = höher, gleicher Wert = gleiche Stufe, 0 = neutral">
                         {m.priority === 0 ? <span className="text-gray-300">–</span> : m.priority}
@@ -1931,8 +1944,9 @@ export default function ProjectDetailPage() {
                   },
                   {
                     key: 'vacation_days_taken', header: 'Urlaub genommen',
+                    headerTitle: 'Bereits genommene Urlaubstage pro Mitarbeiter (projektbezogen, nicht je Posten) — reduziert die geschätzte Rest-Abwesenheit. Bearbeiten über „Bearbeiten“.',
                     render: (m: ProjectMembership) => (
-                      <span title="Bereits genommene Urlaubstage (pauschal, projektbezogen). Werden vom Jahres-Urlaubskontingent abgezogen und senken die geschätzte Abwesenheit.">
+                      <span title="Bereits genommene Urlaubstage (pro Mitarbeiter, projektbezogen). Werden vom Jahres-Urlaubskontingent abgezogen und senken die geschätzte Abwesenheit.">
                         {m.vacation_days_taken > 0 ? `${m.vacation_days_taken} T` : <span className="text-gray-300">–</span>}
                       </span>
                     ),
@@ -1951,7 +1965,11 @@ export default function ProjectDetailPage() {
                     ),
                   },
                 ]}
-                rows={memberships}
+                rows={[...memberships].sort((a, b) =>
+                  personName(a.person_id).localeCompare(personName(b.person_id), 'de') ||
+                  a.priority - b.priority ||
+                  b.weekly_capacity_hours - a.weekly_capacity_hours
+                )}
                 keyFn={(m) => m.id}
               />
             </div>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -735,8 +735,10 @@ function MemberAssignmentsModal({
         <p className="text-xs text-gray-500">Zeitraum gilt für alle Posten-Zuweisungen dieses MA.</p>
 
         <div className="border border-gray-200 rounded overflow-hidden">
-          <div className="grid grid-cols-[1fr_5rem_5rem_2rem] gap-2 px-2 py-1.5 bg-gray-50 text-[11px] font-medium text-gray-500">
-            <span>Posten</span><span>h/Woche</span><span>Priorität</span><span></span>
+          <div className="grid grid-cols-[1fr_5rem_5rem_5rem_2rem] gap-2 px-2 py-1.5 bg-gray-50 text-[11px] font-medium text-gray-500">
+            <span>Posten</span><span>h/Woche</span><span>Priorität</span>
+            <span title="Bereits genommener Urlaub für dieses Projekt (Tage) — reduziert die Rest-Urlaubsschätzung.">Url. gen.</span>
+            <span></span>
           </div>
           {rows.length === 0 && (
             <div className="px-2 py-3 text-xs text-gray-400">Noch keine Zuweisung — „+ Posten" klicken.</div>
@@ -745,7 +747,7 @@ function MemberAssignmentsModal({
             const pos = r.billing_position_id != null ? posById.get(r.billing_position_id) : undefined
             const rateFromPos = pos != null && pos.billing_rate_per_hour > 0
             return (
-              <div key={r.key} className="grid grid-cols-[1fr_5rem_5rem_2rem] gap-2 px-2 py-1.5 items-center border-t border-gray-100">
+              <div key={r.key} className="grid grid-cols-[1fr_5rem_5rem_5rem_2rem] gap-2 px-2 py-1.5 items-center border-t border-gray-100">
                 <div>
                   <select className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
                     value={r.billing_position_id ?? ''}
@@ -772,6 +774,10 @@ function MemberAssignmentsModal({
                   className="border border-gray-300 rounded px-2 py-1 text-sm"
                   value={r.priority}
                   onChange={(e) => setRow(r.key, { priority: parseInt(e.target.value) || 0 })} />
+                <input type="number" min={0} step={0.5} title="Bereits genommener Urlaub (Tage) für dieses Projekt"
+                  className="border border-gray-300 rounded px-2 py-1 text-sm"
+                  value={r.vacation_days_taken || ''}
+                  onChange={(e) => setRow(r.key, { vacation_days_taken: parseFloat(e.target.value) || 0 })} />
                 <button type="button" title="Zuweisung entfernen"
                   className="text-gray-400 hover:text-red-600"
                   onClick={() => setRows((rs) => rs.filter((x) => x.key !== r.key))}>

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -562,8 +562,13 @@ function BillingPositionsSection({
           <div>
             <p className="text-sm font-medium text-gray-700">Posten-Modus</p>
             <p className="text-xs text-gray-400 max-w-md">
-              Aktiviert die Verteilung, Zuweisung, Import-Zuordnung und Abrechnung je Posten.
-              Voraussetzung: alle aktiven Mitglieder einem Posten zugewiesen und Budget vollständig verteilt.
+              Beim Aktivieren werden Budget, Zuweisungen, Import-Zuordnung und Abrechnung je Posten
+              geführt statt für das Projekt als Ganzes; bestehende Buchungen werden anhand der
+              Mappings den Posten zugeordnet.
+            </p>
+            <p className="text-xs text-gray-400 max-w-md mt-1">
+              Voraussetzungen: mindestens ein Posten mit Satz vorhanden, Σ Posten-Budget = Gesamtbudget
+              und alle aktiven Mitglieder einem Posten zugewiesen. Lässt sich jederzeit wieder deaktivieren.
             </p>
           </div>
           <button
@@ -1661,6 +1666,11 @@ export default function ProjectDetailPage() {
                         )
                       })}
                   </div>
+                  <div className="px-4 py-2 bg-gray-50 border-t border-gray-100 text-[11px] text-gray-400 leading-relaxed">
+                    <span className="font-medium text-gray-500">Ist</span> = bereits gebuchter Aufwand ·{' '}
+                    <span className="font-medium text-gray-500">Prognose</span> = erwarteter Gesamtaufwand bei Projektende (Ist + geplanter Rest) ·{' '}
+                    <span className="font-medium text-gray-500">Rest</span> = Posten-Budget − Prognose (negativ = Überschreitung).
+                  </div>
                 </div>
               )}
             </div>
@@ -1901,6 +1911,9 @@ export default function ProjectDetailPage() {
                   ) },
                   ...(billingPositions.length > 0 ? [{
                     key: 'billing_position_id', header: 'Posten',
+                    headerTitle: positionMode
+                      ? 'Im Posten-Modus muss jedes aktive Mitglied einem Posten zugewiesen sein — daraus kommen Stundensatz und die Zuordnung von Plan und Ist zum Posten-Budget.'
+                      : 'Optionale Zuordnung zu einer Vertragsposition. Ein zugewiesener Posten liefert den Stundensatz. Im Posten-Modus wird die Zuordnung verpflichtend.',
                     render: (m: ProjectMembership) => {
                       const p = m.billing_position_id != null ? posById.get(m.billing_position_id) : undefined
                       return p
@@ -2117,6 +2130,11 @@ export default function ProjectDetailPage() {
                 auf den unten gewählten Standard-Posten zurück.
               </p>
             ) : null}
+            <p className="text-xs text-gray-400 bg-gray-50 border border-gray-200 rounded px-3 py-2">
+              Nur vorwärts wirksam: Der Abschluss erzeugt Rechnungen für den gewählten Monat.
+              Bereits abgerechnete Monate bleiben unverändert — auch ein späteres Umschalten des
+              Posten-Modus rechnet zurückliegende Rechnungen nicht neu.
+            </p>
             {billingPositions.length > 1 && (
               <div>
                 <label className="block text-xs font-medium text-gray-600 mb-1">

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -833,8 +833,6 @@ export default function ProjectDetailPage() {
   const [tab, setTab] = useState<Tab>('milestones')
   const [showCloseModal, setShowCloseModal] = useState(false)
   const [showAddMember, setShowAddMember] = useState(false)
-  const [editMember, setEditMember] = useState<ProjectMembership | null>(null)
-  const [editMemberForm, setEditMemberForm] = useState({ from_date: '', to_date: '', weekly_capacity_hours: 40, billing_rate_per_hour: 90, priority: 0, vacation_days_taken: 0, billing_position_id: null as number | null })
   const [editAssign, setEditAssign] = useState<{ personId: number; personName: string } | null>(null)  // Posten-Zuweisungs-Liste eines MA
   const [confirmReopenId, setConfirmReopenId] = useState<number | null>(null)
   const [confirmReopenMilestone, setConfirmReopenMilestone] = useState<{ year: number; month: number } | null>(null)
@@ -985,16 +983,6 @@ export default function ProjectDetailPage() {
       if (result.warnings && result.warnings.length > 0) {
         setMemberWarnings(result.warnings)
       }
-    },
-    onError: (e: Error) => setError(errText(e)),
-  })
-  const updateMember = useMutation({
-    mutationFn: () => projects.updateMembership(projectId, editMember!.id, editMemberForm),
-    onSuccess: (result) => {
-      qc.invalidateQueries({ queryKey: ['memberships', projectId] })
-      setEditMember(null)
-      setError(null)
-      if (result.warnings && result.warnings.length > 0) setMemberWarnings(result.warnings)
     },
     onError: (e: Error) => setError(errText(e)),
   })
@@ -2496,79 +2484,6 @@ export default function ProjectDetailPage() {
         />
       )}
 
-      {/* Edit membership modal (legacy single-Posten — nur noch als Fallback) */}
-      {editMember && (
-        <Modal title="Zuweisung bearbeiten" onClose={() => { setEditMember(null); setError(null) }}>
-          <p className="text-xs text-gray-500 mb-3">Person: <strong>{personName(editMember.person_id)}</strong></p>
-          <form onSubmit={(e) => { e.preventDefault(); updateMember.mutate() }} className="space-y-3">
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs font-medium text-gray-600 mb-1">Von</label>
-                <input required type="date" className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
-                  value={editMemberForm.from_date}
-                  onChange={(e) => setEditMemberForm({ ...editMemberForm, from_date: e.target.value })} />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-600 mb-1">Bis</label>
-                <input required type="date" className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
-                  value={editMemberForm.to_date}
-                  onChange={(e) => setEditMemberForm({ ...editMemberForm, to_date: e.target.value })} />
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs font-medium text-gray-600 mb-1">h/Woche</label>
-                <input required type="number" min={0} max={60} step={0.01}
-                  className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
-                  value={editMemberForm.weekly_capacity_hours}
-                  onChange={(e) => setEditMemberForm({ ...editMemberForm, weekly_capacity_hours: parseFloat(e.target.value) })} />
-              </div>
-              {(() => {
-                const pos = editMemberForm.billing_position_id != null ? posById.get(editMemberForm.billing_position_id) : undefined
-                const fromPosition = pos != null && pos.billing_rate_per_hour > 0
-                return (
-                  <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1">Stundensatz (€)</label>
-                    <input required={!fromPosition} type="number" min={0} step={0.01} disabled={fromPosition}
-                      className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm disabled:bg-gray-50 disabled:text-gray-400"
-                      title={fromPosition ? 'Satz kommt vom zugewiesenen Posten' : undefined}
-                      value={fromPosition ? pos!.billing_rate_per_hour : editMemberForm.billing_rate_per_hour}
-                      onChange={(e) => setEditMemberForm({ ...editMemberForm, billing_rate_per_hour: parseFloat(e.target.value) })} />
-                  </div>
-                )
-              })()}
-            </div>
-            <PositionSelect positions={billingPositions} required={positionMode}
-              value={editMemberForm.billing_position_id}
-              onChange={(v) => setEditMemberForm({ ...editMemberForm, billing_position_id: v })} />
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">
-                Priorität <span className="text-gray-400 font-normal">(kleiner = höher, gleicher Wert = gleiche Stufe, 0 = neutral)</span>
-              </label>
-              <input type="number" step={1}
-                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
-                value={editMemberForm.priority}
-                onChange={(e) => setEditMemberForm({ ...editMemberForm, priority: parseInt(e.target.value) || 0 })} />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">
-                Bereits genommener Urlaub <span className="text-gray-400 font-normal">(Tage, projektbezogen — reduziert die geschätzte Abwesenheit)</span>
-              </label>
-              <input type="number" min={0} step={0.5}
-                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
-                value={editMemberForm.vacation_days_taken}
-                onChange={(e) => setEditMemberForm({ ...editMemberForm, vacation_days_taken: parseFloat(e.target.value) || 0 })} />
-            </div>
-            {error && <p className="text-xs text-red-600">{error}</p>}
-            <div className="flex justify-end gap-2 pt-2">
-              <button type="button" onClick={() => { setEditMember(null); setError(null) }}
-                className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
-              <button type="submit"
-                className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">Speichern</button>
-            </div>
-          </form>
-        </Modal>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -277,7 +277,15 @@ export default function SettingsPage() {
   const SETTING_META: Record<string, { label: string; description: string }> = {
     default_vacation_days: {
       label: 'Standard-Urlaubstage (Tage/Jahr)',
-      description: 'Wird beim Anlegen einer neuen Person automatisch als Urlaubskontingent für das aktuelle Jahr übernommen.',
+      description: 'Urlaubskontingent, das beim Anlegen einer neuen Person automatisch für das aktuelle Jahr übernommen wird. Standard: 30.',
+    },
+    sick_days_per_year: {
+      label: 'Pauschale Krankheitstage (Tage/Jahr)',
+      description: 'Angenommene Krankheitstage pro Person und Jahr. Fließen als geschätzte Abwesenheit in die Meilenstein-Prognose ein und mindern die verfügbare Kapazität. Pro Projekt überschreibbar; 0 deaktiviert die Schätzung. Standard: 10.',
+    },
+    training_days_per_year: {
+      label: 'Pauschale Fortbildungstage (Tage/Jahr)',
+      description: 'Angenommene Fortbildungs-/Schulungstage pro Person und Jahr. Fließen als geschätzte Abwesenheit in die Meilenstein-Prognose ein und mindern die verfügbare Kapazität. Pro Projekt überschreibbar; 0 deaktiviert die Schätzung. Standard: 5.',
     },
   }
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+/** App version injected by Vite from package.json (see vite.config.ts `define`). */
+declare const __APP_VERSION__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'node:fs'
+
+// Single source of truth for the app version: package.json (SemVer). Bumped via the
+// release process (see docs) — never hardcode the version in the UI.
+const pkgVersion = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8')).version
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkgVersion),
+  },
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {


### PR DESCRIPTION
## Zusammenfassung
Aufräum-/Nacharbeiten nach den beiden Epics (Multi-Posten #21, Import-Mapping #29), eine zuverlässige App-Versionierung sowie die nutzerseitigen Hilfetexte zum Posten-Modus (#8).

### Nacharbeiten
- Urlaub-genommen im MA-Formular editierbar; Posten inline im Import-Resolver anlegbar.
- App-Version wird aus `package.json` gelesen (`__APP_VERSION__` via Vite `define`) statt hartkodiert — behebt das dauerhafte `v0.2.0` im UI.

### Versionierungs-Prozess (neu)
- `commit-and-tag-version` (SemVer + Conventional Commits, lokal, kein CI).
- `npm run release` leitet den Bump aus den Commits ab, pflegt `CHANGELOG.md`, committet und taggt `vX.Y.Z`.
- `.versionrc.json` + `docs/RELEASING.md` (inkl. Baseline-Hinweis für die erste Ausführung).

### Hilfetexte Posten-Modus (#8) — rein erläuternd, keine Logikänderung
- Einstellungen: sprechende Labels + Beschreibungen für `sick_days_per_year` / `training_days_per_year` (statt Code-Schlüssel ohne Erklärung).
- Toggle-Text „Was passiert beim Aktivieren?" + Voraussetzungen + Reversibilität.
- Members-Tab Posten-Spalte: Header-Tooltip (Pflicht im Modus).
- „Aufwand nach Posten"-Panel: Legende Ist/Prognose/Rest.
- Rechnungen-Tab: forward-only-Hinweis.

Closes #8

### Mitglieder-Tab (Findings)
- **Fix:** „Urlaub genommen" ist jetzt ein Wert pro Mitarbeiter (im Zuweisungs-Dialog), nicht mehr pro Posten — verhindert stille Fehlberechnung bei mehreren Posten.
- Mitglieder-Tabelle nach Name sortiert (dann Priorität, h/Woche).
- Header-Tooltips für alle Spalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)