### PR TITLE
Urlaubslogik + Abwesenheits-Anzeige + halbe Tage (#37, #39, #40)

### DIFF
--- a/backend/alembic/versions/d4f1c7e93a20_absence_half_day_segments.py
+++ b/backend/alembic/versions/d4f1c7e93a20_absence_half_day_segments.py
@@ -1,0 +1,49 @@
+"""PersonAbsence half-day segments (start_segment/end_segment) — doc #40
+
+Adds two columns to person_absence so an absence can cover only part of its start
+and/or end day (half days). Values: 'full' (default), 'morning' (Vormittag),
+'afternoon' (Nachmittag). A half segment counts 0.5 working days.
+
+Note: runtime/tests build the schema via SQLModel.metadata.create_all; this migration
+keeps the Alembic chain in sync for migration-built databases. Existing rows default
+to 'full' (unchanged behaviour).
+
+Revision ID: d4f1c7e93a20
+Revises: c3e0a6b28d71
+Create Date: 2026-07-20
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4f1c7e93a20"
+down_revision: Union[str, None] = "c3e0a6b28d71"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _cols(conn, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(sa.text(f"PRAGMA table_info({table})"))}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    existing = _cols(conn, "person_absence")
+    if "start_segment" not in existing:
+        op.add_column(
+            "person_absence",
+            sa.Column("start_segment", sa.String(), nullable=False, server_default="full"),
+        )
+    if "end_segment" not in existing:
+        op.add_column(
+            "person_absence",
+            sa.Column("end_segment", sa.String(), nullable=False, server_default="full"),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("person_absence", "end_segment")
+    op.drop_column("person_absence", "start_segment")

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -26,6 +26,19 @@ class AbsenceStatus(str, Enum):
     ongoing = "ongoing"      # sick only
 
 
+class AbsenceDaySegment(str, Enum):
+    """Which part of a day an absence covers (for half-day absences).
+
+    Applies to the start day (start_segment) and end day (end_segment) of an
+    absence. A half segment (morning/afternoon) counts 0.5 working days; full
+    counts 1.0. Middle days of a multi-day absence are always full.
+    """
+
+    full = "full"
+    morning = "morning"      # Vormittag
+    afternoon = "afternoon"  # Nachmittag
+
+
 class MilestoneStatus(str, Enum):
     open = "open"
     closed = "closed"

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -7,7 +7,7 @@ from sqlalchemy import UniqueConstraint
 from sqlmodel import Field
 
 from app.models.base import ValidatedSQLModel
-from app.models.enums import AbsenceStatus, AbsenceType
+from app.models.enums import AbsenceDaySegment, AbsenceStatus, AbsenceType
 
 
 class Person(ValidatedSQLModel, table=True):
@@ -54,6 +54,11 @@ class PersonAbsence(ValidatedSQLModel, table=True):
     absence_type: AbsenceType
     status: AbsenceStatus
     note: str = ""
+    # Half-day support: which part of the start/end day the absence covers.
+    # full = whole day (default); morning/afternoon = half day (0.5). For a single-day
+    # absence only start_segment is meaningful (end_segment stays full).
+    start_segment: AbsenceDaySegment = Field(default=AbsenceDaySegment.full)
+    end_segment: AbsenceDaySegment = Field(default=AbsenceDaySegment.full)
 
     @model_validator(mode="after")
     def validate_type_status_and_dates(self) -> "PersonAbsence":

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -18,6 +18,7 @@ from app.models.person import Person, PersonAbsence
 from app.models.project import Project
 from app.models.timebooking import TimeBooking
 from app.services.holiday import HolidayFetchError, get_holidays_in_range
+from app.services.planning import absence_booking
 from app.services.holiday_region import (
     extra_holiday_dates,
     get_active_extra_keys,
@@ -44,6 +45,11 @@ class AbsenceOut(BaseModel):
     end_date: date | None
     absence_type: str
     status: str
+    # What the absence books for the person (working days / hours over its whole range).
+    booked_working_days: int = 0
+    booked_hours: float = 0.0
+    # For vacation only: contingent days consumed after the confirmed-sick (AU) refund.
+    contingent_days: float | None = None
 
 
 class MembershipOut(BaseModel):
@@ -160,9 +166,12 @@ def get_calendar(
         )
     ).all()
 
+    persons_by_id = {p.id: p for p in persons_raw}
     absences_by_person: dict[int, list[AbsenceOut]] = {pid: [] for pid in person_ids}
     for a in absences_raw:
         if a.person_id in absences_by_person and a.id is not None:
+            # Booking metrics use the person's own effective region (honors per-person override).
+            booking = absence_booking(persons_by_id[a.person_id], a, session)
             absences_by_person[a.person_id].append(
                 AbsenceOut(
                     id=a.id,
@@ -170,6 +179,9 @@ def get_calendar(
                     end_date=a.end_date,
                     absence_type=a.absence_type.value,
                     status=a.status.value,
+                    booked_working_days=booking["working_days"],
+                    booked_hours=booking["hours"],
+                    contingent_days=booking.get("contingent_days"),
                 )
             )
 
@@ -363,9 +375,12 @@ def get_calendar_year(
         )
     ).all()
 
+    persons_by_id = {p.id: p for p in persons_raw}
     absences_by_person: dict[int, list[AbsenceOut]] = {pid: [] for pid in person_ids}
     for a in absences_raw:
         if a.person_id in absences_by_person and a.id is not None:
+            # Booking metrics use the person's own effective region (honors per-person override).
+            booking = absence_booking(persons_by_id[a.person_id], a, session)
             absences_by_person[a.person_id].append(
                 AbsenceOut(
                     id=a.id,
@@ -373,6 +388,9 @@ def get_calendar_year(
                     end_date=a.end_date,
                     absence_type=a.absence_type.value,
                     status=a.status.value,
+                    booked_working_days=booking["working_days"],
+                    booked_hours=booking["hours"],
+                    contingent_days=booking.get("contingent_days"),
                 )
             )
 

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -45,8 +45,10 @@ class AbsenceOut(BaseModel):
     end_date: date | None
     absence_type: str
     status: str
+    start_segment: str = "full"
+    end_segment: str = "full"
     # What the absence books for the person (working days / hours over its whole range).
-    booked_working_days: int = 0
+    booked_working_days: float = 0.0
     booked_hours: float = 0.0
     # For vacation only: contingent days consumed after the confirmed-sick (AU) refund.
     contingent_days: float | None = None
@@ -179,6 +181,8 @@ def get_calendar(
                     end_date=a.end_date,
                     absence_type=a.absence_type.value,
                     status=a.status.value,
+                    start_segment=a.start_segment.value,
+                    end_segment=a.end_segment.value,
                     booked_working_days=booking["working_days"],
                     booked_hours=booking["hours"],
                     contingent_days=booking.get("contingent_days"),
@@ -388,6 +392,8 @@ def get_calendar_year(
                     end_date=a.end_date,
                     absence_type=a.absence_type.value,
                     status=a.status.value,
+                    start_segment=a.start_segment.value,
+                    end_segment=a.end_segment.value,
                     booked_working_days=booking["working_days"],
                     booked_hours=booking["hours"],
                     contingent_days=booking.get("contingent_days"),

--- a/backend/app/routers/persons.py
+++ b/backend/app/routers/persons.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, select
 
 from app.db import get_session
-from app.models.enums import AbsenceStatus, AbsenceType
+from app.models.enums import AbsenceDaySegment, AbsenceStatus, AbsenceType
 from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.membership import ProjectMembership
 from app.models.project import Project
@@ -28,6 +28,8 @@ class AbsenceCreate(SQLModel):
     absence_type: AbsenceType
     status: AbsenceStatus
     note: str = ""
+    start_segment: AbsenceDaySegment = AbsenceDaySegment.full
+    end_segment: AbsenceDaySegment = AbsenceDaySegment.full
 
 
 class AbsenceWithBooking(SQLModel):
@@ -45,7 +47,9 @@ class AbsenceWithBooking(SQLModel):
     absence_type: AbsenceType
     status: AbsenceStatus
     note: str
-    booked_working_days: int
+    start_segment: AbsenceDaySegment
+    end_segment: AbsenceDaySegment
+    booked_working_days: float
     booked_hours: float
     contingent_days: float | None = None
 
@@ -247,6 +251,7 @@ def list_absences(person_id: int, session: SessionDep):
         out.append(AbsenceWithBooking(
             id=a.id, start_date=a.start_date, end_date=a.end_date,
             absence_type=a.absence_type, status=a.status, note=a.note,
+            start_segment=a.start_segment, end_segment=a.end_segment,
             booked_working_days=booking["working_days"],
             booked_hours=booking["hours"],
             contingent_days=booking.get("contingent_days"),
@@ -266,6 +271,8 @@ def create_absence(person_id: int, body: AbsenceCreate, session: SessionDep):
             absence_type=body.absence_type,
             status=body.status,
             note=body.note,
+            start_segment=body.start_segment,
+            end_segment=body.end_segment,
         )
     except Exception as exc:
         raise HTTPException(422, str(exc)) from exc

--- a/backend/app/routers/persons.py
+++ b/backend/app/routers/persons.py
@@ -11,7 +11,7 @@ from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.membership import ProjectMembership
 from app.models.project import Project
 from app.models.setting import Setting
-from app.services.planning import absence_booking
+from app.services.planning import absence_booking, absence_summary
 
 router = APIRouter(prefix="/persons", tags=["persons"])
 
@@ -96,6 +96,19 @@ def list_persons_with_projects(session: SessionDep):
         )
         for p in all_persons
     ]
+
+
+@router.get("/absence-summary")
+def batch_absence_summary(session: SessionDep, year: int | None = None):
+    """Per-person absence overview for a year (defaults to the current year).
+
+    Keyed by person_id. Used by the persons table's vacation column. Declared
+    before /{person_id} so the literal path wins the route match.
+    """
+    from datetime import date as _date
+    yr = year or _date.today().year
+    persons_all = session.exec(select(Person)).all()
+    return {p.id: absence_summary(p, yr, session) for p in persons_all if p.id is not None}
 
 
 @router.post("", response_model=Person, status_code=201)
@@ -209,6 +222,16 @@ def list_person_memberships(person_id: int, session: SessionDep):
 # ---------------------------------------------------------------------------
 # Absences
 # ---------------------------------------------------------------------------
+
+@router.get("/{person_id}/absence-summary")
+def person_absence_summary(person_id: int, session: SessionDep, year: int | None = None):
+    """Absence overview (categories + vacation taken/planned/open) for one person/year."""
+    from datetime import date as _date
+    person = session.get(Person, person_id)
+    if not person:
+        raise HTTPException(404, "Person not found.")
+    return absence_summary(person, year or _date.today().year, session)
+
 
 @router.get("/{person_id}/absences", response_model=list[AbsenceWithBooking])
 def list_absences(person_id: int, session: SessionDep):

--- a/backend/app/routers/persons.py
+++ b/backend/app/routers/persons.py
@@ -11,6 +11,7 @@ from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.membership import ProjectMembership
 from app.models.project import Project
 from app.models.setting import Setting
+from app.services.planning import absence_booking
 
 router = APIRouter(prefix="/persons", tags=["persons"])
 
@@ -27,6 +28,26 @@ class AbsenceCreate(SQLModel):
     absence_type: AbsenceType
     status: AbsenceStatus
     note: str = ""
+
+
+class AbsenceWithBooking(SQLModel):
+    """A PersonAbsence plus what it actually books (working days / hours).
+
+    booked_working_days / booked_hours: working days (Mon–Fri ∩ no holiday ∩
+    pattern>0) in the absence range and the person's hours over them.
+    contingent_days: for vacation only — days that draw down the contingent after
+    the confirmed-sick (AU) refund; None for non-vacation types.
+    """
+
+    id: int
+    start_date: date
+    end_date: date | None
+    absence_type: AbsenceType
+    status: AbsenceStatus
+    note: str
+    booked_working_days: int
+    booked_hours: float
+    contingent_days: float | None = None
 
 
 class ContingentCreate(SQLModel):
@@ -189,13 +210,25 @@ def list_person_memberships(person_id: int, session: SessionDep):
 # Absences
 # ---------------------------------------------------------------------------
 
-@router.get("/{person_id}/absences", response_model=list[PersonAbsence])
+@router.get("/{person_id}/absences", response_model=list[AbsenceWithBooking])
 def list_absences(person_id: int, session: SessionDep):
-    if not session.get(Person, person_id):
+    person = session.get(Person, person_id)
+    if not person:
         raise HTTPException(404, "Person not found.")
-    return session.exec(
+    rows = session.exec(
         select(PersonAbsence).where(PersonAbsence.person_id == person_id)
     ).all()
+    out: list[AbsenceWithBooking] = []
+    for a in rows:
+        booking = absence_booking(person, a, session)
+        out.append(AbsenceWithBooking(
+            id=a.id, start_date=a.start_date, end_date=a.end_date,
+            absence_type=a.absence_type, status=a.status, note=a.note,
+            booked_working_days=booking["working_days"],
+            booked_hours=booking["hours"],
+            contingent_days=booking.get("contingent_days"),
+        ))
+    return out
 
 
 @router.post("/{person_id}/absences", response_model=PersonAbsence, status_code=201)

--- a/backend/app/services/milestones.py
+++ b/backend/app/services/milestones.py
@@ -256,11 +256,15 @@ def _person_available_hours(
         holiday_dates = set()
     holiday_days_count = len(holiday_dates)
 
-    # Working days in effective period (Mon-Fri, not holiday)
+    # Effective working days: Mon-Fri, not a workday holiday (project region) and — if a
+    # work-week pattern is set — a day the person actually works (pattern hours > 0).
+    # Same definition as planning.effective_working_dates so capacity/absence stay aligned.
+    pattern = _parse_work_week_pattern(person.work_week_pattern) if person.work_week_pattern else None
     working_day_list: list[date] = []
     d = eff_start
     while d <= eff_end:
-        if d.weekday() < 5 and d not in holiday_dates:
+        wd = d.weekday()
+        if wd < 5 and d not in holiday_dates and (pattern is None or pattern[wd] > 0):
             working_day_list.append(d)
         d += timedelta(days=1)
     work_days_count = len(working_day_list)
@@ -269,7 +273,6 @@ def _person_available_hours(
         return PersonMonthStats(0.0, 0, 0, holiday_days_count)
 
     # Gross hours from pattern or uniform
-    pattern = _parse_work_week_pattern(person.work_week_pattern) if person.work_week_pattern else None
     if pattern:
         total_pattern = sum(pattern)
         gross_hours = sum(
@@ -281,15 +284,20 @@ def _person_available_hours(
 
     avg_daily_hours = gross_hours / work_days_count
 
-    # Specific absence days (all types including vacation)
-    abs_days = absence_days_in_range(person.id, eff_start, eff_end, session)
+    # Specific absence working days (all types), deduped so overlaps count once.
+    abs_days = absence_days_in_range(
+        person.id, eff_start, eff_end, session,
+        project.holiday_country, project.holiday_state,
+    )
 
     # Unplanned (remaining) vacation estimate for the effective period.
-    # estimated_vacation_days already subtracts concrete vacation already taken in the
-    # year (no double counting with abs_days) and distributes the remaining contingent
-    # across the remaining days of the year — see B3 / planning.estimated_vacation_days.
+    # estimated_vacation_days already subtracts concrete vacation working days consumed
+    # in the year (after the AU refund; no double counting with abs_days) and distributes
+    # the remaining contingent across the remaining days — see B3 / planning.
     vacation_estimate = estimated_vacation_days(
-        person.id, eff_start, eff_end, session, taken_days_flat=membership.vacation_days_taken
+        person.id, eff_start, eff_end, session,
+        taken_days_flat=membership.vacation_days_taken,
+        country=project.holiday_country, state=project.holiday_state,
     )
     # Cap: can't estimate more vacation days than actual available working days
     vacation_estimate = min(vacation_estimate, max(0, work_days_count - abs_days))

--- a/backend/app/services/planning.py
+++ b/backend/app/services/planning.py
@@ -20,11 +20,16 @@ from app.models.enums import AbsenceStatus, AbsenceType
 from app.models.membership import ProjectMembership
 from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.project import Project
-from app.services.holiday import get_holidays_in_range
+from app.services.holiday import HolidayFetchError, get_holidays_in_range
+from app.services.holiday_region import resolve_holiday_region
 
 
 def working_days(start: date, end: date) -> int:
-    """Count Mon–Fri days in [start, end] (inclusive). O(1) arithmetic."""
+    """Count Mon–Fri days in [start, end] (inclusive). O(1) arithmetic.
+
+    Calendar-only helper (ignores holidays and work-week patterns). For an
+    absence-/capacity-relevant count use ``effective_working_dates``.
+    """
     if end < start:
         return 0
     total = (end - start).days + 1
@@ -45,31 +50,147 @@ def _overlap_days(range_start: date, range_end: date, a_start: date, a_end: date
     return (overlap_end - overlap_start).days + 1
 
 
-def absence_days_in_range(
-    person_id: int,
+def parse_work_week_pattern_or_none(person: Person | None) -> list[float] | None:
+    """The person's Mon–Fri daily-hours pattern, or None if unset/invalid."""
+    if person is None or not person.work_week_pattern:
+        return None
+    try:
+        return _parse_work_week_pattern(person.work_week_pattern)
+    except ValueError:
+        return None
+
+
+def effective_working_dates(
     start: date,
     end: date,
     session: Session,
-) -> float:
-    """Sum of calendar absence days that overlap [start, end].
+    country: str,
+    state: str,
+    pattern: list[float] | None = None,
+    client: httpx.Client | None = None,
+) -> list[date]:
+    """Dates in [start, end] the person would normally work.
 
-    Counts vacation (planned+confirmed), training (planned+confirmed),
-    sick (ongoing+confirmed). Ongoing sick with null end_date uses today.
+    A day qualifies when it is Mon–Fri, is not a public holiday that falls on a
+    workday in (country, state), and — if a work-week ``pattern`` is given — has
+    pattern hours > 0. This is the single definition of "a working day" used by
+    absence counting, availability and capacity so they can never drift apart.
     """
-    absences = session.exec(
+    if end < start:
+        return []
+    try:
+        holidays = get_holidays_in_range(start, end, country, state, session, client)
+        holiday_dates = {h.holiday_date for h in holidays if h.is_workday}
+    except HolidayFetchError:
+        # Graceful degradation: if the holiday source is unavailable, don't drop
+        # working days (better to over-count availability than to crash the calc).
+        holiday_dates = set()
+    out: list[date] = []
+    d = start
+    while d <= end:
+        wd = d.weekday()
+        if wd < 5 and d not in holiday_dates and (pattern is None or pattern[wd] > 0):
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def _overlapping_absences(
+    person_id: int, start: date, end: date, session: Session
+) -> list[PersonAbsence]:
+    """All of the person's absences whose date range overlaps [start, end].
+
+    An ongoing sick record (null end_date) is treated as running until today.
+    """
+    rows = session.exec(
         select(PersonAbsence).where(
             PersonAbsence.person_id == person_id,
             PersonAbsence.start_date <= end,
         )
     ).all()
+    result: list[PersonAbsence] = []
+    for a in rows:
+        a_end = a.end_date if a.end_date is not None else date.today()
+        if a_end >= start:
+            result.append(a)
+    return result
 
-    total = 0.0
-    for absence in absences:
-        effective_end = absence.end_date if absence.end_date is not None else date.today()
-        if effective_end < start:
-            continue
-        total += _overlap_days(start, end, absence.start_date, effective_end)
-    return total
+
+def _covers(absence: PersonAbsence, day: date) -> bool:
+    a_end = absence.end_date if absence.end_date is not None else date.today()
+    return absence.start_date <= day <= a_end
+
+
+def _is_confirmed_sick(a: PersonAbsence) -> bool:
+    """A sick record with a medical certificate on file (AU vorliegt)."""
+    return a.absence_type == AbsenceType.sick and a.status == AbsenceStatus.confirmed
+
+
+def _resolve_region(
+    person_id: int, session: Session, country: str | None, state: str | None
+) -> tuple[str, str, Person | None]:
+    person = session.get(Person, person_id)
+    if country is None:
+        country, state = resolve_holiday_region(session, person)
+    return country, state or "", person
+
+
+def absence_days_in_range(
+    person_id: int,
+    start: date,
+    end: date,
+    session: Session,
+    country: str | None = None,
+    state: str | None = None,
+    client: httpx.Client | None = None,
+) -> float:
+    """Number of the person's *working days* in [start, end] covered by any absence.
+
+    Only Mon–Fri days that are neither a public holiday (in the effective region)
+    nor a non-working day of the person's work-week pattern count. A day covered by
+    several overlapping absences counts exactly once (no double counting). When
+    ``country``/``state`` are omitted the person's effective region is resolved.
+    """
+    country, state, person = _resolve_region(person_id, session, country, state)
+    pattern = parse_work_week_pattern_or_none(person)
+    workdates = effective_working_dates(start, end, session, country, state, pattern, client)
+    if not workdates:
+        return 0.0
+    absences = _overlapping_absences(person_id, start, end, session)
+    if not absences:
+        return 0.0
+    return float(sum(1 for d in workdates if any(_covers(a, d) for a in absences)))
+
+
+def vacation_days_consumed_in_year(
+    person_id: int,
+    year: int,
+    session: Session,
+    country: str | None = None,
+    state: str | None = None,
+    client: httpx.Client | None = None,
+) -> float:
+    """Vacation working days consumed in ``year`` after the AU refund.
+
+    A working day covered by a vacation absence is counted, unless the same day is
+    also covered by a *confirmed* sick absence (AU liegt vor) — then the day counts
+    as sick and the vacation day is refunded (§ "Krankheit während Urlaub")."""
+    country, state, person = _resolve_region(person_id, session, country, state)
+    pattern = parse_work_week_pattern_or_none(person)
+    year_start, year_end = date(year, 1, 1), date(year, 12, 31)
+    workdates = effective_working_dates(year_start, year_end, session, country, state, pattern, client)
+    if not workdates:
+        return 0.0
+    absences = _overlapping_absences(person_id, year_start, year_end, session)
+    vac = [a for a in absences if a.absence_type == AbsenceType.vacation]
+    sick_confirmed = [a for a in absences if _is_confirmed_sick(a)]
+    if not vac:
+        return 0.0
+    consumed = 0
+    for d in workdates:
+        if any(_covers(a, d) for a in vac) and not any(_covers(a, d) for a in sick_confirmed):
+            consumed += 1
+    return float(consumed)
 
 
 def estimated_vacation_days(
@@ -78,17 +199,22 @@ def estimated_vacation_days(
     end: date,
     session: Session,
     taken_days_flat: float = 0.0,
+    country: str | None = None,
+    state: str | None = None,
+    client: httpx.Client | None = None,
 ) -> float:
     """Estimate unplanned vacation for person in [start, end].
 
     For each calendar year that overlaps the period:
-        remaining_contingent = total_days − Σ concrete vacation absences in year − taken_days_flat
+        remaining_contingent = total_days − vacation working days consumed in year − taken_days_flat
         fraction = period_days_in_year_segment / remaining_days_in_year_from_period_start
         estimate += max(0, remaining_contingent) × fraction
 
-    Days already covered by a concrete absence are excluded to avoid double-counting
-    (absence_days_in_range handles those). taken_days_flat is a project-specific flat number
-    of already-taken vacation days (no dates) that further reduces the remaining contingent.
+    Consumed vacation is counted in *working days* after the AU refund
+    (vacation_days_consumed_in_year), so weekends, holidays, non-working pattern
+    days and days topped by confirmed sick leave never reduce the contingent.
+    taken_days_flat is a project-specific flat number of already-taken vacation
+    days (no dates) that further reduces the remaining contingent.
     """
     total_estimate = 0.0
     for year in range(start.year, end.year + 1):
@@ -104,20 +230,9 @@ def estimated_vacation_days(
         if contingent_row is None:
             continue
 
-        # Sum all concrete vacation absence days in this year
-        concrete_absences = session.exec(
-            select(PersonAbsence).where(
-                PersonAbsence.person_id == person_id,
-                PersonAbsence.absence_type == AbsenceType.vacation,
-                PersonAbsence.start_date <= year_end,
-            )
-        ).all()
-        used_days = 0.0
-        for absence in concrete_absences:
-            a_end = absence.end_date if absence.end_date is not None else date.today()
-            if a_end < year_start:
-                continue
-            used_days += _overlap_days(year_start, year_end, absence.start_date, a_end)
+        used_days = vacation_days_consumed_in_year(
+            person_id, year, session, country, state, client
+        )
 
         remaining_contingent = max(0.0, contingent_row.total_days - used_days - taken_days_flat)
         if remaining_contingent == 0.0:
@@ -149,17 +264,19 @@ def available_days(
 ) -> float:
     """Compute available working days for person in [start, end].
 
-    available = working_days − workday_holidays − absence_days − estimated_vacation
+    available = effective_working_days − absence_days − estimated_vacation
+
+    Holidays and non-working pattern days are already excluded from the base
+    (effective_working_dates), so they are not subtracted again here.
     """
-    wdays = working_days(start, end)
+    person = session.get(Person, person_id)
+    pattern = parse_work_week_pattern_or_none(person)
+    base = len(effective_working_dates(start, end, session, country, state, pattern, client))
 
-    holidays = get_holidays_in_range(start, end, country, state, session, client)
-    holiday_deduction = sum(1 for h in holidays if h.is_workday)
+    absences = absence_days_in_range(person_id, start, end, session, country, state, client)
+    estimate = estimated_vacation_days(person_id, start, end, session, 0.0, country, state, client)
 
-    absences = absence_days_in_range(person_id, start, end, session)
-    estimate = estimated_vacation_days(person_id, start, end, session)
-
-    return float(wdays) - holiday_deduction - absences - estimate
+    return float(base) - absences - estimate
 
 
 def _parse_work_week_pattern(pattern: str) -> list[float]:
@@ -209,35 +326,28 @@ def capacity_hours(
     state = project.holiday_state if project else "BY"
 
     person = session.get(Person, person_id)
-    pattern: list[float] | None = None
-    if person and person.work_week_pattern:
-        try:
-            pattern = _parse_work_week_pattern(person.work_week_pattern)
-        except ValueError:
-            pattern = None
+    pattern = parse_work_week_pattern_or_none(person)
 
     if pattern is None:
         avail = available_days(person_id, start, end, country, state, session, client)
         return max(0.0, avail * (membership.weekly_capacity_hours / 5.0))
 
-    # Pattern-aware: sum hours for each working day not covered by holidays/absences.
-    holidays = get_holidays_in_range(start, end, country, state, session, client)
-    holiday_dates = {h.holiday_date for h in holidays if h.is_workday}
-    absence_count = absence_days_in_range(person_id, start, end, session)
-    vacation_estimate = estimated_vacation_days(person_id, start, end, session)
-    # Compute available fraction: (working_days - absences - vacations) / working_days
-    wdays = working_days(start, end)
-    net_working_days = max(0.0, wdays - absence_count - vacation_estimate)
-    if wdays == 0:
+    # Pattern-aware: sum pattern hours over the person's effective working days,
+    # scaled by the availability fraction. Base, absences and holidays all use the
+    # same effective-working-day definition so nothing is deducted twice.
+    workdates = effective_working_dates(start, end, session, country, state, pattern, client)
+    base = len(workdates)
+    if base == 0:
         return 0.0
-    availability_fraction = net_working_days / wdays
+    absence_count = absence_days_in_range(person_id, start, end, session, country, state, client)
+    vacation_estimate = estimated_vacation_days(
+        person_id, start, end, session, 0.0, country, state, client
+    )
+    net_working_days = max(0.0, base - absence_count - vacation_estimate)
+    availability_fraction = net_working_days / base
 
     total = 0.0
-    day = start
-    while day <= end:
-        wd = day.weekday()
-        if wd < 5 and day not in holiday_dates:
-            h = _hours_per_day_from_pattern(pattern, wd, membership.weekly_capacity_hours)
-            total += h * availability_fraction
-        day += timedelta(days=1)
+    for day in workdates:
+        h = _hours_per_day_from_pattern(pattern, day.weekday(), membership.weekly_capacity_hours)
+        total += h * availability_fraction
     return max(0.0, total)

--- a/backend/app/services/planning.py
+++ b/backend/app/services/planning.py
@@ -193,6 +193,56 @@ def vacation_days_consumed_in_year(
     return float(consumed)
 
 
+def _person_daily_hours(person: Person | None, weekday: int, pattern: list[float] | None) -> float:
+    """Absolute hours the person works on a given weekday (Mon=0 … Fri=4)."""
+    if weekday >= 5:
+        return 0.0
+    if pattern is not None:
+        return pattern[weekday]
+    if person is None:
+        return 0.0
+    return person.default_weekly_hours / 5.0
+
+
+def absence_booking(
+    person: Person,
+    absence: PersonAbsence,
+    session: Session,
+    country: str | None = None,
+    state: str | None = None,
+    client: httpx.Client | None = None,
+) -> dict:
+    """What a single absence books for the person.
+
+    Returns ``working_days`` (Mon–Fri ∩ no holiday ∩ pattern>0 within the absence
+    range) and ``hours`` (person's daily hours summed over those days). For a
+    vacation absence it also returns ``contingent_days`` = working days that
+    actually draw down the vacation contingent, i.e. after refunding days topped
+    by a confirmed sick absence (AU). Region defaults to the person's own.
+    """
+    if country is None:
+        country, state = resolve_holiday_region(session, person)
+    pattern = parse_work_week_pattern_or_none(person)
+    a_end = absence.end_date if absence.end_date is not None else date.today()
+    if a_end < absence.start_date:
+        return {"working_days": 0, "hours": 0.0}
+    workdates = effective_working_dates(
+        absence.start_date, a_end, session, country, state or "", pattern, client
+    )
+    days = len(workdates)
+    hours = sum(_person_daily_hours(person, d.weekday(), pattern) for d in workdates)
+    result: dict = {"working_days": days, "hours": round(hours, 2)}
+    if absence.absence_type == AbsenceType.vacation:
+        sick_confirmed = [
+            a for a in _overlapping_absences(person.id, absence.start_date, a_end, session)
+            if _is_confirmed_sick(a)
+        ]
+        result["contingent_days"] = sum(
+            1 for d in workdates if not any(_covers(s, d) for s in sick_confirmed)
+        )
+    return result
+
+
 def estimated_vacation_days(
     person_id: int,
     start: date,

--- a/backend/app/services/planning.py
+++ b/backend/app/services/planning.py
@@ -243,6 +243,75 @@ def absence_booking(
     return result
 
 
+def absence_summary(
+    person: Person,
+    year: int,
+    session: Session,
+    country: str | None = None,
+    state: str | None = None,
+    client: httpx.Client | None = None,
+) -> dict:
+    """Per-year absence overview for one person.
+
+    Returns, for the given ``year``:
+    - ``categories``: for each AbsenceType a ``{days, hours}`` sum of booked working
+      days (deduped within the type) and the person's hours over them.
+    - ``vacation``: ``{contingent, taken, planned, open}`` in working days. Taken =
+      confirmed vacation, planned = planned vacation; both after the confirmed-sick
+      (AU) refund. Open = max(0, contingent − taken − planned).
+
+    All counts respect weekends, holidays (effective region) and the work-week pattern.
+    """
+    if country is None:
+        country, state = resolve_holiday_region(session, person)
+    pattern = parse_work_week_pattern_or_none(person)
+    year_start, year_end = date(year, 1, 1), date(year, 12, 31)
+    workdates = effective_working_dates(year_start, year_end, session, country, state or "", pattern, client)
+    absences = _overlapping_absences(person.id, year_start, year_end, session)
+
+    def hours_over(days: list[date]) -> float:
+        return round(sum(_person_daily_hours(person, d.weekday(), pattern) for d in days), 2)
+
+    categories: dict[str, dict] = {}
+    for t in AbsenceType:
+        of_type = [a for a in absences if a.absence_type == t]
+        covered = [d for d in workdates if any(_covers(a, d) for a in of_type)]
+        categories[t.value] = {"days": len(covered), "hours": hours_over(covered)}
+
+    # Vacation split by status, with the confirmed-sick (AU) refund applied.
+    sick_confirmed = [a for a in absences if _is_confirmed_sick(a)]
+    vac_confirmed = [a for a in absences if a.absence_type == AbsenceType.vacation and a.status == AbsenceStatus.confirmed]
+    vac_planned = [a for a in absences if a.absence_type == AbsenceType.vacation and a.status == AbsenceStatus.planned]
+    taken = planned = 0
+    for d in workdates:
+        if any(_covers(s, d) for s in sick_confirmed):
+            continue  # topped by AU → refunded, consumes no vacation
+        if any(_covers(a, d) for a in vac_confirmed):
+            taken += 1
+        elif any(_covers(a, d) for a in vac_planned):
+            planned += 1
+
+    contingent_row = session.exec(
+        select(VacationContingent).where(
+            VacationContingent.person_id == person.id,
+            VacationContingent.year == year,
+        )
+    ).first()
+    contingent = contingent_row.total_days if contingent_row else 0.0
+    open_days = max(0.0, contingent - taken - planned)
+
+    return {
+        "year": year,
+        "categories": categories,
+        "vacation": {
+            "contingent": contingent,
+            "taken": float(taken),
+            "planned": float(planned),
+            "open": open_days,
+        },
+    }
+
+
 def estimated_vacation_days(
     person_id: int,
     start: date,

--- a/backend/app/services/planning.py
+++ b/backend/app/services/planning.py
@@ -16,7 +16,7 @@ from datetime import date, timedelta
 import httpx
 from sqlmodel import Session, select
 
-from app.models.enums import AbsenceStatus, AbsenceType
+from app.models.enums import AbsenceDaySegment, AbsenceStatus, AbsenceType
 from app.models.membership import ProjectMembership
 from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.project import Project
@@ -121,6 +121,25 @@ def _covers(absence: PersonAbsence, day: date) -> bool:
     return absence.start_date <= day <= a_end
 
 
+def _day_fraction(absence: PersonAbsence, day: date) -> float:
+    """Fraction of ``day`` the absence covers: 0.0 (not covered), 0.5 (half) or 1.0.
+
+    The start day uses start_segment, the end day uses end_segment; a single-day
+    absence (start == end) uses start_segment. Middle days are always full.
+    A morning/afternoon segment is half a day; full is a whole day.
+    """
+    a_end = absence.end_date if absence.end_date is not None else date.today()
+    if not (absence.start_date <= day <= a_end):
+        return 0.0
+    if day == absence.start_date:  # also the single-day case (start == end)
+        seg = absence.start_segment
+    elif day == a_end:
+        seg = absence.end_segment
+    else:
+        return 1.0
+    return 0.5 if seg in (AbsenceDaySegment.morning, AbsenceDaySegment.afternoon) else 1.0
+
+
 def _is_confirmed_sick(a: PersonAbsence) -> bool:
     """A sick record with a medical certificate on file (AU vorliegt)."""
     return a.absence_type == AbsenceType.sick and a.status == AbsenceStatus.confirmed
@@ -159,7 +178,9 @@ def absence_days_in_range(
     absences = _overlapping_absences(person_id, start, end, session)
     if not absences:
         return 0.0
-    return float(sum(1 for d in workdates if any(_covers(a, d) for a in absences)))
+    # Per working day, the absent portion = the largest coverage among overlapping
+    # absences (0.5 for a half day, 1.0 for a full day); summed over the range.
+    return sum(max((_day_fraction(a, d) for a in absences), default=0.0) for d in workdates)
 
 
 def vacation_days_consumed_in_year(
@@ -186,11 +207,12 @@ def vacation_days_consumed_in_year(
     sick_confirmed = [a for a in absences if _is_confirmed_sick(a)]
     if not vac:
         return 0.0
-    consumed = 0
+    consumed = 0.0
     for d in workdates:
-        if any(_covers(a, d) for a in vac) and not any(_covers(a, d) for a in sick_confirmed):
-            consumed += 1
-    return float(consumed)
+        if any(_covers(a, d) for a in sick_confirmed):
+            continue  # topped by AU → refunded
+        consumed += max((_day_fraction(a, d) for a in vac), default=0.0)
+    return consumed
 
 
 def _person_daily_hours(person: Person | None, weekday: int, pattern: list[float] | None) -> float:
@@ -229,17 +251,17 @@ def absence_booking(
     workdates = effective_working_dates(
         absence.start_date, a_end, session, country, state or "", pattern, client
     )
-    days = len(workdates)
-    hours = sum(_person_daily_hours(person, d.weekday(), pattern) for d in workdates)
+    days = round(sum(_day_fraction(absence, d) for d in workdates), 3)
+    hours = sum(_day_fraction(absence, d) * _person_daily_hours(person, d.weekday(), pattern) for d in workdates)
     result: dict = {"working_days": days, "hours": round(hours, 2)}
     if absence.absence_type == AbsenceType.vacation:
         sick_confirmed = [
             a for a in _overlapping_absences(person.id, absence.start_date, a_end, session)
             if _is_confirmed_sick(a)
         ]
-        result["contingent_days"] = sum(
-            1 for d in workdates if not any(_covers(s, d) for s in sick_confirmed)
-        )
+        result["contingent_days"] = round(sum(
+            _day_fraction(absence, d) for d in workdates if not any(_covers(s, d) for s in sick_confirmed)
+        ), 3)
     return result
 
 
@@ -269,27 +291,32 @@ def absence_summary(
     workdates = effective_working_dates(year_start, year_end, session, country, state or "", pattern, client)
     absences = _overlapping_absences(person.id, year_start, year_end, session)
 
-    def hours_over(days: list[date]) -> float:
-        return round(sum(_person_daily_hours(person, d.weekday(), pattern) for d in days), 2)
-
     categories: dict[str, dict] = {}
     for t in AbsenceType:
         of_type = [a for a in absences if a.absence_type == t]
-        covered = [d for d in workdates if any(_covers(a, d) for a in of_type)]
-        categories[t.value] = {"days": len(covered), "hours": hours_over(covered)}
+        days = 0.0
+        hours = 0.0
+        for d in workdates:
+            frac = max((_day_fraction(a, d) for a in of_type), default=0.0)
+            if frac:
+                days += frac
+                hours += frac * _person_daily_hours(person, d.weekday(), pattern)
+        categories[t.value] = {"days": round(days, 3), "hours": round(hours, 2)}
 
     # Vacation split by status, with the confirmed-sick (AU) refund applied.
     sick_confirmed = [a for a in absences if _is_confirmed_sick(a)]
     vac_confirmed = [a for a in absences if a.absence_type == AbsenceType.vacation and a.status == AbsenceStatus.confirmed]
     vac_planned = [a for a in absences if a.absence_type == AbsenceType.vacation and a.status == AbsenceStatus.planned]
-    taken = planned = 0
+    taken = planned = 0.0
     for d in workdates:
         if any(_covers(s, d) for s in sick_confirmed):
             continue  # topped by AU → refunded, consumes no vacation
-        if any(_covers(a, d) for a in vac_confirmed):
-            taken += 1
-        elif any(_covers(a, d) for a in vac_planned):
-            planned += 1
+        tf = max((_day_fraction(a, d) for a in vac_confirmed), default=0.0)
+        pf = max((_day_fraction(a, d) for a in vac_planned), default=0.0)
+        if tf > 0:
+            taken += tf
+        elif pf > 0:
+            planned += pf
 
     contingent_row = session.exec(
         select(VacationContingent).where(
@@ -305,9 +332,9 @@ def absence_summary(
         "categories": categories,
         "vacation": {
             "contingent": contingent,
-            "taken": float(taken),
-            "planned": float(planned),
-            "open": open_days,
+            "taken": round(taken, 3),
+            "planned": round(planned, 3),
+            "open": round(open_days, 3),
         },
     }
 

--- a/backend/tests/unit/test_services_planning.py
+++ b/backend/tests/unit/test_services_planning.py
@@ -8,7 +8,7 @@ from hypothesis import strategies as st
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
-from app.models.enums import AbsenceStatus, AbsenceType
+from app.models.enums import AbsenceDaySegment, AbsenceStatus, AbsenceType
 from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.project import Project
 from app.models.membership import ProjectMembership
@@ -96,6 +96,8 @@ def _make_absence(
     end: date | None,
     absence_type: AbsenceType = AbsenceType.vacation,
     status: AbsenceStatus = AbsenceStatus.planned,
+    start_segment: AbsenceDaySegment = AbsenceDaySegment.full,
+    end_segment: AbsenceDaySegment = AbsenceDaySegment.full,
 ) -> PersonAbsence:
     a = PersonAbsence(
         person_id=person_id,
@@ -103,6 +105,8 @@ def _make_absence(
         end_date=end,
         absence_type=absence_type,
         status=status,
+        start_segment=start_segment,
+        end_segment=end_segment,
     )
     session.add(a)
     session.commit()
@@ -555,6 +559,63 @@ def test_absence_summary_confirmed_sick_refunds_vacation(mem_session):
     # Only Mon+Tue draw vacation; Wed–Fri refunded by AU
     assert s["vacation"]["taken"] == 2.0
     assert s["vacation"]["open"] == 28.0
+
+
+# ---------------------------------------------------------------------------
+# Half-day absences (segments)
+# ---------------------------------------------------------------------------
+
+def test_half_day_single_counts_half(mem_session):
+    p = _make_person(mem_session)  # 40h/week → 8h/day
+    a = _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 1),  # Monday, single day
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+        start_segment=AbsenceDaySegment.afternoon,
+    )
+    b = absence_booking(p, a, mem_session, "DE", "BY", _empty_client())
+    assert b["working_days"] == 0.5
+    assert b["hours"] == 4.0
+    assert b["contingent_days"] == 0.5
+
+
+def test_half_day_range_start_and_end(mem_session):
+    """Mon–Fri with a half start and half end day → 4.0 working days."""
+    p = _make_person(mem_session)
+    a = _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5),  # Mon–Fri = 5 full
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+        start_segment=AbsenceDaySegment.afternoon, end_segment=AbsenceDaySegment.morning,
+    )
+    b = absence_booking(p, a, mem_session, "DE", "BY", _empty_client())
+    assert b["working_days"] == 4.0  # 0.5 + 1 + 1 + 1 + 0.5
+    assert b["hours"] == 32.0
+
+
+def test_half_day_absence_days_in_range(mem_session):
+    p = _make_person(mem_session)
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 1),
+        start_segment=AbsenceDaySegment.morning,
+    )
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
+    assert result == 0.5
+
+
+def test_half_day_summary_taken(mem_session):
+    p = _make_person(mem_session)
+    mem_session.add(VacationContingent(person_id=p.id, year=2026, total_days=30.0))
+    mem_session.commit()
+    _make_absence(
+        mem_session, p.id, date(2026, 3, 2), date(2026, 3, 2),  # single half day
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+        start_segment=AbsenceDaySegment.morning,
+    )
+    s = absence_summary(p, 2026, mem_session, "DE", "BY", _empty_client())
+    assert s["vacation"]["taken"] == 0.5
+    assert s["vacation"]["open"] == 29.5
+    assert s["categories"]["vacation"]["days"] == 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_services_planning.py
+++ b/backend/tests/unit/test_services_planning.py
@@ -14,6 +14,7 @@ from app.models.project import Project
 from app.models.membership import ProjectMembership
 from app.services.planning import (
     absence_booking,
+    absence_summary,
     absence_days_in_range,
     available_days,
     capacity_hours,
@@ -509,6 +510,51 @@ def test_absence_booking_non_vacation_has_no_contingent(mem_session):
     result = absence_booking(p, a, mem_session, "DE", "BY", _empty_client())
     assert result["working_days"] == 3
     assert "contingent_days" not in result
+
+
+# ---------------------------------------------------------------------------
+# absence_summary (per-year overview)
+# ---------------------------------------------------------------------------
+
+def test_absence_summary_vacation_split_and_open(mem_session):
+    p = _make_person(mem_session)
+    mem_session.add(VacationContingent(person_id=p.id, year=2026, total_days=30.0))
+    mem_session.commit()
+    _make_absence(  # confirmed = genommen, 5 working days
+        mem_session, p.id, date(2026, 3, 2), date(2026, 3, 6),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )
+    _make_absence(  # planned = geplant, 3 working days
+        mem_session, p.id, date(2026, 9, 21), date(2026, 9, 23),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.planned,
+    )
+    _make_absence(  # sick, own category
+        mem_session, p.id, date(2026, 4, 1), date(2026, 4, 2),
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )
+    s = absence_summary(p, 2026, mem_session, "DE", "BY", _empty_client())
+    assert s["vacation"] == {"contingent": 30.0, "taken": 5.0, "planned": 3.0, "open": 22.0}
+    assert s["categories"]["vacation"]["days"] == 8
+    assert s["categories"]["sick"]["days"] == 2
+    assert s["categories"]["training"]["days"] == 0
+
+
+def test_absence_summary_confirmed_sick_refunds_vacation(mem_session):
+    p = _make_person(mem_session)
+    mem_session.add(VacationContingent(person_id=p.id, year=2026, total_days=30.0))
+    mem_session.commit()
+    _make_absence(
+        mem_session, p.id, date(2026, 3, 2), date(2026, 3, 6),  # 5 wd vacation confirmed
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )
+    _make_absence(
+        mem_session, p.id, date(2026, 3, 4), date(2026, 3, 6),  # 3 wd confirmed sick (AU)
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )
+    s = absence_summary(p, 2026, mem_session, "DE", "BY", _empty_client())
+    # Only Mon+Tue draw vacation; Wed–Fri refunded by AU
+    assert s["vacation"]["taken"] == 2.0
+    assert s["vacation"]["open"] == 28.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_services_planning.py
+++ b/backend/tests/unit/test_services_planning.py
@@ -13,6 +13,7 @@ from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.project import Project
 from app.models.membership import ProjectMembership
 from app.services.planning import (
+    absence_booking,
     absence_days_in_range,
     available_days,
     capacity_hours,
@@ -457,6 +458,57 @@ def test_estimated_vacation_refunded_days_return_to_contingent(mem_session):
         p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
     )
     assert result > 0.0  # refund left contingent to distribute
+
+
+# ---------------------------------------------------------------------------
+# absence_booking (per-absence UI metrics)
+# ---------------------------------------------------------------------------
+
+def test_absence_booking_days_and_hours(mem_session):
+    p = _make_person(mem_session)  # 40h/week → 8h/working day
+    a = _make_absence(mem_session, p.id, date(2026, 6, 1), date(2026, 6, 10))  # vacation
+    result = absence_booking(p, a, mem_session, "DE", "BY", _empty_client())
+    assert result["working_days"] == 8
+    assert result["hours"] == 64.0  # 8 days × 8h
+    assert result["contingent_days"] == 8
+
+
+def test_absence_booking_uses_pattern_hours(mem_session):
+    p = _make_person(mem_session)
+    p.work_week_pattern = "8,8,8,8,0"  # 4-day week
+    mem_session.add(p)
+    mem_session.commit()
+    a = _make_absence(mem_session, p.id, date(2026, 4, 20), date(2026, 4, 24))  # Mon–Fri
+    result = absence_booking(p, a, mem_session, "DE", "BY", _empty_client())
+    assert result["working_days"] == 4  # Fri excluded by pattern
+    assert result["hours"] == 32.0
+    assert result["contingent_days"] == 4
+
+
+def test_absence_booking_vacation_refunds_confirmed_sick(mem_session):
+    p = _make_person(mem_session)
+    vac = _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 3), date(2026, 6, 5),
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )
+    result = absence_booking(p, vac, mem_session, "DE", "BY", _empty_client())
+    assert result["working_days"] == 5   # the vacation still spans 5 working days …
+    assert result["contingent_days"] == 2  # … but only Mon+Tue draw down the contingent
+
+
+def test_absence_booking_non_vacation_has_no_contingent(mem_session):
+    p = _make_person(mem_session)
+    a = _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 3),
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )
+    result = absence_booking(p, a, mem_session, "DE", "BY", _empty_client())
+    assert result["working_days"] == 3
+    assert "contingent_days" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_services_planning.py
+++ b/backend/tests/unit/test_services_planning.py
@@ -17,6 +17,7 @@ from app.services.planning import (
     available_days,
     capacity_hours,
     estimated_vacation_days,
+    vacation_days_consumed_in_year,
     working_days,
 )
 
@@ -107,6 +108,19 @@ def _make_absence(
     return a
 
 
+def _empty_client():
+    """httpx client whose holiday API always returns no holidays (deterministic)."""
+    import httpx
+    return httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+
+
+def _holiday_client(mapping: dict[str, str]):
+    """httpx client returning fixed holidays. mapping: {name: 'YYYY-MM-DD'}."""
+    import httpx
+    payload = {name: {"datum": d, "hinweis": ""} for name, d in mapping.items()}
+    return httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, json=payload)))
+
+
 # ---------------------------------------------------------------------------
 # working_days
 # ---------------------------------------------------------------------------
@@ -171,57 +185,110 @@ def test_working_days_never_exceeds_calendar_days(start_offset, length):
 
 def test_absence_days_no_absences(mem_session):
     p = _make_person(mem_session)
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
     assert result == 0
 
 
-def test_absence_days_full_overlap(mem_session):
+def test_absence_days_counts_working_days_only(mem_session):
+    """A Mon–next-Wed absence (10 calendar days) counts only its 8 working days."""
     p = _make_person(mem_session)
     _make_absence(mem_session, p.id, date(2026, 6, 1), date(2026, 6, 10))
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 10), mem_session)
-    assert result == 10
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 10), mem_session, "DE", "BY", _empty_client()
+    )
+    assert result == 8  # 01–05 (Mon–Fri) + 08–10 (Mon–Wed); 06/07 weekend excluded
 
 
-def test_absence_days_partial_overlap_before(mem_session):
+def test_absence_days_excludes_weekend_only_absence(mem_session):
+    """An absence that falls entirely on a weekend books zero days."""
     p = _make_person(mem_session)
-    # Absence starts before the period
-    _make_absence(mem_session, p.id, date(2026, 5, 25), date(2026, 6, 5))
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
-    assert result == 5  # 6-01 to 6-05
+    _make_absence(mem_session, p.id, date(2026, 6, 6), date(2026, 6, 7))  # Sat+Sun
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
+    assert result == 0
+
+
+def test_absence_days_excludes_holiday(mem_session):
+    """A public holiday inside the absence range does not count as an absence day."""
+    p = _make_person(mem_session)
+    _make_absence(mem_session, p.id, date(2026, 1, 5), date(2026, 1, 9))  # Mon–Fri = 5
+    # Tuesday 2026-01-06 is a holiday → only 4 working days remain
+    client = _holiday_client({"Heilige Drei Könige": "2026-01-06"})
+    result = absence_days_in_range(
+        p.id, date(2026, 1, 5), date(2026, 1, 9), mem_session, "DE", "BY", client
+    )
+    assert result == 4
+
+
+def test_absence_days_excludes_non_working_pattern_day(mem_session):
+    """A 4-day-week person (no Friday) does not book a vacation day on Fridays."""
+    p = _make_person(mem_session)
+    p.work_week_pattern = "8,8,8,8,0"
+    mem_session.add(p)
+    mem_session.commit()
+    _make_absence(mem_session, p.id, date(2026, 4, 20), date(2026, 4, 24))  # Mon–Fri
+    result = absence_days_in_range(
+        p.id, date(2026, 4, 20), date(2026, 4, 24), mem_session, "DE", "BY", _empty_client()
+    )
+    assert result == 4  # Fri excluded by pattern
 
 
 def test_absence_days_partial_overlap_after(mem_session):
     p = _make_person(mem_session)
-    # Absence ends after the period
+    # Absence ends after the period; overlap 06-25..06-30 has 4 working days (Thu,Fri,Mon,Tue)
     _make_absence(mem_session, p.id, date(2026, 6, 25), date(2026, 7, 5))
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
-    assert result == 6  # 6-25 to 6-30
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
+    assert result == 4
 
 
 def test_absence_days_no_overlap(mem_session):
     p = _make_person(mem_session)
     _make_absence(mem_session, p.id, date(2026, 7, 1), date(2026, 7, 10))
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
     assert result == 0
+
+
+def test_absence_days_overlapping_absences_counted_once(mem_session):
+    """Overlapping vacation + sick on the same days must not double-count."""
+    p = _make_person(mem_session)
+    _make_absence(mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5))  # vacation Mon–Fri
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 3), date(2026, 6, 5),
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )  # sick overlaps Wed–Fri
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
+    assert result == 5  # union of covered working days, not 5+3
 
 
 def test_absence_days_ongoing_sick_uses_today(mem_session):
     p = _make_person(mem_session)
-    # Ongoing sick starting "today" — should count at least 1 day
-    today = date.today()
+    # Ongoing sick (null end) runs until today; a fixed past Monday is deterministically counted.
     _make_absence(
-        mem_session, p.id, today, None,
+        mem_session, p.id, date(2026, 1, 5), None,
         absence_type=AbsenceType.sick, status=AbsenceStatus.ongoing,
     )
-    result = absence_days_in_range(p.id, today, today, mem_session)
+    result = absence_days_in_range(
+        p.id, date(2026, 1, 5), date(2026, 1, 5), mem_session, "DE", "BY", _empty_client()
+    )
     assert result == 1
 
 
 def test_absence_days_multiple_absences(mem_session):
     p = _make_person(mem_session)
-    _make_absence(mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5))   # 5 days
-    _make_absence(mem_session, p.id, date(2026, 6, 10), date(2026, 6, 12)) # 3 days
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
+    _make_absence(mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5))   # 5 working days
+    _make_absence(mem_session, p.id, date(2026, 6, 10), date(2026, 6, 12)) # 3 working days
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
     assert result == 8
 
 
@@ -231,7 +298,9 @@ def test_absence_days_sick_confirmed_counts(mem_session):
         mem_session, p.id, date(2026, 6, 1), date(2026, 6, 3),
         absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
     )
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
     assert result == 3
 
 
@@ -242,7 +311,9 @@ def test_absence_days_other_counts_like_any_absence(mem_session):
         mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5),
         absence_type=AbsenceType.other, status=AbsenceStatus.confirmed,
     )
-    result = absence_days_in_range(p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session)
+    result = absence_days_in_range(
+        p.id, date(2026, 6, 1), date(2026, 6, 30), mem_session, "DE", "BY", _empty_client()
+    )
     assert result == 5
 
 
@@ -252,21 +323,25 @@ def test_absence_days_other_counts_like_any_absence(mem_session):
 
 def test_estimated_vacation_no_contingent(mem_session):
     p = _make_person(mem_session)
-    result = estimated_vacation_days(p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session)
+    result = estimated_vacation_days(
+        p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
+    )
     assert result == 0.0
 
 
 def test_estimated_vacation_all_used(mem_session):
     p = _make_person(mem_session)
-    # Contingent = 20 days, all already planned
+    # Contingent = 20 days, fully consumed by a 20-working-day vacation (Jan 5 – Jan 30).
     vc = VacationContingent(person_id=p.id, year=2026, total_days=20.0)
     mem_session.add(vc)
     mem_session.commit()
     _make_absence(
-        mem_session, p.id, date(2026, 1, 5), date(2026, 1, 24),
+        mem_session, p.id, date(2026, 1, 5), date(2026, 1, 30),
         absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
-    )  # 20 calendar days
-    result = estimated_vacation_days(p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session)
+    )  # 4 full weeks = 20 working days
+    result = estimated_vacation_days(
+        p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
+    )
     assert result == 0.0
 
 
@@ -278,7 +353,9 @@ def test_estimated_vacation_proportional(mem_session):
     vc = VacationContingent(person_id=p.id, year=2026, total_days=20.0)
     mem_session.add(vc)
     mem_session.commit()
-    result = estimated_vacation_days(p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session)
+    result = estimated_vacation_days(
+        p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
+    )
     expected = 20.0 * (31 / 184)
     assert abs(result - expected) < 0.01
 
@@ -291,8 +368,10 @@ def test_estimated_vacation_already_has_concrete_absence(mem_session):
     mem_session.commit()
     # Concrete vacation already planned in the period
     _make_absence(mem_session, p.id, date(2026, 7, 1), date(2026, 7, 10))
-    result = estimated_vacation_days(p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session)
-    # The 10 planned days reduce the remaining contingent;
+    result = estimated_vacation_days(
+        p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
+    )
+    # The planned days reduce the remaining contingent;
     # estimate applies only to remaining days without concrete absences.
     assert result >= 0.0
 
@@ -309,9 +388,75 @@ def test_estimated_vacation_ignores_other_type(mem_session):
         mem_session, p.id, date(2026, 1, 5), date(2026, 3, 31),
         absence_type=AbsenceType.other, status=AbsenceStatus.confirmed,
     )
-    result = estimated_vacation_days(p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session)
+    result = estimated_vacation_days(
+        p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
+    )
     expected = 20.0 * (31 / 184)  # identical to test_estimated_vacation_proportional
     assert abs(result - expected) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# vacation_days_consumed_in_year (working days + AU refund)
+# ---------------------------------------------------------------------------
+
+def test_vacation_consumed_working_days_only(mem_session):
+    p = _make_person(mem_session)
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 10),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )
+    result = vacation_days_consumed_in_year(p.id, 2026, mem_session, "DE", "BY", _empty_client())
+    assert result == 8  # 10 calendar → 8 working days
+
+
+def test_vacation_consumed_confirmed_sick_refunds(mem_session):
+    """Confirmed sick during vacation tops the vacation → those days are refunded."""
+    p = _make_person(mem_session)
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )  # 5 working days
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 3), date(2026, 6, 5),
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )  # AU covers Wed–Fri (3 working days)
+    result = vacation_days_consumed_in_year(p.id, 2026, mem_session, "DE", "BY", _empty_client())
+    assert result == 2  # only Mon+Tue consume vacation; Wed–Fri refunded
+
+
+def test_vacation_consumed_ongoing_sick_does_not_refund(mem_session):
+    """Sick without AU (ongoing) does NOT refund vacation days."""
+    p = _make_person(mem_session)
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 1), date(2026, 6, 5),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )
+    _make_absence(
+        mem_session, p.id, date(2026, 6, 3), None,
+        absence_type=AbsenceType.sick, status=AbsenceStatus.ongoing,
+    )
+    result = vacation_days_consumed_in_year(p.id, 2026, mem_session, "DE", "BY", _empty_client())
+    assert result == 5  # ongoing sick doesn't refund → all 5 vacation days stand
+
+
+def test_estimated_vacation_refunded_days_return_to_contingent(mem_session):
+    """A confirmed sick spell inside a booked vacation frees contingent for the estimate."""
+    p = _make_person(mem_session)
+    vc = VacationContingent(person_id=p.id, year=2026, total_days=20.0)
+    mem_session.add(vc)
+    mem_session.commit()
+    _make_absence(
+        mem_session, p.id, date(2026, 1, 5), date(2026, 1, 30),
+        absence_type=AbsenceType.vacation, status=AbsenceStatus.confirmed,
+    )  # would consume all 20 working days …
+    _make_absence(
+        mem_session, p.id, date(2026, 1, 5), date(2026, 1, 9),
+        absence_type=AbsenceType.sick, status=AbsenceStatus.confirmed,
+    )  # … but a confirmed sick week (5 wd) is refunded → 15 consumed, 5 remain
+    result = estimated_vacation_days(
+        p.id, date(2026, 7, 1), date(2026, 7, 31), mem_session, 0.0, "DE", "BY", _empty_client()
+    )
+    assert result > 0.0  # refund left contingent to distribute
 
 
 # ---------------------------------------------------------------------------
@@ -370,17 +515,17 @@ def test_available_days_subtracts_absences(mem_session):
     assert result == 2.0  # 5 working days − 3 absence days
 
 
-def test_available_days_can_be_negative(mem_session):
-    """absence_days counts calendar days, so a full Mon–Sun absence beats 5 working days."""
+def test_available_days_full_week_absence_is_zero(mem_session):
+    """A full Mon–Sun absence covers exactly the 5 working days → availability 0 (not negative)."""
     p = _make_person(mem_session)
     import httpx
     client = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
-    # Period Mon–Sun (5 working days), absence covers all 7 calendar days → 5 - 7 = -2
+    # Period Mon–Sun (5 working days); absence covers the whole week → 5 - 5 = 0
     _make_absence(mem_session, p.id, date(2026, 1, 5), date(2026, 1, 11))
     result = available_days(
         p.id, date(2026, 1, 5), date(2026, 1, 11), "DE", "BY", mem_session, client
     )
-    assert result < 0
+    assert result == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -371,6 +371,9 @@ export interface PersonAbsence {
   absence_type: 'vacation' | 'sick' | 'training' | 'other';
   status: 'planned' | 'confirmed' | 'ongoing';
   note: string;
+  // Half-day segments: which part of the start/end day the absence covers.
+  start_segment?: 'full' | 'morning' | 'afternoon';
+  end_segment?: 'full' | 'morning' | 'afternoon';
   // Booking metrics (backend-computed): working days & hours the absence books.
   booked_working_days?: number;
   booked_hours?: number;
@@ -478,6 +481,8 @@ export interface CalendarAbsence {
   end_date: string | null;
   absence_type: 'vacation' | 'sick' | 'training' | 'other';
   status: 'planned' | 'confirmed' | 'ongoing';
+  start_segment?: 'full' | 'morning' | 'afternoon';
+  end_segment?: 'full' | 'morning' | 'afternoon';
   booked_working_days?: number;
   booked_hours?: number;
   contingent_days?: number | null;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -378,6 +378,12 @@ export interface PersonAbsence {
   contingent_days?: number | null;
 }
 
+export interface AbsenceSummary {
+  year: number;
+  categories: Record<'vacation' | 'sick' | 'training' | 'other', { days: number; hours: number }>;
+  vacation: { contingent: number; taken: number; planned: number; open: number };
+}
+
 export interface VacationContingent {
   id: number;
   person_id: number;
@@ -413,6 +419,10 @@ export const persons = {
     req<PersonAbsence>('PUT', `/persons/${personId}/absences/${absenceId}`, d),
   deleteAbsence: (personId: number, absenceId: number) =>
     req<void>('DELETE', `/persons/${personId}/absences/${absenceId}`),
+  absenceSummary: (id: number, year?: number) =>
+    req<AbsenceSummary>('GET', `/persons/${id}/absence-summary${year ? `?year=${year}` : ''}`),
+  absenceSummaryBatch: (year?: number) =>
+    req<Record<number, AbsenceSummary>>('GET', `/persons/absence-summary${year ? `?year=${year}` : ''}`),
   vacationContingents: (id: number) => req<VacationContingent[]>('GET', `/persons/${id}/vacation-contingents`),
   addVacationContingent: (id: number, d: Omit<VacationContingent, 'id' | 'person_id'>) =>
     req<VacationContingent>('POST', `/persons/${id}/vacation-contingents`, d),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -371,6 +371,11 @@ export interface PersonAbsence {
   absence_type: 'vacation' | 'sick' | 'training' | 'other';
   status: 'planned' | 'confirmed' | 'ongoing';
   note: string;
+  // Booking metrics (backend-computed): working days & hours the absence books.
+  booked_working_days?: number;
+  booked_hours?: number;
+  // Vacation only: contingent days consumed after the confirmed-sick (AU) refund.
+  contingent_days?: number | null;
 }
 
 export interface VacationContingent {
@@ -463,6 +468,9 @@ export interface CalendarAbsence {
   end_date: string | null;
   absence_type: 'vacation' | 'sick' | 'training' | 'other';
   status: 'planned' | 'confirmed' | 'ongoing';
+  booked_working_days?: number;
+  booked_hours?: number;
+  contingent_days?: number | null;
 }
 
 export interface CalendarMembership {

--- a/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
+++ b/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
@@ -7,8 +7,14 @@ import { TYPE_LABELS, STATUS_LABELS } from '../../lib/absenceColors'
 
 type AbsenceType = 'vacation' | 'sick' | 'training' | 'other'
 type AbsenceStatus = 'planned' | 'confirmed' | 'ongoing'
+type DaySegment = 'full' | 'morning' | 'afternoon'
 
 const TYPES: AbsenceType[] = ['vacation', 'training', 'sick', 'other']
+const SEGMENTS: [DaySegment, string][] = [
+  ['full', 'Voller Tag'],
+  ['morning', 'Vormittag (½)'],
+  ['afternoon', 'Nachmittag (½)'],
+]
 
 function allowedStatuses(type: AbsenceType): AbsenceStatus[] {
   return type === 'sick' ? ['confirmed', 'ongoing'] : ['planned', 'confirmed']
@@ -45,9 +51,13 @@ export default function AbsenceQuickCreateModal({
   const [start, setStart] = useState(editAbsence?.start_date ?? startDate)
   const [end, setEnd] = useState(editAbsence?.end_date ?? endDate)
   const [note, setNote] = useState(editAbsence?.note ?? '')
+  const [startSegment, setStartSegment] = useState<DaySegment>(editAbsence?.start_segment ?? 'full')
+  const [endSegment, setEndSegment] = useState<DaySegment>(editAbsence?.end_segment ?? 'full')
   const [error, setError] = useState<string | null>(null)
 
   const isOngoing = type === 'sick' && status === 'ongoing'
+  // Single-day (or ongoing) uses one segment; multi-day uses a start- and end-day segment.
+  const singleDay = isOngoing || start === end
 
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ['calendar-year'] })
@@ -65,6 +75,9 @@ export default function AbsenceQuickCreateModal({
         absence_type: type,
         status,
         note,
+        start_segment: startSegment,
+        // On a single-day/ongoing absence only the start segment is meaningful.
+        end_segment: singleDay ? 'full' as DaySegment : endSegment,
       }
       return isEdit
         ? personsApi.updateAbsence(editAbsence!.person_id, editAbsence!.id, payload)
@@ -151,6 +164,45 @@ export default function AbsenceQuickCreateModal({
             />
           </div>
         </div>
+
+        {/* Half-day segments. One dropdown for a single day (or ongoing), two for a range. */}
+        {singleDay ? (
+          <div>
+            <label htmlFor="qc-seg" className="block text-xs font-medium text-gray-600 mb-1">
+              Tag <span className="font-normal text-gray-400">— voller oder halber Tag</span>
+            </label>
+            <select id="qc-seg"
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={startSegment}
+              onChange={(e) => setStartSegment(e.target.value as DaySegment)}
+            >
+              {SEGMENTS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+            </select>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="qc-seg-start" className="block text-xs font-medium text-gray-600 mb-1">Erster Tag</label>
+              <select id="qc-seg-start"
+                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                value={startSegment}
+                onChange={(e) => setStartSegment(e.target.value as DaySegment)}
+              >
+                {SEGMENTS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="qc-seg-end" className="block text-xs font-medium text-gray-600 mb-1">Letzter Tag</label>
+              <select id="qc-seg-end"
+                className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                value={endSegment}
+                onChange={(e) => setEndSegment(e.target.value as DaySegment)}
+              >
+                {SEGMENTS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+              </select>
+            </div>
+          </div>
+        )}
 
         <div>
           <label htmlFor="qc-note" className="block text-xs font-medium text-gray-600 mb-1">Notiz <span className="font-normal text-gray-400">optional</span></label>

--- a/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
+++ b/frontend/src/components/absence/AbsenceQuickCreateModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { persons as personsApi } from '../../api'
+import { Trash2 } from 'lucide-react'
+import { persons as personsApi, type PersonAbsence } from '../../api'
 import Modal from '../Modal'
 import { TYPE_LABELS, STATUS_LABELS } from '../../lib/absenceColors'
 
@@ -23,6 +24,7 @@ export default function AbsenceQuickCreateModal({
   initialPersonId,
   startDate,
   endDate,
+  editAbsence,
   onClose,
   onCreated,
 }: {
@@ -30,34 +32,51 @@ export default function AbsenceQuickCreateModal({
   initialPersonId: number | null
   startDate: string
   endDate: string
+  /** When set, the modal edits this existing absence instead of creating one. */
+  editAbsence?: PersonAbsence | null
   onClose: () => void
   onCreated: () => void
 }) {
   const qc = useQueryClient()
-  const [personId, setPersonId] = useState<number | null>(initialPersonId)
-  const [type, setType] = useState<AbsenceType>('vacation')
-  const [status, setStatus] = useState<AbsenceStatus>('confirmed')
-  const [start, setStart] = useState(startDate)
-  const [end, setEnd] = useState(endDate)
-  const [note, setNote] = useState('')
+  const isEdit = !!editAbsence
+  const [personId, setPersonId] = useState<number | null>(editAbsence?.person_id ?? initialPersonId)
+  const [type, setType] = useState<AbsenceType>(editAbsence?.absence_type ?? 'vacation')
+  const [status, setStatus] = useState<AbsenceStatus>(editAbsence?.status ?? 'confirmed')
+  const [start, setStart] = useState(editAbsence?.start_date ?? startDate)
+  const [end, setEnd] = useState(editAbsence?.end_date ?? endDate)
+  const [note, setNote] = useState(editAbsence?.note ?? '')
   const [error, setError] = useState<string | null>(null)
 
   const isOngoing = type === 'sick' && status === 'ongoing'
 
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['calendar-year'] })
+    qc.invalidateQueries({ queryKey: ['absence-summary'] })
+    qc.invalidateQueries({ queryKey: ['absence-summary-batch'] })
+    qc.invalidateQueries({ queryKey: ['absences', personId] })
+    qc.invalidateQueries({ queryKey: ['persons', personId, 'absences'] })
+  }
+
   const create = useMutation({
-    mutationFn: () =>
-      personsApi.addAbsence(personId as number, {
+    mutationFn: () => {
+      const payload = {
         start_date: start,
         end_date: isOngoing ? null : end,
         absence_type: type,
         status,
         note,
-      }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['calendar-year'] })
-      qc.invalidateQueries({ queryKey: ['persons', personId, 'absences'] })
-      onCreated()
+      }
+      return isEdit
+        ? personsApi.updateAbsence(editAbsence!.person_id, editAbsence!.id, payload)
+        : personsApi.addAbsence(personId as number, payload)
     },
+    onSuccess: () => { invalidate(); onCreated() },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  const remove = useMutation({
+    mutationFn: () => personsApi.deleteAbsence(editAbsence!.person_id, editAbsence!.id),
+    onSuccess: () => { invalidate(); onCreated() },
     onError: (e: Error) => setError(e.message),
   })
 
@@ -75,12 +94,12 @@ export default function AbsenceQuickCreateModal({
   }
 
   return (
-    <Modal title="Neue Abwesenheit" onClose={onClose}>
+    <Modal title={isEdit ? 'Abwesenheit bearbeiten' : 'Neue Abwesenheit'} onClose={onClose}>
       <form onSubmit={submit} className="space-y-3">
         <div>
           <label htmlFor="qc-person" className="block text-xs font-medium text-gray-600 mb-1">Mitarbeiter</label>
-          <select id="qc-person" required
-            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          <select id="qc-person" required disabled={isEdit}
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
             value={personId ?? ''}
             onChange={(e) => setPersonId(e.target.value ? parseInt(e.target.value) : null)}
           >
@@ -142,14 +161,28 @@ export default function AbsenceQuickCreateModal({
           />
         </div>
 
+        {isEdit && status === 'planned' && (end || start) < new Date().toISOString().slice(0, 10) && (
+          <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1.5">
+            Dieser geplante Zeitraum liegt in der Vergangenheit — bitte auf „Bestätigt" umstellen, falls er tatsächlich stattgefunden hat.
+          </p>
+        )}
+
         {error && <p className="text-sm text-red-600">{error}</p>}
 
-        <div className="flex justify-end gap-2 pt-2">
-          <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
-          <button type="submit" disabled={create.isPending}
-            className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
-            Speichern
-          </button>
+        <div className="flex items-center gap-2 pt-2">
+          {isEdit && (
+            <button type="button" onClick={() => remove.mutate()} disabled={remove.isPending}
+              className="flex items-center gap-1 px-2 py-1.5 text-sm text-red-600 hover:bg-red-50 rounded disabled:opacity-50" aria-label="Abwesenheit löschen">
+              <Trash2 size={14} /> Löschen
+            </button>
+          )}
+          <div className="ml-auto flex gap-2">
+            <button type="button" onClick={onClose} className="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Abbrechen</button>
+            <button type="submit" disabled={create.isPending}
+              className="px-4 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+              Speichern
+            </button>
+          </div>
         </div>
       </form>
     </Modal>

--- a/frontend/src/components/absence/YearCalendar.tsx
+++ b/frontend/src/components/absence/YearCalendar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronUp, ChevronDown, ChevronsUp, ChevronsDown, LocateFixed } from 'lucide-react'
 import type { YearHoliday, YearCalendarPerson } from '../../api'
 import { TYPE_SHORT, TYPE_LABELS, STATUS_LABELS, personColor } from '../../lib/absenceColors'
-import { computeAbsenceSegments } from '../../lib/absenceSegments'
+import { computeAbsenceSegments, type AbsenceSegment } from '../../lib/absenceSegments'
 import { regionKey, regionShade } from '../../lib/holidayRegions'
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
@@ -48,6 +48,32 @@ function fmtDe(iso: string | null): string {
   return `${d}.${m}.${y}`
 }
 
+/** A planned absence whose period already lies in the past should be confirmed. */
+function needsConfirmation(status: string, absEnd: string | null, absStart: string, todayStr: string): boolean {
+  if (status !== 'planned') return false
+  return (absEnd ?? absStart) < todayStr
+}
+
+/** Multi-line hover tooltip for an absence bar: who/type/status, range, booked
+ *  working days & hours, vacation contingent (after AU refund) and a hint when a
+ *  past-dated planned absence still needs confirmation. */
+function barTooltip(s: AbsenceSegment, todayStr: string): string {
+  const lines = [
+    `${s.personName} · ${TYPE_LABELS[s.type]} (${STATUS_LABELS[s.status]})`,
+    `${fmtDe(s.absStart)} – ${fmtDe(s.absEnd)}`,
+  ]
+  if (s.bookedWorkingDays != null) {
+    lines.push(`Bucht: ${s.bookedWorkingDays} Arbeitstag(e) · ${s.bookedHours ?? 0} h`)
+    if (s.type === 'vacation' && s.contingentDays != null && s.contingentDays !== s.bookedWorkingDays) {
+      lines.push(`Urlaubskontingent: ${s.contingentDays} (${s.bookedWorkingDays - s.contingentDays} durch AU erstattet)`)
+    }
+  }
+  if (needsConfirmation(s.status, s.absEnd, s.absStart, todayStr)) {
+    lines.push('⚠ Geplant und in der Vergangenheit — bitte bestätigen (Klick zum Bearbeiten).')
+  }
+  return lines.join('\n')
+}
+
 interface DragState {
   year: number
   monthIdx: number
@@ -64,12 +90,15 @@ export default function YearCalendar({
   persons,
   displayedRegions,
   onRangeSelect,
+  onAbsenceClick,
 }: {
   years: number[]
   holidaysByYear: Record<number, YearHoliday[]>
   persons: YearCalendarPerson[]
   displayedRegions?: Set<string>
   onRangeSelect?: (personId: number | null, startISO: string, endISO: string) => void
+  /** Click on an existing absence bar → edit it (fixes the lost edit affordance). */
+  onAbsenceClick?: (personId: number, absenceId: number) => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const currentRowRef = useRef<HTMLDivElement>(null)
@@ -235,24 +264,35 @@ export default function YearCalendar({
             const hovered = hoveredPersonId === s.personId
             const span = s.endDay - s.startDay + 1
             const roundCls = (s.openStart ? 'rounded-l-none border-l-0 ' : '') + (s.openEnd ? 'rounded-r-none border-r-0 ' : '')
+            const mustConfirm = needsConfirmation(s.status, s.absEnd, s.absStart, todayStr)
+            const clickable = !!onAbsenceClick
             return (
               <div
                 key={`${s.personId}-${s.absenceId}-${i}`}
                 className={`absolute flex items-center justify-center overflow-hidden rounded-sm border ${c.bar} ${c.border} ${roundCls} ${
                   hovered ? `ring-2 ${c.ring} z-20 brightness-105 scale-[1.08]` : 'z-10'
-                } transition-transform`}
+                } transition-transform ${clickable ? 'cursor-pointer' : ''}`}
                 style={{
                   left: `calc(${s.startDay - 1} * ${CELL_W})`,
                   width: `calc(${span} * ${CELL_W})`,
                   top: `calc(${lane * laneHpct}% + 1px)`,
                   height: `calc(${laneHpct}% - 2px)`,
                 }}
-                title={`${s.personName} · ${TYPE_LABELS[s.type]} (${STATUS_LABELS[s.status]}) · ${fmtDe(s.absStart)} – ${fmtDe(s.absEnd)}`}
+                title={barTooltip(s, todayStr)}
                 onMouseEnter={() => setHoveredPersonId(s.personId)}
                 onMouseLeave={() => setHoveredPersonId(null)}
+                // Stop the mousedown so a click on a bar edits it instead of starting a drag-create.
+                onMouseDown={clickable ? (e) => e.stopPropagation() : undefined}
+                onClick={clickable ? (e) => { e.stopPropagation(); onAbsenceClick!(s.personId, s.absenceId) } : undefined}
               >
                 {showLabels && span >= 2 && (
                   <span className="text-[9px] font-semibold leading-none text-gray-700 select-none pointer-events-none">{TYPE_SHORT[s.type]}</span>
+                )}
+                {mustConfirm && (
+                  <span
+                    className="absolute top-0 right-0 h-1.5 w-1.5 rounded-full bg-amber-500 ring-1 ring-white pointer-events-none"
+                    aria-label="Bitte bestätigen"
+                  />
                 )}
               </div>
             )

--- a/frontend/src/lib/absenceSegments.ts
+++ b/frontend/src/lib/absenceSegments.ts
@@ -23,6 +23,10 @@ export interface AbsenceSegment {
   /** full absence range for tooltips (ISO, end null = ongoing) */
   absStart: string
   absEnd: string | null
+  /** backend-computed booking metrics (see planning.absence_booking) */
+  bookedWorkingDays: number | null
+  bookedHours: number | null
+  contingentDays: number | null
 }
 
 interface YMD {
@@ -87,6 +91,9 @@ export function computeAbsenceSegments(
           openEnd: m < lastMonth || extendsAfterYear,
           absStart: a.start_date,
           absEnd: a.end_date,
+          bookedWorkingDays: a.booked_working_days ?? null,
+          bookedHours: a.booked_hours ?? null,
+          contingentDays: a.contingent_days ?? null,
         })
       }
     }

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -61,6 +61,21 @@ function absenceOnDay(absence: CalendarAbsence, dateStr: string): boolean {
   return absence.start_date <= dateStr && end >= dateStr
 }
 
+/** Hover tooltip for an absence: type/status, range and what it books
+ *  (working days & hours, minus weekends/holidays/non-working days; for vacation
+ *  the contingent consumed after the confirmed-sick (AU) refund). */
+function absenceTooltip(a: CalendarAbsence): string {
+  const lines = [`${ABSENCE_NAME[a.absence_type]} (${STATUS_NAME[a.status]})`]
+  lines.push(`${a.start_date} – ${a.end_date ?? 'laufend'}`)
+  if (a.booked_working_days != null) {
+    lines.push(`Bucht: ${a.booked_working_days} Arbeitstag(e) · ${a.booked_hours ?? 0} h`)
+    if (a.absence_type === 'vacation' && a.contingent_days != null && a.contingent_days !== a.booked_working_days) {
+      lines.push(`Urlaubskontingent: ${a.contingent_days} (${a.booked_working_days - a.contingent_days} durch AU erstattet)`)
+    }
+  }
+  return lines.join('\n')
+}
+
 // Clamp membership dates to the visible month, returning 1-based day numbers
 function membershipStartDay(fromDate: string, year: number, month: number): number {
   if (fromDate <= isoDate(year, month, 1)) return 1
@@ -263,7 +278,7 @@ function PersonRow({
             if (!absence) return null
             const bg = ABSENCE_BG[absence.absence_type] ?? 'bg-gray-200'
             const label = ABSENCE_LABEL[absence.absence_type] ?? '?'
-            const title = `${ABSENCE_NAME[absence.absence_type]} (${STATUS_NAME[absence.status]})`
+            const title = absenceTooltip(absence)
             return (
               <div
                 key={day}

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -412,39 +412,55 @@ export default function PersonDetailPage() {
     queryFn: () => persons.memberships(personId),
   })
 
+  // Absence/contingent/region changes here also feed the year calendar, the
+  // absence summary panel and the persons-table vacation column — invalidate them
+  // all so those views don't show stale data until a reload.
+  const invalidateDerived = () => {
+    qc.invalidateQueries({ queryKey: ['absences', personId] })
+    qc.invalidateQueries({ queryKey: ['absence-summary'] })
+    qc.invalidateQueries({ queryKey: ['absence-summary-batch'] })
+    qc.invalidateQueries({ queryKey: ['calendar-year'] })
+  }
+
   const updatePerson = useMutation({
     mutationFn: (d: Omit<Person, 'id'>) => persons.update(personId, d),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['person', personId] }); setShowEdit(false); setError(null) },
+    onSuccess: () => {
+      // A holiday-region override changes the calendar's resolved region and the
+      // working-day-based summary, so refresh those too.
+      qc.invalidateQueries({ queryKey: ['person', personId] })
+      invalidateDerived()
+      setShowEdit(false); setError(null)
+    },
     onError: (e: Error) => setError(e.message),
   })
   const addAbsence = useMutation({
     mutationFn: (d: Omit<PersonAbsence, 'id' | 'person_id'>) => persons.addAbsence(personId, d),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['absences', personId] }); setShowAddAbsence(false); setError(null) },
+    onSuccess: () => { invalidateDerived(); setShowAddAbsence(false); setError(null) },
     onError: (e: Error) => setError(e.message),
   })
   const updateAbsence = useMutation({
     mutationFn: (d: Omit<PersonAbsence, 'id' | 'person_id'>) => persons.updateAbsence(personId, editingAbsence!.id, d),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['absences', personId] }); setEditingAbsence(null); setError(null) },
+    onSuccess: () => { invalidateDerived(); setEditingAbsence(null); setError(null) },
     onError: (e: Error) => setError(e.message),
   })
   const deleteAbsence = useMutation({
     mutationFn: (absenceId: number) => persons.deleteAbsence(personId, absenceId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['absences', personId] }),
+    onSuccess: () => invalidateDerived(),
   })
   const addContingent = useMutation({
     mutationFn: (d: { year: number; total_days: number }) => persons.addVacationContingent(personId, d),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['contingents', personId] }); setShowAddContingent(false); setError(null) },
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['contingents', personId] }); invalidateDerived(); setShowAddContingent(false); setError(null) },
     onError: (e: Error) => setError(e.message),
   })
   const updateContingent = useMutation({
     mutationFn: ({ id, d }: { id: number; d: { year: number; total_days: number } }) =>
       persons.updateVacationContingent(personId, id, d),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['contingents', personId] }); setEditingContingent(null); setError(null) },
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['contingents', personId] }); invalidateDerived(); setEditingContingent(null); setError(null) },
     onError: (e: Error) => setError(e.message),
   })
   const deleteContingent = useMutation({
     mutationFn: (contingentId: number) => persons.deleteVacationContingent(personId, contingentId),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['contingents', personId] }); setConfirmDeleteContingent(null) },
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['contingents', personId] }); invalidateDerived(); setConfirmDeleteContingent(null) },
   })
   const addMembership = useMutation({
     mutationFn: (d: Omit<ProjectMembership, 'id' | 'project_id'>) =>

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -237,6 +237,64 @@ function renderBooking(a: PersonAbsence) {
   return <span title={isVacation ? `${days} Urlaubstag(e) · ${hours} h (ohne Wochenenden/Feiertage/freie Tage)` : `${days} Arbeitstag(e) · ${hours} h`}>{base}</span>
 }
 
+/** Absence overview above the table: per-category booked days/hours and, for
+ *  vacation, the contingent split into taken / planned / open. Year selectable. */
+function AbsenceSummaryPanel({ personId }: { personId: number }) {
+  const [year, setYear] = useState(() => new Date().getFullYear())
+  const { data } = useQuery({
+    queryKey: ['absence-summary', personId, year],
+    queryFn: () => persons.absenceSummary(personId, year),
+  })
+  const v = data?.vacation
+  const cats = data?.categories
+  const CATS: [keyof NonNullable<typeof cats>, string, string][] = [
+    ['vacation', 'Urlaub', 'bg-sky-50 text-sky-700 border-sky-200'],
+    ['sick', 'Krank', 'bg-rose-50 text-rose-700 border-rose-200'],
+    ['training', 'Fortbildung', 'bg-violet-50 text-violet-700 border-violet-200'],
+    ['other', 'Sonstiges', 'bg-gray-50 text-gray-600 border-gray-200'],
+  ]
+  const total = v && v.contingent > 0 ? v.contingent : 0
+  const pct = (n: number) => (total > 0 ? Math.min(100, (n / total) * 100) : 0)
+  return (
+    <div className="mb-4 bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-gray-700">Abwesenheits-Übersicht {year}</h4>
+        <div className="flex items-center gap-1 text-sm">
+          <button onClick={() => setYear((y) => y - 1)} className="px-2 py-0.5 rounded border border-gray-200 text-gray-500 hover:bg-gray-50" aria-label="Jahr zurück">‹</button>
+          <span className="w-12 text-center font-medium text-gray-700">{year}</span>
+          <button onClick={() => setYear((y) => y + 1)} className="px-2 py-0.5 rounded border border-gray-200 text-gray-500 hover:bg-gray-50" aria-label="Jahr vor">›</button>
+        </div>
+      </div>
+
+      {v && (
+        <div className="mb-3">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+            <span className="text-gray-600" title="Jahres-Urlaubskontingent">Urlaub: <b className="text-gray-800">{v.contingent}</b> AT</span>
+            <span className="text-emerald-700" title="Bestätigte Urlaubstage">genommen {v.taken}</span>
+            <span className="text-blue-600" title="Vorgemerkte (geplante) Urlaubstage">geplant {v.planned}</span>
+            <span className={v.open <= 0 ? 'text-gray-400' : 'text-amber-600'} title="Verbleibendes Kontingent">offen {v.open}</span>
+          </div>
+          <div className="mt-1.5 h-2 w-full max-w-md rounded bg-gray-100 overflow-hidden flex" title={`genommen ${v.taken} · geplant ${v.planned} · offen ${v.open} von ${v.contingent}`}>
+            <div className="bg-emerald-500 h-full" style={{ width: `${pct(v.taken)}%` }} />
+            <div className="bg-blue-400 h-full" style={{ width: `${pct(v.planned)}%` }} />
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {CATS.map(([k, label, cls]) => {
+          const c = cats?.[k]
+          return (
+            <span key={k} className={`px-2 py-1 rounded border text-xs ${cls}`}>
+              {label}: <b>{c?.days ?? 0}</b> AT · {c?.hours ?? 0} h
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 type Tab = 'absences' | 'projects'
 
 // ─── Membership form ──────────────────────────────────────────────────────────
@@ -460,6 +518,7 @@ export default function PersonDetailPage() {
                 <Plus size={14} /> Neue Abwesenheit
               </button>
             </div>
+            <AbsenceSummaryPanel personId={personId} />
             <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -84,10 +84,17 @@ function AbsenceForm({
     start_date: initial?.start_date ?? '',
     end_date: initial?.end_date ?? '',
     note: initial?.note ?? '',
+    start_segment: initial?.start_segment ?? 'full',
+    end_segment: initial?.end_segment ?? 'full',
   })
 
   const isSick = form.absence_type === 'sick'
   const isOngoing = form.status === 'ongoing'
+  // One segment dropdown for a single day / ongoing; two for a multi-day range.
+  const singleDay = isOngoing || !form.end_date || form.end_date === form.start_date
+  const SEGS: [NonNullable<AbsenceFormData['start_segment']>, string][] = [
+    ['full', 'Voller Tag'], ['morning', 'Vormittag (½)'], ['afternoon', 'Nachmittag (½)'],
+  ]
 
   // Adjust status when type changes
   function setType(t: PersonAbsence['absence_type']) {
@@ -101,7 +108,7 @@ function AbsenceForm({
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    onSave({ ...form, end_date: form.end_date || null })
+    onSave({ ...form, end_date: form.end_date || null, end_segment: singleDay ? 'full' : form.end_segment })
   }
 
   const allowedStatuses: PersonAbsence['status'][] = isSick
@@ -155,6 +162,40 @@ function AbsenceForm({
             onChange={(e) => setForm((f) => ({ ...f, end_date: e.target.value || null }))} />
         </div>
       </div>
+      {singleDay ? (
+        <div>
+          <label htmlFor="abs-seg" className="block text-xs font-medium text-gray-600 mb-1">
+            Tag <span className="font-normal text-gray-400">— voller oder halber Tag</span>
+          </label>
+          <select id="abs-seg"
+            className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={form.start_segment ?? 'full'}
+            onChange={(e) => setForm((f) => ({ ...f, start_segment: e.target.value as AbsenceFormData['start_segment'] }))}>
+            {SEGS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+          </select>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="abs-seg-start" className="block text-xs font-medium text-gray-600 mb-1">Erster Tag</label>
+            <select id="abs-seg-start"
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={form.start_segment ?? 'full'}
+              onChange={(e) => setForm((f) => ({ ...f, start_segment: e.target.value as AbsenceFormData['start_segment'] }))}>
+              {SEGS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="abs-seg-end" className="block text-xs font-medium text-gray-600 mb-1">Letzter Tag</label>
+            <select id="abs-seg-end"
+              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={form.end_segment ?? 'full'}
+              onChange={(e) => setForm((f) => ({ ...f, end_segment: e.target.value as AbsenceFormData['end_segment'] }))}>
+              {SEGS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
       <div>
         <label htmlFor="abs-note" className="block text-xs font-medium text-gray-600 mb-1">Notiz</label>
         <input id="abs-note" type="text"
@@ -219,6 +260,11 @@ function ContingentForm({
 
 /** "Gebucht" cell: working days + hours an absence books, with the vacation
  *  contingent (after the AU refund) called out when it differs from the raw days. */
+/** Short half-day marker for a day cell (Vm = Vormittag, Nm = Nachmittag). */
+function segShort(seg?: string): string {
+  return seg === 'morning' ? ' · ½ Vm' : seg === 'afternoon' ? ' · ½ Nm' : ''
+}
+
 function renderBooking(a: PersonAbsence) {
   if (a.booked_working_days == null) return <span className="text-gray-300">–</span>
   const days = a.booked_working_days
@@ -564,8 +610,8 @@ export default function PersonDetailPage() {
                           {TYPE_LABELS[a.absence_type]}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-700">{a.start_date}</td>
-                      <td className="px-4 py-3 text-sm text-gray-600">{a.end_date ?? <span className="text-gray-400 italic">laufend</span>}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">{a.start_date}<span className="text-amber-600 text-xs">{segShort(a.start_segment)}</span></td>
+                      <td className="px-4 py-3 text-sm text-gray-600 whitespace-nowrap">{a.end_date ? <>{a.end_date}{a.end_date !== a.start_date && <span className="text-amber-600 text-xs">{segShort(a.end_segment)}</span>}</> : <span className="text-gray-400 italic">laufend</span>}</td>
                       <td className="px-4 py-3 text-sm text-gray-600">{STATUS_LABELS[a.status]}</td>
                       <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">{renderBooking(a)}</td>
                       <td className="px-4 py-3 text-sm text-gray-400 max-w-[12rem] truncate">{a.note}</td>

--- a/frontend/src/pages/PersonDetailPage.tsx
+++ b/frontend/src/pages/PersonDetailPage.tsx
@@ -217,6 +217,26 @@ function ContingentForm({
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
+/** "Gebucht" cell: working days + hours an absence books, with the vacation
+ *  contingent (after the AU refund) called out when it differs from the raw days. */
+function renderBooking(a: PersonAbsence) {
+  if (a.booked_working_days == null) return <span className="text-gray-300">–</span>
+  const days = a.booked_working_days
+  const hours = a.booked_hours ?? 0
+  const base = `${days} AT · ${hours} h`
+  const isVacation = a.absence_type === 'vacation'
+  const refunded = isVacation && a.contingent_days != null && a.contingent_days !== days
+  if (refunded) {
+    return (
+      <span title={`${a.contingent_days} Urlaubstag(e) verbraucht — ${days - (a.contingent_days ?? 0)} durch beglaubigte Krankheit (AU) erstattet. Stunden: ${hours} h.`}>
+        {base}
+        <span className="ml-1 text-amber-600">(Kontingent {a.contingent_days})</span>
+      </span>
+    )
+  }
+  return <span title={isVacation ? `${days} Urlaubstag(e) · ${hours} h (ohne Wochenenden/Feiertage/freie Tage)` : `${days} Arbeitstag(e) · ${hours} h`}>{base}</span>
+}
+
 type Tab = 'absences' | 'projects'
 
 // ─── Membership form ──────────────────────────────────────────────────────────
@@ -444,14 +464,23 @@ export default function PersonDetailPage() {
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
-                    {['Typ', 'Von', 'Bis', 'Status', 'Notiz', ''].map((h) => (
-                      <th key={h} scope="col" className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">{h}</th>
+                    {[
+                      { h: 'Typ', t: undefined },
+                      { h: 'Von', t: undefined },
+                      { h: 'Bis', t: undefined },
+                      { h: 'Status', t: undefined },
+                      { h: 'Gebucht', t: 'Gebuchte Arbeitstage und Stunden dieses Zeitraums — ohne Wochenenden, Feiertage und im Arbeitsmodell freie Tage. Bei Urlaub: Kontingentverbrauch nach Erstattung bei beglaubigter Krankheit (AU).' },
+                      { h: 'Notiz', t: undefined },
+                      { h: '', t: undefined },
+                    ].map(({ h, t }) => (
+                      <th key={h || 'actions'} scope="col" title={t}
+                        className={`px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase ${t ? 'cursor-help' : ''}`}>{h}</th>
                     ))}
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-100">
                   {sortedAbsences.length === 0 && (
-                    <tr><td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-400">Keine Abwesenheiten eingetragen.</td></tr>
+                    <tr><td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">Keine Abwesenheiten eingetragen.</td></tr>
                   )}
                   {sortedAbsences.map((a) => (
                     <tr key={a.id}>
@@ -463,6 +492,7 @@ export default function PersonDetailPage() {
                       <td className="px-4 py-3 text-sm text-gray-700">{a.start_date}</td>
                       <td className="px-4 py-3 text-sm text-gray-600">{a.end_date ?? <span className="text-gray-400 italic">laufend</span>}</td>
                       <td className="px-4 py-3 text-sm text-gray-600">{STATUS_LABELS[a.status]}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">{renderBooking(a)}</td>
                       <td className="px-4 py-3 text-sm text-gray-400 max-w-[12rem] truncate">{a.note}</td>
                       <td className="px-4 py-3 text-sm">
                         <div className="flex items-center gap-2">

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Pencil, Trash2, ChevronDown, Search, ArrowUpRight } from 'lucide-react'
-import { persons, calendar, programs, projects as projectsApi, type Person, type YearCalendarPerson } from '../api'
+import { persons, calendar, programs, projects as projectsApi, type Person, type YearCalendarPerson, type PersonAbsence } from '../api'
 import PageHeader from '../components/PageHeader'
 import Modal from '../components/Modal'
 import YearCalendar from '../components/absence/YearCalendar'
@@ -138,6 +138,19 @@ export default function PersonsPage() {
   const [error, setError] = useState<string | null>(null)
 
   const [quickCreate, setQuickCreate] = useState<{ personId: number | null; start: string; end: string } | null>(null)
+  const [editAbsence, setEditAbsence] = useState<PersonAbsence | null>(null)
+
+  // Click on a calendar bar → load the full absence and open it for editing.
+  async function handleAbsenceClick(personId: number, absenceId: number) {
+    const list = await persons.absences(personId)
+    const a = list.find((x) => x.id === absenceId)
+    if (a) {
+      setEditAbsence({
+        id: a.id, person_id: personId, start_date: a.start_date, end_date: a.end_date,
+        absence_type: a.absence_type, status: a.status, note: a.note,
+      })
+    }
+  }
 
   // Vertical scroll spans several years; the calendar centres on the current month.
   const currentYear = new Date().getFullYear()
@@ -155,6 +168,12 @@ export default function PersonsPage() {
   const { data = [], isLoading } = useQuery({
     queryKey: ['persons-with-projects'],
     queryFn: persons.withProjects,
+  })
+
+  // Vacation overview per person for the current year (persons-table column).
+  const { data: vacByPerson = {} } = useQuery({
+    queryKey: ['absence-summary-batch', currentYear],
+    queryFn: () => persons.absenceSummaryBatch(currentYear),
   })
 
   const yearQueries = useQueries({
@@ -397,6 +416,7 @@ export default function PersonsPage() {
               persons={calendarPersons}
               displayedRegions={displayedRegions}
               onRangeSelect={(personId, start, end) => setQuickCreate({ personId, start, end })}
+              onAbsenceClick={handleAbsenceClick}
             />
           )}
           <div className="mt-2 flex flex-wrap gap-4 text-xs text-gray-600" aria-label="Legende">
@@ -445,13 +465,17 @@ export default function PersonsPage() {
                       <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Name</th>
                       <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Sage-Name</th>
                       <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Wochenstunden</th>
+                      <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider cursor-help"
+                        title={`Urlaub ${currentYear} (Arbeitstage): genommen (bestätigt) · geplant (vorgemerkt) · offen (Rest des Jahreskontingents). Krankheit mit AU während des Urlaubs wird erstattet.`}>
+                        Urlaub {currentYear}
+                      </th>
                       <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Projekte</th>
                       <th className="px-4 py-2" />
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-100">
                     {filteredRows.length === 0 && (
-                      <tr><td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-400">Keine MA gefunden.</td></tr>
+                      <tr><td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">Keine MA gefunden.</td></tr>
                     )}
                     {filteredRows.map((p) => {
                       const sel = isSelected(p.id)
@@ -480,6 +504,22 @@ export default function PersonsPage() {
                           </td>
                           <td className={`px-4 py-2 text-sm ${sel ? 'text-gray-700' : 'text-gray-400'}`}>{p.sage_employee_name}</td>
                           <td className={`px-4 py-2 text-sm ${sel ? 'text-gray-700' : 'text-gray-400'}`}>{p.default_weekly_hours} h</td>
+                          <td className="px-4 py-2 text-sm whitespace-nowrap">
+                            {(() => {
+                              const v = vacByPerson[p.id]?.vacation
+                              if (!v) return <span className="text-gray-300 text-xs">–</span>
+                              return (
+                                <span title={`Kontingent ${v.contingent} AT · genommen ${v.taken} · geplant ${v.planned} · offen ${v.open}`}>
+                                  <span className="text-emerald-700 font-medium">{v.taken}</span>
+                                  <span className="text-gray-300"> / </span>
+                                  <span className="text-blue-600 font-medium">{v.planned}</span>
+                                  <span className="text-gray-300"> / </span>
+                                  <span className={`font-medium ${v.open <= 0 ? 'text-gray-400' : 'text-amber-600'}`}>{v.open}</span>
+                                  <span className="text-gray-400 text-xs"> von {v.contingent}</span>
+                                </span>
+                              )
+                            })()}
+                          </td>
                           <td className="px-4 py-2">
                             {(!p.project_numbers || p.project_numbers.length === 0)
                               ? <span className="text-xs text-gray-400">–</span>
@@ -533,6 +573,18 @@ export default function PersonsPage() {
           endDate={quickCreate.end}
           onClose={() => setQuickCreate(null)}
           onCreated={() => setQuickCreate(null)}
+        />
+      )}
+
+      {editAbsence && (
+        <AbsenceQuickCreateModal
+          persons={(mergedPersons.length ? mergedPersons : data).map((p) => ({ id: p.id, name: p.name }))}
+          initialPersonId={editAbsence.person_id}
+          startDate={editAbsence.start_date}
+          endDate={editAbsence.end_date ?? editAbsence.start_date}
+          editAbsence={editAbsence}
+          onClose={() => setEditAbsence(null)}
+          onCreated={() => setEditAbsence(null)}
         />
       )}
 

--- a/frontend/src/pages/PersonsPage.tsx
+++ b/frontend/src/pages/PersonsPage.tsx
@@ -208,11 +208,20 @@ export default function PersonsPage() {
   const { data: programList = [] } = useQuery({ queryKey: ['programs'], queryFn: programs.list })
   const { data: projectList = [] } = useQuery({ queryKey: ['projects'], queryFn: projectsApi.list })
 
+  // Person changes (esp. the holiday-region override) affect the year calendar's
+  // resolved regions/holidays and the vacation summary — invalidate those too, else
+  // the calendar keeps showing a person's old region until a hard reload.
+  const invalidatePersonData = () => {
+    qc.invalidateQueries({ queryKey: ['persons-with-projects'] })
+    qc.invalidateQueries({ queryKey: ['persons'] })
+    qc.invalidateQueries({ queryKey: ['calendar-year'] })
+    qc.invalidateQueries({ queryKey: ['absence-summary-batch'] })
+  }
+
   const create = useMutation({
     mutationFn: persons.create,
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['persons-with-projects'] })
-      qc.invalidateQueries({ queryKey: ['persons'] })
+      invalidatePersonData()
       setShowCreate(false)
       setError(null)
     },
@@ -222,8 +231,7 @@ export default function PersonsPage() {
   const update = useMutation({
     mutationFn: ({ id, data }: { id: number; data: Omit<Person, 'id'> }) => persons.update(id, data),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['persons-with-projects'] })
-      qc.invalidateQueries({ queryKey: ['persons'] })
+      invalidatePersonData()
       setEditPerson(null)
       setError(null)
     },
@@ -233,8 +241,7 @@ export default function PersonsPage() {
   const remove = useMutation({
     mutationFn: (id: number) => persons.delete(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['persons-with-projects'] })
-      qc.invalidateQueries({ queryKey: ['persons'] })
+      invalidatePersonData()
       setConfirmDelete(null)
     },
     onError: (e: Error) => setError(e.message),


### PR DESCRIPTION
## Zusammenfassung
Korrigiert die Urlaubs-/Abwesenheitslogik (Issue #37) und macht sie im UI nachvollziehbar.

### Motor (U1)
- Abwesenheiten zählen jetzt **Arbeitstage** statt Kalendertage: Wochenenden, Feiertage (regionsabhängig) und im `work_week_pattern` freie Tage werden ausgenommen.
- Überlappende Abwesenheiten werden **nicht mehr doppelt** gezählt.
- **Krankheit während Urlaub**: eine beglaubigte AU (`sick`+`confirmed`) toppt überlappende Urlaubstage und erstattet sie dem Kontingent; `ongoing` erstattet nicht.
- Eine gemeinsame Definition `effective_working_dates` speist Zählung, Verfügbarkeit und Kapazität; robust bei Feiertags-API-Ausfall.
- **Ändert bestehende Zahlen** (i. d. R. etwas mehr Kapazität, da WE/Feiertage nicht mehr abgezogen werden).

### API + UI (U2/U3)
- `planning.absence_booking` liefert pro Abwesenheit gebuchte Arbeitstage/Stunden + (bei Urlaub) Kontingentverbrauch nach Erstattung.
- Personenkalender-Tooltip erweitert; neue Spalte „Gebucht" in der Abwesenheitstabelle (`X AT · Y h`, bei Erstattung `(Kontingent Z)`).

### Verifikation
- Volle Suite grün (**529**), Coverage 91%; neue Tests für WE-/Feiertags-/Pattern-Ausschluss, Doppelzählungs-Dedup und AU-Erstattung.
- Live geprüft: Tabelle/Tooltip rendern Tage·Stunden; überlappende AU senkt Urlaub 5 AT → Kontingent 2.

Closes #37

---

## Nachtrag: Abwesenheits-Anzeige (#39)
Folge-Findings/-Wünsche, im selben dev→main-Zyklus:
- **Fix**: Jahreskalender-**Balken**-Tooltip zeigt jetzt gebuchte Arbeitstage/Stunden + Urlaubskontingent (der frühere Fix traf nur die Monatsansicht).
- Vergangene *geplante* Abwesenheiten: Amber-Punkt am Balken + Tooltip-Hinweis „bitte bestätigen".
- **Regression behoben**: Klick auf einen Balken öffnet wieder das Bearbeiten (inkl. Löschen, planned→confirmed).
- MA-Abwesenheitsübersicht über der Tabelle (Kategorien + Urlaub gesamt/genommen/geplant/offen, Jahr wählbar).
- Personentabelle: Spalte „Urlaub {Jahr}" (genommen/geplant/offen) mit Header-Tooltip.
- Backend: `absence_summary` + Endpoints; 531 Tests grün, Coverage 91%.

Closes #39

---

## Nachtrag: Halbe Tage (#40)
- Abwesenheiten (alle Typen) können halbe Tage sein: Segment je Start-/Endtag (Voller Tag / Vormittag / Nachmittag), Default voller Tag; halber Tag = halbe Arbeitsstunden.
- Modell `AbsenceDaySegment` + `PersonAbsence.start_segment/end_segment` + Migration `d4f1c7e93a20` (Bestand → full).
- Zähl-Logik summiert Tagesbruchteile (0,5/1,0) in Verfügbarkeit/Kapazität/Kontingent/Übersicht.
- Formular: 1 Dropdown bei eintägig, 2 bei mehrtägig; Tabelle zeigt ½-Marker.
- 535 Tests grün, Coverage 91%; API end-to-end verifiziert (halber Urlaubstag = 0,5 AT / halbe Stunden / 0,5 Kontingent).

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)