### PR TITLE
Prod-Docker-Deployment (Compose) + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,53 @@ docs/
 
 ---
 
+## Deployment (Linux, firm LAN)
+
+The production stack runs via Docker Compose: a FastAPI backend (uvicorn, migrations
+applied on start) reachable only inside the compose network, plus the built SPA served
+by nginx which reverse-proxies `/api` to the backend. SQLite lives in a named volume.
+
+**Prerequisites on the host:** Docker Engine + the Compose plugin, and network access
+to the public holiday APIs (feiertage-api.de / openholidays / nager.at).
+
+```bash
+# 1) Get the code (GitHub is the source of truth)
+git clone https://github.com/sefalk/ProjektPlanner.git
+cd ProjektPlanner
+
+# 2) Build & start (published on port 8080 by default; override with WEB_PORT)
+WEB_PORT=8080 docker compose -f docker-compose.prod.yml up -d --build
+
+# 3) Open from inside the LAN
+#    http://<host-ip>:8080     (e.g. http://192.168.100.141:8080)
+```
+
+**Update to a new version:**
+
+```bash
+git pull
+docker compose -f docker-compose.prod.yml up -d --build   # migrations run automatically
+```
+
+**Operations:**
+
+```bash
+docker compose -f docker-compose.prod.yml ps        # status
+docker compose -f docker-compose.prod.yml logs -f   # follow logs
+docker compose -f docker-compose.prod.yml down      # stop (data volume is kept)
+```
+
+Notes:
+- LAN-only: the host is not internet-exposed; only the nginx port (`WEB_PORT`) is
+  published. The backend is not published to the host.
+- The SQLite database persists in the `backend_data` volume. Back it up with
+  `docker run --rm -v projektplanner_backend_data:/data -v "$PWD":/backup alpine \
+   tar czf /backup/pp-db-backup.tgz -C /data .`.
+- Automated deploy (ADO self-hosted agent) is a follow-up; until then use the
+  `git pull … up -d --build` step above.
+
+---
+
 ## Privacy
 
 All person names, project numbers, billing rates, and time bookings are stored in the local SQLite database only — never sent to any server.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,7 @@ ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_COMPILE_BYTECODE=1 \
     PATH="/app/.venv/bin:$PATH"
 
-COPY pyproject.toml .
+COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 # --- dev: adds dev dependencies + live reload ---

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,41 @@
+# Production stack for the internal Linux host (LAN-only).
+#
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# - backend: FastAPI (uvicorn, 2 workers). Runs DB migrations on start, then serves.
+#   Not published to the host — only reachable inside the compose network via nginx.
+# - frontend: the built SPA served by nginx, which also reverse-proxies /api → backend.
+#   Published on ${WEB_PORT:-8080} on all interfaces (reachable from the firm LAN).
+# - SQLite lives in a named volume (survives restarts/rebuilds).
+services:
+  backend:
+    build:
+      context: ./backend
+      target: prod
+    restart: unless-stopped
+    environment:
+      # No data_config.json in the container → this URL is used (SQLite in the volume).
+      # Relative to WORKDIR /app → /app/data/projektplanner.db (matches docker-compose.yml).
+      - DATABASE_URL=sqlite:///./data/projektplanner.db
+      - DEFAULT_HOLIDAY_COUNTRY=DE
+      - DEFAULT_HOLIDAY_STATE=BY
+      - DEBUG=false
+    volumes:
+      - backend_data:/app/data
+    # Apply migrations before serving so schema changes land on deploy.
+    command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2"
+    expose:
+      - "8000"
+
+  frontend:
+    build:
+      context: ./frontend
+      target: prod
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "${WEB_PORT:-8080}:80"
+
+volumes:
+  backend_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,9 @@ services:
     volumes:
       - backend_data:/app/data
     # Apply migrations before serving so schema changes land on deploy.
-    command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2"
+    # Single worker: internal low-traffic app + the startup default-seeding isn't yet
+    # safe under concurrent workers (see follow-up). 1 worker = deterministic startup.
+    command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1"
     expose:
       - "8000"
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.vite
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# --- build: compile the Vite app to static files ---
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Install deps first (better layer caching)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# --- prod: serve the static build via nginx + reverse-proxy /api ---
+FROM nginx:alpine AS prod
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,31 @@
+# Serves the built SPA and reverse-proxies /api to the backend container.
+# The frontend calls same-origin "/api/..."; nginx strips /api and forwards to backend:8000.
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Sage-Import files can be a few MB.
+    client_max_body_size 25m;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # SPA client-side routing: fall back to index.html.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # API → backend service (trailing slash on proxy_pass strips the /api prefix:
+    # /api/persons → http://backend:8000/persons).
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
Prod-Deployment-Assets für das interne Linux-Deployment (Docker Compose, LAN-only).

- `frontend/Dockerfile` (Vite-Build → nginx) + `nginx.conf`: SPA ausliefern, `/api` → Backend-Container proxen.
- `docker-compose.prod.yml`: Backend (prod-Target, Migrationen vor Start, nur intern) + Frontend-nginx (Port `${WEB_PORT:-8080}`), SQLite im Named Volume.
- README: Abschnitt „Deployment (Linux, firm LAN)" (Start/Update/Ops/Backup).

Auf `main` gebracht, damit der Zielhost via `git clone … main` deployen kann. Image-Validierung beim ersten Deploy auf dem Host. Automatischer Deploy (ADO self-hosted Agent) folgt separat.

---

### Live auf dem internen Linux-Host validiert ✅
Erfolgreich deployed und aus dem LAN erreichbar (**http://192.168.100.141:8080**). Dabei zwei Fixes ergänzt:
- `fix(docker)`: `uv.lock` ins Backend-Image kopieren (`--frozen` brach sonst ab).
- `build(deploy)`: Backend mit **1 uvicorn-Worker** (Startup-Seeding ist noch nicht mehrprozess-sicher → Issue #42).

Frontend (200), API via nginx-Proxy (`/api/persons` → `200 []`), Migrationen laufen beim Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)