### PR TITLE
Release v0.3.0 — Multi-User / Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ backend/.coverage
 # Local runtime config (may contain absolute paths / usernames)
 backend/data_config.json
 
+# Deployment secrets — host-side only (keep the *.example templates)
+deploy/*.env
+!deploy/*.env.example
+
 # Real seed / production data — NEVER commit
 seed/real/
 data/

--- a/README.md
+++ b/README.md
@@ -167,17 +167,31 @@ one DB (see issue #45). Host-side secrets live outside the repo at
 `/home/<user>/pp-secrets/`:
 
 ```bash
-# once: create the secrets dir, a self-signed cert, and the login
+# once: create the secrets dir, a self-signed cert, and the (nginx) login
 mkdir -p ~/pp-secrets
 openssl req -x509 -newkey rsa:2048 -nodes -days 825 \
   -keyout ~/pp-secrets/key.pem -out ~/pp-secrets/cert.pem \
   -subj "/CN=$(hostname)" -addext "subjectAltName=IP:<host-ip>,DNS:$(hostname)"
 htpasswd -cB ~/pp-secrets/htpasswd <login-name>     # prompts for the password
 
+# once: app secrets — first-admin bootstrap + session signing key (see below)
+cp deploy/server-secrets.env.example ~/pp-secrets/server.env
+#   → edit ~/pp-secrets/server.env: set ADMIN_EMAIL + a strong ADMIN_PASSWORD,
+#     and AUTH_SECRET=$(openssl rand -hex 32).  chmod 600 ~/pp-secrets/server.env
+
 # start / update
 docker compose -f docker-compose.server.yml up -d --build
 #   → https://<host-ip>   (self-signed cert → browser warning is expected)
 ```
+
+**First login / entry point.** There is no built-in default admin. On the very
+first start with an empty database, the backend creates exactly one superuser
+from `ADMIN_EMAIL`/`ADMIN_PASSWORD` in `server.env` (idempotent — ignored once any
+user exists). Log in with those, then create invite tokens under **Einladungen**
+so colleagues can self-register. Registration is invite-only, so without this
+bootstrap nobody could get in. `AUTH_SECRET` **must** be a fresh random value
+(never the dev default); the session cookie is served `Secure` behind the
+forced-HTTPS proxy.
 
 Replace the self-signed cert with an internal-CA certificate to avoid the browser
 warning. Notes below apply analogously (backend not published; DB in the volume).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,7 +15,7 @@ DEFAULT_HOLIDAY_COUNTRY=DE
 DEFAULT_HOLIDAY_STATE=BY
 
 # Application
-APP_VERSION=0.2.0
+APP_VERSION=0.3.0
 DEBUG=false
 
 # Auth (multi-user, doc 25 WP2) — session-cookie carrying a signed JWT.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,3 +32,6 @@ AUTH_COOKIE_SAMESITE=lax
 # disable. NEVER commit real credentials.
 ADMIN_EMAIL=
 ADMIN_PASSWORD=
+# Registration domain allowlist (#53): comma-separated list of allowed e-mail
+# domains, e.g. "infoteam.de,infoteam.com". Empty = any domain allowed.
+AUTH_ALLOWED_EMAIL_DOMAINS=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,18 @@ DEFAULT_HOLIDAY_STATE=BY
 # Application
 APP_VERSION=0.2.0
 DEBUG=false
+
+# Auth (multi-user, doc 25 WP2) — session-cookie carrying a signed JWT.
+# AUTH_SECRET MUST be a long random value in production (>=32 chars); it signs
+# session tokens and password-reset/verify tokens. NEVER commit a real secret.
+AUTH_SECRET=dev-insecure-secret-change-me-0123456789abcdef
+# Session lifetime in seconds (default 12h). No refresh tokens by design.
+AUTH_SESSION_LIFETIME=43200
+# Cookie flags: set AUTH_COOKIE_SECURE=true behind HTTPS (server deployment).
+AUTH_COOKIE_SECURE=false
+AUTH_COOKIE_SAMESITE=lax
+# First-admin bootstrap: if BOTH are set and no user exists yet, a superuser is
+# created on startup (breaks the invite-token chicken-and-egg). Leave empty to
+# disable. NEVER commit real credentials.
+ADMIN_EMAIL=
+ADMIN_PASSWORD=

--- a/backend/alembic/versions/a1b2c3d4e5f6_setting_per_owner.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_setting_per_owner.py
@@ -1,0 +1,71 @@
+"""Per-owner settings: rebuild `setting` with a surrogate id + owner_id (doc 25, WP3 step 3b)
+
+Settings become per-user. The `setting` table is rebuilt from a globally-unique
+``key`` PK to:
+    id      INTEGER PRIMARY KEY
+    owner_id INTEGER  -> user.id  (nullable, indexed)
+    key     TEXT NOT NULL (indexed)
+    value   TEXT NOT NULL
+    UNIQUE(owner_id, key)
+
+so every owner keeps their own copy of the defaults. Per the multi-user epic's
+fresh-DB decision, any pre-existing global rows are dropped — they are just the
+re-seedable defaults and are re-created per owner on first access
+(``db.ensure_owner_settings``). No global startup seeding remains.
+
+Note: runtime/tests build the schema via SQLModel.metadata.create_all; the hosted
+deployment builds it via `alembic upgrade head`, so this migration is the
+schema-of-record for production.
+
+Revision ID: a1b2c3d4e5f6
+Revises: e7a1c9d2f3b4
+Create Date: 2026-07-22
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "e7a1c9d2f3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _tables(conn) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute(sa.text("SELECT name FROM sqlite_master WHERE type='table'"))
+    }
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if "setting" in _tables(conn):
+        op.drop_table("setting")
+    op.create_table(
+        "setting",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("owner_id", sa.Integer(), nullable=True),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("value", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["owner_id"], ["user.id"], name="fk_setting_owner"),
+        sa.UniqueConstraint("owner_id", "key", name="uq_setting_owner_key"),
+    )
+    op.create_index("ix_setting_owner_id", "setting", ["owner_id"])
+    op.create_index("ix_setting_key", "setting", ["key"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if "setting" in _tables(conn):
+        op.drop_index("ix_setting_key", table_name="setting")
+        op.drop_index("ix_setting_owner_id", table_name="setting")
+        op.drop_table("setting")
+    op.create_table(
+        "setting",
+        sa.Column("key", sa.String(), primary_key=True, nullable=False),
+        sa.Column("value", sa.String(), nullable=False),
+    )

--- a/backend/alembic/versions/e7a1c9d2f3b4_multi_user_owner_id.py
+++ b/backend/alembic/versions/e7a1c9d2f3b4_multi_user_owner_id.py
@@ -1,0 +1,193 @@
+"""Multi-user tenancy: user + invite_token tables, owner_id on ownable entities (doc 25, WP1)
+
+Introduces application identity (`user`) and the one-time registration gate
+(`invite_token`), and adds a nullable `owner_id` FK → user.id to every ownable
+entity (root + denormalised children) so the central owner-filter (WP3) can be
+applied uniformly without a join. The four formerly-global unique keys become
+unique PER OWNER:
+    program.program_number        → (owner_id, program_number)
+    project.project_number        → (owner_id, project_number)
+    person.sage_employee_name     → (owner_id, sage_employee_name)
+    sage_project_mapping.sage_project_name → (owner_id, sage_project_name)
+
+owner_id is nullable for now: WP3 sets it on insert and enforces the filter; a
+later migration can tighten it to NOT NULL once every row is provably owned.
+`holiday` (reference data) stays global; `setting` stays global in WP1 and is
+converted to per-owner in WP3 (needs a user context for per-account seeding).
+
+Note: runtime/tests build the schema via SQLModel.metadata.create_all; the
+hosted deployment builds it via `alembic upgrade head` — so this migration is
+the schema-of-record for production and must be complete.
+
+Revision ID: e7a1c9d2f3b4
+Revises: d4f1c7e93a20
+Create Date: 2026-07-22
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e7a1c9d2f3b4"
+down_revision: Union[str, None] = "d4f1c7e93a20"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Ownable child tables that only need a denormalised owner_id (+ FK + index).
+_CHILD_TABLES = [
+    "vacation_contingent",
+    "person_absence",
+    "billing_position",
+    "project_membership",
+    "milestone",
+    "milestone_person_budget",
+    "monthly_invoice",
+    "invoice_person_entry",
+    "import_batch",
+    "sage_position_mapping",
+    "time_booking",
+]
+
+
+def _tables(conn) -> set[str]:
+    return {
+        row[0]
+        for row in conn.execute(sa.text("SELECT name FROM sqlite_master WHERE type='table'"))
+    }
+
+
+def _cols(conn, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(sa.text(f"PRAGMA table_info({table})"))}
+
+
+def _add_owner_id(table: str) -> None:
+    """Add a denormalised owner_id column (+ FK + index) to a child table."""
+    with op.batch_alter_table(table) as batch_op:
+        batch_op.add_column(sa.Column("owner_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(f"fk_{table}_owner", "user", ["owner_id"], ["id"])
+        batch_op.create_index(f"ix_{table}_owner_id", ["owner_id"], unique=False)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    tables = _tables(conn)
+
+    # 1. Auth / identity tables ────────────────────────────────────────────────
+    if "user" not in tables:
+        op.create_table(
+            "user",
+            sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+            sa.Column("email", sa.String(), nullable=False),
+            sa.Column("hashed_password", sa.String(), nullable=False),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+            sa.Column("is_superuser", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+            sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        )
+        op.create_index("ix_user_email", "user", ["email"], unique=True)
+
+    if "invite_token" not in tables:
+        op.create_table(
+            "invite_token",
+            sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+            sa.Column("token", sa.String(), nullable=False),
+            sa.Column("created_by", sa.Integer(), sa.ForeignKey("user.id"), nullable=True),
+            sa.Column("used_by", sa.Integer(), sa.ForeignKey("user.id"), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("used_at", sa.DateTime(), nullable=True),
+            sa.Column("expires_at", sa.DateTime(), nullable=True),
+        )
+        op.create_index("ix_invite_token_token", "invite_token", ["token"], unique=True)
+
+    # 2. Root tables: add owner_id + swap the global unique for a per-owner one ──
+    if "owner_id" not in _cols(conn, "program"):
+        with op.batch_alter_table("program") as b:
+            b.add_column(sa.Column("owner_id", sa.Integer(), nullable=True))
+            b.create_foreign_key("fk_program_owner", "user", ["owner_id"], ["id"])
+            b.drop_index("ix_program_program_number")
+            b.create_index("ix_program_program_number", ["program_number"], unique=False)
+            b.create_index("ix_program_owner_id", ["owner_id"], unique=False)
+            b.create_unique_constraint("uq_program_owner_number", ["owner_id", "program_number"])
+
+    if "owner_id" not in _cols(conn, "project"):
+        with op.batch_alter_table("project") as b:
+            b.add_column(sa.Column("owner_id", sa.Integer(), nullable=True))
+            b.create_foreign_key("fk_project_owner", "user", ["owner_id"], ["id"])
+            b.drop_index("ix_project_project_number")
+            b.create_index("ix_project_project_number", ["project_number"], unique=False)
+            b.create_index("ix_project_owner_id", ["owner_id"], unique=False)
+            b.create_unique_constraint("uq_project_owner_number", ["owner_id", "project_number"])
+
+    if "owner_id" not in _cols(conn, "person"):
+        with op.batch_alter_table("person") as b:
+            b.add_column(sa.Column("owner_id", sa.Integer(), nullable=True))
+            b.create_foreign_key("fk_person_owner", "user", ["owner_id"], ["id"])
+            b.drop_index("ix_person_sage_employee_name")
+            b.create_index("ix_person_sage_employee_name", ["sage_employee_name"], unique=False)
+            b.create_index("ix_person_owner_id", ["owner_id"], unique=False)
+            b.create_unique_constraint("uq_person_owner_sage_name", ["owner_id", "sage_employee_name"])
+
+    if "owner_id" not in _cols(conn, "sage_project_mapping"):
+        with op.batch_alter_table("sage_project_mapping") as b:
+            b.add_column(sa.Column("owner_id", sa.Integer(), nullable=True))
+            b.create_foreign_key("fk_sage_project_mapping_owner", "user", ["owner_id"], ["id"])
+            b.drop_index("ix_sage_project_mapping_sage_project_name")
+            b.create_index("ix_sage_project_mapping_sage_project_name", ["sage_project_name"], unique=False)
+            b.create_index("ix_sage_project_mapping_owner_id", ["owner_id"], unique=False)
+            b.create_unique_constraint("uq_sage_mapping_owner_name", ["owner_id", "sage_project_name"])
+
+    # 3. Child tables: denormalised owner_id only ────────────────────────────────
+    for table in _CHILD_TABLES:
+        if "owner_id" not in _cols(conn, table):
+            _add_owner_id(table)
+
+
+def _drop_owner_id(table: str) -> None:
+    with op.batch_alter_table(table) as batch_op:
+        batch_op.drop_index(f"ix_{table}_owner_id")
+        batch_op.drop_constraint(f"fk_{table}_owner", type_="foreignkey")
+        batch_op.drop_column("owner_id")
+
+
+def downgrade() -> None:
+    for table in reversed(_CHILD_TABLES):
+        _drop_owner_id(table)
+
+    with op.batch_alter_table("sage_project_mapping") as b:
+        b.drop_constraint("uq_sage_mapping_owner_name", type_="unique")
+        b.drop_index("ix_sage_project_mapping_owner_id")
+        b.drop_index("ix_sage_project_mapping_sage_project_name")
+        b.create_index("ix_sage_project_mapping_sage_project_name", ["sage_project_name"], unique=True)
+        b.drop_constraint("fk_sage_project_mapping_owner", type_="foreignkey")
+        b.drop_column("owner_id")
+
+    with op.batch_alter_table("person") as b:
+        b.drop_constraint("uq_person_owner_sage_name", type_="unique")
+        b.drop_index("ix_person_owner_id")
+        b.drop_index("ix_person_sage_employee_name")
+        b.create_index("ix_person_sage_employee_name", ["sage_employee_name"], unique=True)
+        b.drop_constraint("fk_person_owner", type_="foreignkey")
+        b.drop_column("owner_id")
+
+    with op.batch_alter_table("project") as b:
+        b.drop_constraint("uq_project_owner_number", type_="unique")
+        b.drop_index("ix_project_owner_id")
+        b.drop_index("ix_project_project_number")
+        b.create_index("ix_project_project_number", ["project_number"], unique=True)
+        b.drop_constraint("fk_project_owner", type_="foreignkey")
+        b.drop_column("owner_id")
+
+    with op.batch_alter_table("program") as b:
+        b.drop_constraint("uq_program_owner_number", type_="unique")
+        b.drop_index("ix_program_owner_id")
+        b.drop_index("ix_program_program_number")
+        b.create_index("ix_program_program_number", ["program_number"], unique=True)
+        b.drop_constraint("fk_program_owner", type_="foreignkey")
+        b.drop_column("owner_id")
+
+    op.drop_index("ix_invite_token_token", table_name="invite_token")
+    op.drop_table("invite_token")
+    op.drop_index("ix_user_email", table_name="user")
+    op.drop_table("user")

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,0 +1,11 @@
+"""Authentication layer (doc 25, WP2).
+
+In-app auth built on fastapi-users: session-cookie carrying a signed JWT,
+one-time invite-token registration gate, and an admin (is_superuser) flag.
+
+The app stack is fully synchronous (sync SQLAlchemy Session), whereas the
+official fastapi-users SQLAlchemy adapter is async-only. Rather than add a
+second async engine over the same SQLite file (locking risk), we provide a
+thin synchronous BaseUserDatabase (user_db.py) whose async-declared methods
+run sync Session queries — correct for this low-traffic internal app.
+"""

--- a/backend/app/auth/backend.py
+++ b/backend/app/auth/backend.py
@@ -1,0 +1,43 @@
+"""Authentication backend: httpOnly session-cookie carrying a signed JWT.
+
+Chosen over a Bearer/localStorage token (XSS-safe cookie) and over stateful DB
+sessions (no extra table / no refresh-token ballast) — see doc 25 §4. Logout
+clears the cookie; the short-lived JWT then simply expires.
+"""
+
+from __future__ import annotations
+
+from fastapi_users import FastAPIUsers
+from fastapi_users.authentication import AuthenticationBackend, CookieTransport, JWTStrategy
+
+from app.auth.manager import get_user_manager
+from app.config import settings
+from app.models.user import User
+
+cookie_transport = CookieTransport(
+    cookie_name="projektplannerauth",
+    cookie_max_age=settings.auth_session_lifetime,
+    cookie_secure=settings.auth_cookie_secure,
+    cookie_httponly=True,
+    cookie_samesite=settings.auth_cookie_samesite,  # type: ignore[arg-type]
+)
+
+
+def get_jwt_strategy() -> JWTStrategy:
+    return JWTStrategy(secret=settings.auth_secret, lifetime_seconds=settings.auth_session_lifetime)
+
+
+auth_backend = AuthenticationBackend(
+    name="cookie",
+    transport=cookie_transport,
+    get_strategy=get_jwt_strategy,
+)
+
+fastapi_users = FastAPIUsers[User, int](get_user_manager, [auth_backend])
+
+# Dependencies for routes.
+current_active_user = fastapi_users.current_user(active=True)
+current_superuser = fastapi_users.current_user(active=True, superuser=True)
+# Optional variant (returns None when unauthenticated) — used by the owner-filter
+# in WP3 so unauthenticated/background contexts simply see nothing.
+current_user_optional = fastapi_users.current_user(active=True, optional=True)

--- a/backend/app/auth/bootstrap.py
+++ b/backend/app/auth/bootstrap.py
@@ -1,0 +1,35 @@
+"""First-admin bootstrap (doc 25, WP2).
+
+Registration requires an invite token, and invite tokens are minted by an
+admin — a chicken-and-egg. To break it, if ADMIN_EMAIL + ADMIN_PASSWORD are
+configured and NO user exists yet, a superuser is created on startup. Idempotent:
+does nothing once any user exists.
+"""
+
+from __future__ import annotations
+
+from fastapi_users.password import PasswordHelper
+from sqlmodel import Session, select
+
+from app.config import settings
+from app.db import engine
+from app.models.user import User
+
+
+def seed_admin_user() -> None:
+    if not settings.admin_email or not settings.admin_password:
+        return
+    with Session(engine) as session:
+        if session.exec(select(User)).first() is not None:
+            return  # some user already exists — never auto-create again
+        hashed = PasswordHelper().hash(settings.admin_password)
+        session.add(
+            User(
+                email=settings.admin_email,
+                hashed_password=hashed,
+                is_active=True,
+                is_superuser=True,
+                is_verified=True,
+            )
+        )
+        session.commit()

--- a/backend/app/auth/deps.py
+++ b/backend/app/auth/deps.py
@@ -15,7 +15,7 @@ filter (see ``app/tenancy.py``).
 
 from __future__ import annotations
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from sqlmodel import Session
 
 from app.auth.backend import current_active_user
@@ -30,4 +30,16 @@ def owner_context(
 ) -> User:
     """Authenticate the caller and bind them as the session's owner."""
     bind_owner(session, user_id=user.id, is_superuser=user.is_superuser)  # type: ignore[arg-type]
+    return user
+
+
+def require_superuser(user: User = Depends(owner_context)) -> User:
+    """Guard for instance-wide, admin-only actions (#53).
+
+    Builds on ``owner_context`` (so it also binds the owner and is covered by the
+    test suite's single dependency override) and additionally requires the admin
+    flag. Use as a per-route dependency on routers already bound to owner_context.
+    """
+    if not user.is_superuser:
+        raise HTTPException(status_code=403, detail="Diese Aktion ist Administratoren vorbehalten.")
     return user

--- a/backend/app/auth/deps.py
+++ b/backend/app/auth/deps.py
@@ -1,0 +1,33 @@
+"""Request dependency that guards a CRUD router and binds its owner (doc 25, WP3).
+
+Attaching ``dependencies=[Depends(owner_context)]`` to a router does two things
+at once for every request it serves:
+
+1. Requires an authenticated, active user (401 otherwise) — the actual access
+   boundary for owned data.
+2. Binds that user onto the request's Session (``tenancy.bind_owner``) so the
+   central ``do_orm_execute`` / ``before_flush`` listeners scope all reads and
+   stamp all inserts to this owner — without any per-query code.
+
+Superusers are bound with ``is_superuser=True`` and consequently bypass the read
+filter (see ``app/tenancy.py``).
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlmodel import Session
+
+from app.auth.backend import current_active_user
+from app.db import get_session
+from app.models.user import User
+from app.tenancy import bind_owner
+
+
+def owner_context(
+    user: User = Depends(current_active_user),
+    session: Session = Depends(get_session),
+) -> User:
+    """Authenticate the caller and bind them as the session's owner."""
+    bind_owner(session, user_id=user.id, is_superuser=user.is_superuser)  # type: ignore[arg-type]
+    return user

--- a/backend/app/auth/manager.py
+++ b/backend/app/auth/manager.py
@@ -1,0 +1,63 @@
+"""fastapi-users UserManager with the one-time invite-token registration gate."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import Depends, HTTPException, Request
+from fastapi_users import BaseUserManager, IntegerIDMixin
+from sqlmodel import select
+
+from app.auth.user_db import SQLModelUserDatabase, get_user_db
+from app.config import settings
+from app.models.invite_token import InviteToken
+from app.models.user import User
+
+
+def utcnow_naive() -> datetime:
+    """Naive UTC timestamp — matches how SQLite returns stored datetimes."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
+    reset_password_token_secret = settings.auth_secret
+    verification_token_secret = settings.auth_secret
+
+    user_db: SQLModelUserDatabase  # narrowed from BaseUserDatabase
+
+    async def create(self, user_create, safe: bool = False, request: Request | None = None) -> User:
+        """Consume a valid one-time invite token, then create the user.
+
+        The token is validated BEFORE creating the user and marked used only
+        after the user is successfully created, so a failed registration does
+        not burn the token.
+        """
+        invite = self._require_valid_invite(getattr(user_create, "invite_token", ""))
+        user = await super().create(user_create, safe=safe, request=request)
+        invite.used_by = user.id
+        invite.used_at = utcnow_naive()
+        self.user_db.session.add(invite)
+        self.user_db.session.commit()
+        return user
+
+    def _require_valid_invite(self, token: str) -> InviteToken:
+        token = (token or "").strip()
+        if not token:
+            raise HTTPException(400, "An invite token is required to register.")
+        invite = self.user_db.session.exec(
+            select(InviteToken).where(InviteToken.token == token)
+        ).first()
+        if invite is None:
+            raise HTTPException(400, "Invalid invite token.")
+        if invite.used_by is not None:
+            raise HTTPException(400, "This invite token has already been used.")
+        if invite.expires_at is not None and invite.expires_at < utcnow_naive():
+            raise HTTPException(400, "This invite token has expired.")
+        return invite
+
+    async def on_after_register(self, user: User, request: Request | None = None) -> None:
+        pass  # hook kept for future audit logging
+
+
+def get_user_manager(user_db: SQLModelUserDatabase = Depends(get_user_db)):
+    yield UserManager(user_db)

--- a/backend/app/auth/manager.py
+++ b/backend/app/auth/manager.py
@@ -6,8 +6,10 @@ from datetime import datetime, timezone
 
 from fastapi import Depends, HTTPException, Request
 from fastapi_users import BaseUserManager, IntegerIDMixin
+from fastapi_users.exceptions import InvalidPasswordException
 from sqlmodel import select
 
+from app.auth.password_policy import password_problems
 from app.auth.user_db import SQLModelUserDatabase, get_user_db
 from app.config import settings
 from app.models.invite_token import InviteToken
@@ -28,10 +30,13 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
     async def create(self, user_create, safe: bool = False, request: Request | None = None) -> User:
         """Consume a valid one-time invite token, then create the user.
 
-        The token is validated BEFORE creating the user and marked used only
-        after the user is successfully created, so a failed registration does
-        not burn the token.
+        Validation order matters: the e-mail domain and invite token are checked,
+        then ``super().create`` validates the password and inserts the user. The
+        token is marked used only AFTER the user is successfully created, so a
+        rejected registration (bad domain, weak password, duplicate e-mail) does
+        NOT burn the token (#53, regression-tested).
         """
+        self._require_allowed_domain(getattr(user_create, "email", ""))
         invite = self._require_valid_invite(getattr(user_create, "invite_token", ""))
         user = await super().create(user_create, safe=safe, request=request)
         invite.used_by = user.id
@@ -39,6 +44,27 @@ class UserManager(IntegerIDMixin, BaseUserManager[User, int]):
         self.user_db.session.add(invite)
         self.user_db.session.commit()
         return user
+
+    async def validate_password(self, password: str, user) -> None:
+        """Enforce the shared password policy (app/auth/password_policy.py, #53)."""
+        problems = password_problems(password)
+        if problems:
+            raise InvalidPasswordException(reason="Passwort benötigt: " + ", ".join(problems) + ".")
+
+    @staticmethod
+    def _require_allowed_domain(email: str) -> None:
+        """Reject e-mail domains outside the configured allowlist (#53).
+
+        Empty allowlist = every domain allowed. Comparison is case-insensitive.
+        """
+        raw = (settings.auth_allowed_email_domains or "").strip()
+        if not raw:
+            return
+        allowed = {d.strip().lower() for d in raw.split(",") if d.strip()}
+        domain = email.rsplit("@", 1)[-1].strip().lower() if "@" in email else ""
+        if domain not in allowed:
+            pretty = ", ".join(sorted(allowed))
+            raise HTTPException(400, f"Registrierung nur mit E-Mail-Adressen dieser Domains: {pretty}.")
 
     def _require_valid_invite(self, token: str) -> InviteToken:
         token = (token or "").strip()

--- a/backend/app/auth/password_policy.py
+++ b/backend/app/auth/password_policy.py
@@ -1,0 +1,34 @@
+"""Password policy (doc 25, #53).
+
+Single source of truth for the backend password rules. Enforced authoritatively
+in ``UserManager.validate_password``; the frontend mirrors the SAME rules in
+``src/lib/passwordPolicy.ts`` for a live checklist (keep both in sync).
+
+Policy: length first, plus the four character classes the user asked for
+(min length gives most of the entropy; the classes are a floor against trivial
+passwords). Adjust ``PASSWORD_MIN_LENGTH`` / the checks here and mirror them.
+"""
+
+from __future__ import annotations
+
+import re
+
+PASSWORD_MIN_LENGTH = 12
+
+
+def password_problems(password: str) -> list[str]:
+    """Return the unmet requirements (German fragments), empty if the password is OK."""
+    problems: list[str] = []
+    if len(password) < PASSWORD_MIN_LENGTH:
+        problems.append(f"mindestens {PASSWORD_MIN_LENGTH} Zeichen")
+    if not (re.search(r"[a-z]", password) and re.search(r"[A-Z]", password)):
+        problems.append("Groß- und Kleinbuchstaben")
+    if not re.search(r"\d", password):
+        problems.append("eine Ziffer")
+    if not re.search(r"[^A-Za-z0-9]", password):
+        problems.append("ein Sonderzeichen")
+    return problems
+
+
+def is_password_valid(password: str) -> bool:
+    return not password_problems(password)

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -1,0 +1,22 @@
+"""fastapi-users request/response schemas (doc 25, WP2)."""
+
+from fastapi_users import schemas
+
+
+class UserRead(schemas.BaseUser[int]):
+    """Public user representation (never includes the password hash)."""
+
+
+class UserCreate(schemas.BaseUserCreate):
+    """Registration payload. Requires a valid one-time invite token.
+
+    is_superuser / is_verified inherited from BaseUserCreate are ignored on the
+    public /register route (fastapi-users calls create with safe=True), so a
+    self-registering user cannot elevate themselves to admin.
+    """
+
+    invite_token: str
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    """Self-service profile update (password/email)."""

--- a/backend/app/auth/user_db.py
+++ b/backend/app/auth/user_db.py
@@ -1,0 +1,71 @@
+"""Synchronous fastapi-users user database backed by the sync SQLModel Session.
+
+Implements the fastapi-users BaseUserDatabase protocol. Methods are declared
+async (the manager awaits them) but execute plain synchronous Session queries —
+the app has no async engine and SQLite calls are fast enough for this
+low-traffic internal tool.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+from fastapi import Depends
+from fastapi_users.db.base import BaseUserDatabase
+from sqlmodel import Session, select
+
+from app.db import get_session
+from app.models.user import User
+
+_USER_COLUMNS = set(User.__table__.columns.keys())  # type: ignore[attr-defined]
+
+
+class SQLModelUserDatabase(BaseUserDatabase[User, int]):
+    """Sync-backed user store for fastapi-users."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    async def get(self, id: int) -> User | None:
+        return self.session.get(User, id)
+
+    async def get_by_email(self, email: str) -> User | None:
+        # Case-insensitive lookup: e-mail addresses are not case-sensitive.
+        stmt = select(User).where(User.email == email)
+        user = self.session.exec(stmt).first()
+        if user is not None:
+            return user
+        return self.session.exec(
+            select(User).where(User.email.ilike(email))  # type: ignore[attr-defined]
+        ).first()
+
+    async def get_by_oauth_account(self, oauth: str, account_id: str) -> User | None:
+        return None  # OAuth not used
+
+    async def create(self, create_dict: dict[str, Any]) -> User:
+        # Drop any keys that are not real User columns (e.g. the invite_token
+        # carried on the registration schema).
+        data = {k: v for k, v in create_dict.items() if k in _USER_COLUMNS}
+        user = User(**data)
+        self.session.add(user)
+        self.session.commit()
+        self.session.refresh(user)
+        return user
+
+    async def update(self, user: User, update_dict: dict[str, Any]) -> User:
+        for key, value in update_dict.items():
+            if key in _USER_COLUMNS:
+                setattr(user, key, value)
+        self.session.add(user)
+        self.session.commit()
+        self.session.refresh(user)
+        return user
+
+    async def delete(self, user: User) -> None:
+        self.session.delete(user)
+        self.session.commit()
+
+
+def get_user_db(session: Session = Depends(get_session)) -> Generator[SQLModelUserDatabase, None, None]:
+    yield SQLModelUserDatabase(session)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,23 @@ class Settings(BaseSettings):
     app_version: str = "0.2.0"
     debug: bool = False
 
+    # Auth (multi-user, doc 25 WP2). Session-cookie carrying a signed JWT.
+    # auth_secret MUST be overridden in production (used to sign session tokens
+    # and password-reset/verify tokens). A fixed dev default keeps local runs and
+    # tests working without configuration.
+    auth_secret: str = "dev-insecure-secret-change-me-0123456789abcdef"
+    # Session lifetime in seconds (default 12h). No refresh tokens by design.
+    auth_session_lifetime: int = 60 * 60 * 12
+    # Cookie flags. Secure=True requires HTTPS; disabled by default for local http
+    # dev and flipped on in the server deployment (behind TLS).
+    auth_cookie_secure: bool = False
+    auth_cookie_samesite: str = "lax"
+    # First-admin bootstrap: when both are set and NO user exists yet, a superuser
+    # is created on startup (breaks the invite-token chicken-and-egg). Leave empty
+    # to disable. Never commit real values.
+    admin_email: str = ""
+    admin_password: str = ""
+
 
 # Module-level singleton — import this where settings are needed.
 settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,6 +53,10 @@ class Settings(BaseSettings):
     # to disable. Never commit real values.
     admin_email: str = ""
     admin_password: str = ""
+    # Optional registration domain allowlist (#53). Comma-separated list of allowed
+    # e-mail domains, e.g. "infoteam.de,infoteam.com". Empty = any domain allowed.
+    # Defense-in-depth on top of the invite token; case-insensitive.
+    auth_allowed_email_domains: str = ""
 
 
 # Module-level singleton — import this where settings are needed.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     default_holiday_state: str = "BY"
 
     # Application
-    app_version: str = "0.2.0"
+    app_version: str = "0.3.0"
     debug: bool = False
 
     # Auth (multi-user, doc 25 WP2). Session-cookie carrying a signed JWT.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -13,10 +13,24 @@ from collections.abc import Generator
 
 from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.config import settings
 from app.services.db_management import resolve_db_url
+
+# Default application settings, seeded per owner on first access (doc 25, WP3).
+# The read paths (milestones, persons, holiday_region) fall back to these same
+# values when a key is absent, so behaviour is identical before and after seeding.
+DEFAULT_SETTINGS: dict[str, str] = {
+    "default_vacation_days": "30",
+    "sick_days_per_year": "10",
+    "training_days_per_year": "5",
+    # Holiday region for the year calendar. holiday_extra = CSV of activated
+    # optional local holidays (keys from EXTRA_HOLIDAY_CATALOG).
+    "holiday_country": "DE",
+    "holiday_state": "BY",
+    "holiday_extra": "",
+}
 
 _db_url = resolve_db_url()
 
@@ -40,39 +54,30 @@ def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
 
 
-def seed_default_settings() -> None:
-    """Insert default settings rows if they do not yet exist.
+def ensure_owner_settings(session: Session) -> None:
+    """Seed any missing default settings for the session's current owner (#42, doc 25).
 
-    Idempotent and multi-process safe (#42): with several uvicorn workers the
-    first start on an empty DB races — two workers both see a key missing and
-    both INSERT, tripping ``UNIQUE constraint failed: setting.key``. Each key is
-    therefore inserted in its own transaction and a concurrent-insert
-    IntegrityError is caught and rolled back (treated as "already seeded"). The
-    pre-check keeps the common case (already seeded) free of expected errors.
+    Per-owner (WP3 step 3b): settings are no longer global, so they can't be
+    seeded once at startup — each user needs their own copy. This is called from
+    the authenticated settings endpoints, where the session is owner-bound: the
+    existence SELECT is auto-scoped to the current owner by the central filter,
+    and new rows get their owner_id stamped by the before_flush listener.
+
+    Idempotent and race-safe: each key is inserted in its own transaction and a
+    concurrent-insert IntegrityError (two requests seeding the same brand-new
+    owner at once) is swallowed as "already seeded".
     """
     from app.models.setting import Setting  # local import avoids circular deps at module load
 
-    defaults = {
-        "default_vacation_days": "30",
-        "sick_days_per_year": "10",
-        "training_days_per_year": "5",
-        # Holiday region for the year calendar (WP5). holiday_extra = CSV of
-        # activated optional local holidays (keys from EXTRA_HOLIDAY_CATALOG).
-        "holiday_country": "DE",
-        "holiday_state": "BY",
-        "holiday_extra": "",
-    }
-    with Session(engine) as session:
-        for key, value in defaults.items():
-            if session.get(Setting, key) is not None:
-                continue
-            session.add(Setting(key=key, value=value))
-            try:
-                session.commit()
-            except IntegrityError:
-                # Another worker inserted this key concurrently — that is the
-                # desired end state, so drop our pending row and carry on.
-                session.rollback()
+    existing = {row.key for row in session.exec(select(Setting)).all()}
+    for key, value in DEFAULT_SETTINGS.items():
+        if key in existing:
+            continue
+        session.add(Setting(key=key, value=value))
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
 
 
 def get_session() -> Generator[Session, None, None]:  # pragma: no cover

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -12,6 +12,7 @@ DATABASE_URL env var / pydantic default.
 from collections.abc import Generator
 
 from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, SQLModel, create_engine
 
 from app.config import settings
@@ -40,7 +41,15 @@ def create_db_and_tables() -> None:
 
 
 def seed_default_settings() -> None:
-    """Insert default settings rows if they do not yet exist."""
+    """Insert default settings rows if they do not yet exist.
+
+    Idempotent and multi-process safe (#42): with several uvicorn workers the
+    first start on an empty DB races — two workers both see a key missing and
+    both INSERT, tripping ``UNIQUE constraint failed: setting.key``. Each key is
+    therefore inserted in its own transaction and a concurrent-insert
+    IntegrityError is caught and rolled back (treated as "already seeded"). The
+    pre-check keeps the common case (already seeded) free of expected errors.
+    """
     from app.models.setting import Setting  # local import avoids circular deps at module load
 
     defaults = {
@@ -55,9 +64,15 @@ def seed_default_settings() -> None:
     }
     with Session(engine) as session:
         for key, value in defaults.items():
-            if session.get(Setting, key) is None:
-                session.add(Setting(key=key, value=value))
-        session.commit()
+            if session.get(Setting, key) is not None:
+                continue
+            session.add(Setting(key=key, value=value))
+            try:
+                session.commit()
+            except IntegrityError:
+                # Another worker inserted this key concurrently — that is the
+                # desired end state, so drop our pending row and carry on.
+                session.rollback()
 
 
 def get_session() -> Generator[Session, None, None]:  # pragma: no cover

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app import tenancy  # noqa: F401 — registers the owner-filter ORM event listeners
 from app.auth.bootstrap import seed_admin_user
 from app.config import settings
 from app.db import create_db_and_tables, seed_default_settings

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,15 +10,17 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.auth.bootstrap import seed_admin_user
 from app.config import settings
 from app.db import create_db_and_tables, seed_default_settings
-from app.routers import calendar, imports, invoices, milestones, persons, programs, projects, settings as settings_router
+from app.routers import auth, calendar, imports, invoices, milestones, persons, programs, projects, settings as settings_router
 
 
 @asynccontextmanager
 async def lifespan(application: FastAPI):
     create_db_and_tables()
     seed_default_settings()
+    seed_admin_user()
     yield
 
 
@@ -37,6 +39,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(auth.router)
 app.include_router(programs.router)
 app.include_router(projects.router)
 app.include_router(persons.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,14 +13,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from app import tenancy  # noqa: F401 — registers the owner-filter ORM event listeners
 from app.auth.bootstrap import seed_admin_user
 from app.config import settings
-from app.db import create_db_and_tables, seed_default_settings
+from app.db import create_db_and_tables
 from app.routers import auth, calendar, imports, invoices, milestones, persons, programs, projects, settings as settings_router
 
 
 @asynccontextmanager
 async def lifespan(application: FastAPI):
     create_db_and_tables()
-    seed_default_settings()
+    # Default settings are seeded per owner on first access (doc 25, WP3), not
+    # globally at startup — settings are per-user now.
     seed_admin_user()
     yield
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.enums import (
     ProjectStatus,
 )
 from app.models.holiday import Holiday
+from app.models.invite_token import InviteToken
 from app.models.invoice import InvoicePersonEntry, MonthlyInvoice
 from app.models.membership import ProjectMembership
 from app.models.milestone import Milestone, MilestonePersonBudget
@@ -20,6 +21,7 @@ from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.program import Program
 from app.models.project import Project
 from app.models.timebooking import ImportBatch, SagePositionMapping, SageProjectMapping, TimeBooking
+from app.models.user import User
 
 __all__ = [
     "ValidatedSQLModel",
@@ -28,6 +30,7 @@ __all__ = [
     "BillingPosition",
     "Holiday",
     "ImportBatch",
+    "InviteToken",
     "InvoicePersonEntry",
     "InvoiceStatus",
     "Milestone",
@@ -43,5 +46,6 @@ __all__ = [
     "SagePositionMapping",
     "SageProjectMapping",
     "TimeBooking",
+    "User",
     "VacationContingent",
 ]

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -9,6 +9,8 @@ class BillingPosition(ValidatedSQLModel, table=True):
     __tablename__ = "billing_position"
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)
     position_number: str = Field(min_length=1)
     description: str = ""

--- a/backend/app/models/invite_token.py
+++ b/backend/app/models/invite_token.py
@@ -1,0 +1,26 @@
+"""InviteToken — one-time registration gate (doc 25, WP1/§4).
+
+Registration is only possible with a valid, unused, unexpired token: the admin
+mints a token (created_by), it is consumed on first successful registration
+(used_by / used_at). No SMTP is involved — the admin hands the token to the
+invitee out of band. This is global admin/registration infrastructure, not
+tenant data, so it carries NO owner_id.
+"""
+
+from datetime import datetime
+
+from sqlmodel import Field
+
+from app.models.base import ValidatedSQLModel
+
+
+class InviteToken(ValidatedSQLModel, table=True):
+    __tablename__ = "invite_token"
+
+    id: int | None = Field(default=None, primary_key=True)
+    token: str = Field(unique=True, index=True, min_length=1)
+    created_by: int | None = Field(default=None, foreign_key="user.id")
+    used_by: int | None = Field(default=None, foreign_key="user.id")
+    created_at: datetime | None = None
+    used_at: datetime | None = None
+    expires_at: datetime | None = None

--- a/backend/app/models/invoice.py
+++ b/backend/app/models/invoice.py
@@ -16,6 +16,8 @@ class MonthlyInvoice(ValidatedSQLModel, table=True):
     __tablename__ = "monthly_invoice"
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)
     billing_position_id: int = Field(foreign_key="billing_position.id")
     year: int = Field(ge=2000, le=2100)
@@ -32,6 +34,8 @@ class InvoicePersonEntry(ValidatedSQLModel, table=True):
     __tablename__ = "invoice_person_entry"
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent invoice/project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     invoice_id: int = Field(foreign_key="monthly_invoice.id", index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
     hours: float = Field(ge=0)

--- a/backend/app/models/membership.py
+++ b/backend/app/models/membership.py
@@ -27,6 +27,8 @@ class ProjectMembership(ValidatedSQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project/person.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
     from_date: date

--- a/backend/app/models/milestone.py
+++ b/backend/app/models/milestone.py
@@ -24,6 +24,8 @@ class Milestone(ValidatedSQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)
     year: int = Field(ge=2000, le=2100)
     month: int = Field(ge=1, le=12)
@@ -60,6 +62,8 @@ class MilestonePersonBudget(ValidatedSQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent milestone/project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     milestone_id: int = Field(foreign_key="milestone.id", index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
     # Line item this budget row belongs to (doc 23). None = simple mode / unassigned.

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -12,11 +12,17 @@ from app.models.enums import AbsenceDaySegment, AbsenceStatus, AbsenceType
 
 class Person(ValidatedSQLModel, table=True):
     __tablename__ = "person"
+    # Multi-user (doc 25): sage_employee_name is unique PER OWNER, not globally.
+    __table_args__ = (
+        UniqueConstraint("owner_id", "sage_employee_name", name="uq_person_owner_sage_name"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): owning user; nullable now, populated + enforced in WP3.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     name: str = Field(min_length=1)
     # Must match the employee name string used in Sage ERP exports.
-    sage_employee_name: str = Field(unique=True, index=True, min_length=1)
+    sage_employee_name: str = Field(index=True, min_length=1)
     default_weekly_hours: float = Field(gt=0, le=60)
     # Comma-separated daily hours Mon–Fri, e.g. "8,8,8,8,0" for 4-day/32h week.
     work_week_pattern: str | None = Field(default=None)
@@ -32,6 +38,9 @@ class VacationContingent(ValidatedSQLModel, table=True):
     __table_args__ = (UniqueConstraint("person_id", "year", name="uq_vacation_contingent_person_year"),)
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent person, so the central
+    # filter (WP3) applies uniformly to every table without a join.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
     year: int = Field(ge=2000, le=2100)
     total_days: float = Field(ge=0, le=365)
@@ -48,6 +57,8 @@ class PersonAbsence(ValidatedSQLModel, table=True):
     __tablename__ = "person_absence"
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent person.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
     start_date: date
     end_date: date | None = None  # null only for sick + ongoing

--- a/backend/app/models/program.py
+++ b/backend/app/models/program.py
@@ -1,5 +1,6 @@
 """Program model — top-level grouping of related sub-projects."""
 
+from sqlalchemy import UniqueConstraint
 from sqlmodel import Field
 
 from app.models.base import ValidatedSQLModel
@@ -7,8 +8,17 @@ from app.models.base import ValidatedSQLModel
 
 class Program(ValidatedSQLModel, table=True):
     __tablename__ = "program"
+    # Multi-user (doc 25): program_number is unique PER OWNER, not globally, so two
+    # users may use the same number without one leaking the other's existence.
+    __table_args__ = (
+        UniqueConstraint("owner_id", "program_number", name="uq_program_owner_number"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
-    program_number: str = Field(unique=True, index=True, min_length=1)
+    # owner_id (doc 25): the user who owns this row. Nullable for now — WP3 sets it
+    # automatically on insert and enforces the owner-filter; a later migration can
+    # tighten it to NOT NULL once every row is provably owned.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
+    program_number: str = Field(index=True, min_length=1)
     name: str = Field(min_length=1)
     customer: str = Field(min_length=1)

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -3,6 +3,7 @@
 from datetime import date
 
 from pydantic import model_validator
+from sqlalchemy import UniqueConstraint
 from sqlmodel import Field
 
 from app.models.base import ValidatedSQLModel
@@ -11,10 +12,16 @@ from app.models.enums import ProjectStatus
 
 class Project(ValidatedSQLModel, table=True):
     __tablename__ = "project"
+    # Multi-user (doc 25): project_number is unique PER OWNER, not globally.
+    __table_args__ = (
+        UniqueConstraint("owner_id", "project_number", name="uq_project_owner_number"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): owning user; nullable now, populated + enforced in WP3.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     program_id: int | None = Field(default=None, foreign_key="program.id", index=True)
-    project_number: str = Field(unique=True, index=True, min_length=1)
+    project_number: str = Field(index=True, min_length=1)
     name: str = Field(min_length=1)
     description: str = ""
     start_date: date

--- a/backend/app/models/setting.py
+++ b/backend/app/models/setting.py
@@ -1,5 +1,6 @@
-"""Application-level key/value settings."""
+"""Application-level key/value settings — per owner (doc 25, WP3 step 3b)."""
 
+from sqlalchemy import UniqueConstraint
 from sqlmodel import Field
 
 from app.models.base import ValidatedSQLModel
@@ -7,6 +8,14 @@ from app.models.base import ValidatedSQLModel
 
 class Setting(ValidatedSQLModel, table=True):
     __tablename__ = "setting"
+    # Multi-user (doc 25): settings are per-owner. A surrogate id is the PK (a
+    # composite (owner_id, key) PK can't work — owner_id is nullable) and each key
+    # is unique PER OWNER, so every user keeps their own copy of the defaults.
+    __table_args__ = (
+        UniqueConstraint("owner_id", "key", name="uq_setting_owner_key"),
+    )
 
-    key: str = Field(primary_key=True, min_length=1)
+    id: int | None = Field(default=None, primary_key=True)
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
+    key: str = Field(index=True, min_length=1)
     value: str

--- a/backend/app/models/timebooking.py
+++ b/backend/app/models/timebooking.py
@@ -18,6 +18,8 @@ class ImportBatch(ValidatedSQLModel, table=True):
     __tablename__ = "import_batch"
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)
     imported_at: datetime
     source_filename: str | None = None  # null when data was pasted
@@ -32,9 +34,15 @@ class SageProjectMapping(ValidatedSQLModel, table=True):
     """
 
     __tablename__ = "sage_project_mapping"
+    # Multi-user (doc 25): sage_project_name is unique PER OWNER, not globally.
+    __table_args__ = (
+        UniqueConstraint("owner_id", "sage_project_name", name="uq_sage_mapping_owner_name"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
-    sage_project_name: str = Field(unique=True, index=True, min_length=1)
+    # owner_id (doc 25): denormalised owner of the parent project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
+    sage_project_name: str = Field(index=True, min_length=1)
     project_id: int = Field(foreign_key="project.id", index=True)
 
 
@@ -48,6 +56,8 @@ class SagePositionMapping(ValidatedSQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)
     sage_project_level: str = Field(min_length=1)
     billing_position_id: int = Field(foreign_key="billing_position.id", index=True)
@@ -72,6 +82,8 @@ class TimeBooking(ValidatedSQLModel, table=True):
     )
 
     id: int | None = Field(default=None, primary_key=True)
+    # owner_id (doc 25): denormalised owner of the parent project/person.
+    owner_id: int | None = Field(default=None, foreign_key="user.id", index=True)
     booking_date: date = Field(index=True)
     person_id: int = Field(foreign_key="person.id", index=True)
     project_id: int = Field(foreign_key="project.id", index=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,27 @@
+"""User model — application identity for multi-user tenancy (doc 25, WP1).
+
+Fields mirror the fastapi-users SQLAlchemy user table (id, email,
+hashed_password, is_active, is_superuser, is_verified) so WP2 can wire
+fastapi-users onto this SQLModel table without a schema rework. An int
+primary key is used (not UUID) to match every other FK in the codebase —
+`owner_id` on ownable entities references `user.id`.
+
+is_superuser doubles as the admin flag: the central owner-filter (WP3) is
+bypassed for superusers so an operator/admin account can see all data
+(explicit decision, see doc 25 §1/§6).
+"""
+
+from sqlmodel import Field
+
+from app.models.base import ValidatedSQLModel
+
+
+class User(ValidatedSQLModel, table=True):
+    __tablename__ = "user"
+
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(unique=True, index=True, min_length=3)
+    hashed_password: str
+    is_active: bool = True
+    is_superuser: bool = False  # admin: sees all data, bypasses the owner-filter (WP3)
+    is_verified: bool = False

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,94 @@
+"""Auth routes (doc 25, WP2).
+
+Mounts the fastapi-users login/logout/register/users routers and adds the
+admin-only invite-token management endpoints. Password-reset/verify routers are
+intentionally omitted for now (admin-assisted reset planned).
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from app.auth.backend import auth_backend, current_superuser, fastapi_users
+from app.auth.manager import utcnow_naive
+from app.auth.schemas import UserCreate, UserRead, UserUpdate
+from app.db import get_session
+from app.models.invite_token import InviteToken
+from app.models.user import User
+
+router = APIRouter()
+
+# fastapi-users generated routers.
+router.include_router(fastapi_users.get_auth_router(auth_backend), prefix="/auth", tags=["auth"])
+router.include_router(
+    fastapi_users.get_register_router(UserRead, UserCreate), prefix="/auth", tags=["auth"]
+)
+router.include_router(fastapi_users.get_users_router(UserRead, UserUpdate), prefix="/users", tags=["users"])
+
+
+# ── Invite-token management (admin only) ─────────────────────────────────────
+
+class InviteCreate(BaseModel):
+    expires_in_days: int | None = 14  # None = no expiry
+
+
+class InviteRead(BaseModel):
+    id: int
+    token: str
+    created_by: int | None
+    used_by: int | None
+    created_at: str | None
+    used_at: str | None
+    expires_at: str | None
+
+
+def _to_read(t: InviteToken) -> InviteRead:
+    return InviteRead(
+        id=t.id,  # type: ignore[arg-type]
+        token=t.token,
+        created_by=t.created_by,
+        used_by=t.used_by,
+        created_at=t.created_at.isoformat() if t.created_at else None,
+        used_at=t.used_at.isoformat() if t.used_at else None,
+        expires_at=t.expires_at.isoformat() if t.expires_at else None,
+    )
+
+
+invites = APIRouter(prefix="/auth/invites", tags=["auth"])
+
+
+@invites.post("", response_model=InviteRead, status_code=201)
+def create_invite(
+    body: InviteCreate,
+    session: Session = Depends(get_session),
+    admin: User = Depends(current_superuser),
+) -> InviteRead:
+    now = utcnow_naive()
+    expires = now + timedelta(days=body.expires_in_days) if body.expires_in_days else None
+    invite = InviteToken(
+        token=secrets.token_urlsafe(32),
+        created_by=admin.id,
+        created_at=now,
+        expires_at=expires,
+    )
+    session.add(invite)
+    session.commit()
+    session.refresh(invite)
+    return _to_read(invite)
+
+
+@invites.get("", response_model=list[InviteRead])
+def list_invites(
+    session: Session = Depends(get_session),
+    admin: User = Depends(current_superuser),
+) -> list[InviteRead]:
+    tokens = session.exec(select(InviteToken).order_by(InviteToken.id)).all()
+    return [_to_read(t) for t in tokens]
+
+
+router.include_router(invites)

--- a/backend/app/routers/calendar.py
+++ b/backend/app/routers/calendar.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, select
 
 from sqlalchemy import func
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.membership import ProjectMembership
 from app.models.milestone import Milestone, MilestonePersonBudget
@@ -25,7 +26,7 @@ from app.services.holiday_region import (
     resolve_holiday_region,
 )
 
-router = APIRouter(prefix="/calendar", tags=["calendar"])
+router = APIRouter(prefix="/calendar", tags=["calendar"], dependencies=[Depends(owner_context)])
 SessionDep = Annotated[Session, Depends(get_session)]
 
 

--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.person import Person
 from app.models.timebooking import (
@@ -27,7 +28,7 @@ from app.services.importer import (
 
 
 
-router = APIRouter(tags=["imports"])
+router = APIRouter(tags=["imports"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
@@ -284,10 +285,10 @@ def update_mapping(mapping_id: int, body: MappingCreate, session: SessionDep):
     mapping = session.get(SageProjectMapping, mapping_id)
     if not mapping:
         raise HTTPException(404, "Mapping not found.")
-    mapping.sage_project_name = body.sage_project_name
-    mapping.project_id = body.project_id
     # App-level duplicate check (doc 25): reject a sage_project_name already used by
-    # another of this owner's mappings. Auto-scoped to the owner by WP3's filter.
+    # another of this owner's mappings. Auto-scoped to the owner by WP3's filter. Run
+    # BEFORE mutating `mapping`, else the autoflush the query triggers would write the
+    # conflicting value and trip the per-owner UNIQUE constraint (500 instead of 409).
     dup = session.exec(
         select(SageProjectMapping).where(
             SageProjectMapping.sage_project_name == body.sage_project_name,
@@ -296,6 +297,8 @@ def update_mapping(mapping_id: int, body: MappingCreate, session: SessionDep):
     ).first()
     if dup:
         raise HTTPException(409, "Mapping for this sage_project_name already exists.")
+    mapping.sage_project_name = body.sage_project_name
+    mapping.project_id = body.project_id
     try:
         session.add(mapping)
         session.commit()

--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -254,6 +254,13 @@ def create_mapping(body: MappingCreate, session: SessionDep):
         sage_project_name=body.sage_project_name,
         project_id=body.project_id,
     )
+    # App-level duplicate check (doc 25): sage_project_name is unique per-owner. This
+    # query is auto-scoped to the current owner by WP3's filter; IntegrityError stays
+    # as a race backstop.
+    if session.exec(
+        select(SageProjectMapping).where(SageProjectMapping.sage_project_name == body.sage_project_name)
+    ).first():
+        raise HTTPException(409, "Mapping for this sage_project_name already exists.")
     try:
         session.add(mapping)
         session.commit()
@@ -279,6 +286,16 @@ def update_mapping(mapping_id: int, body: MappingCreate, session: SessionDep):
         raise HTTPException(404, "Mapping not found.")
     mapping.sage_project_name = body.sage_project_name
     mapping.project_id = body.project_id
+    # App-level duplicate check (doc 25): reject a sage_project_name already used by
+    # another of this owner's mappings. Auto-scoped to the owner by WP3's filter.
+    dup = session.exec(
+        select(SageProjectMapping).where(
+            SageProjectMapping.sage_project_name == body.sage_project_name,
+            SageProjectMapping.id != mapping_id,
+        )
+    ).first()
+    if dup:
+        raise HTTPException(409, "Mapping for this sage_project_name already exists.")
     try:
         session.add(mapping)
         session.commit()

--- a/backend/app/routers/invoices.py
+++ b/backend/app/routers/invoices.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Field, Session, SQLModel, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.enums import InvoiceStatus
 from app.models.invoice import InvoicePersonEntry, MonthlyInvoice
@@ -18,7 +19,7 @@ from app.services.invoices import (
     update_invoice_status,
 )
 
-router = APIRouter(tags=["invoices"])
+router = APIRouter(tags=["invoices"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 

--- a/backend/app/routers/milestones.py
+++ b/backend/app/routers/milestones.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func
 from sqlmodel import Field, Session, SQLModel, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.membership import ProjectMembership
 from app.models.milestone import Milestone, MilestonePersonBudget
@@ -43,7 +44,7 @@ from app.services.milestones import (
     set_milestone_target_budget,
 )
 
-router = APIRouter(prefix="/projects", tags=["milestones"])
+router = APIRouter(prefix="/projects", tags=["milestones"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 

--- a/backend/app/routers/persons.py
+++ b/backend/app/routers/persons.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.enums import AbsenceDaySegment, AbsenceStatus, AbsenceType
 from app.models.person import Person, PersonAbsence, VacationContingent
@@ -13,7 +14,7 @@ from app.models.project import Project
 from app.models.setting import Setting
 from app.services.planning import absence_booking, absence_summary
 
-router = APIRouter(prefix="/persons", tags=["persons"])
+router = APIRouter(prefix="/persons", tags=["persons"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
@@ -162,17 +163,18 @@ def update_person(person_id: int, data: Person, session: SessionDep):
     if not person:
         raise HTTPException(404, "Person not found.")
     update = data.model_dump(exclude_unset=True, exclude={"id"})
-    for field, value in update.items():
-        setattr(person, field, value)
     # App-level duplicate check (doc 25): reject a sage_employee_name already used by
-    # another of this owner's persons. Auto-scoped to the owner by WP3's filter.
+    # another of this owner's persons. Auto-scoped to the owner by WP3's filter. Run
+    # BEFORE mutating `person`, else the autoflush the query triggers would write the
+    # conflicting value and trip the per-owner UNIQUE constraint (500 instead of 409).
+    new_name = update.get("sage_employee_name", person.sage_employee_name)
     dup = session.exec(
-        select(Person).where(
-            Person.sage_employee_name == person.sage_employee_name, Person.id != person_id
-        )
+        select(Person).where(Person.sage_employee_name == new_name, Person.id != person_id)
     ).first()
     if dup:
         raise HTTPException(409, "sage_employee_name already exists.")
+    for field, value in update.items():
+        setattr(person, field, value)
     try:
         session.add(person)
         session.commit()

--- a/backend/app/routers/persons.py
+++ b/backend/app/routers/persons.py
@@ -132,7 +132,10 @@ def create_person(person: Person, session: SessionDep):
         session.add(person)
         session.flush()
         # Auto-create vacation contingent for the current year using default_vacation_days setting.
-        setting = session.get(Setting, "default_vacation_days")
+        # Per-owner setting (doc 25): auto-scoped to the current owner by the central filter.
+        setting = session.exec(
+            select(Setting).where(Setting.key == "default_vacation_days")
+        ).first()
         default_days = float(setting.value) if setting else 30.0
         current_year = _date.today().year
         contingent = VacationContingent(

--- a/backend/app/routers/persons.py
+++ b/backend/app/routers/persons.py
@@ -122,6 +122,11 @@ def batch_absence_summary(session: SessionDep, year: int | None = None):
 def create_person(person: Person, session: SessionDep):
     from datetime import date as _date
     person.id = None
+    # App-level duplicate check (doc 25): sage_employee_name is unique per-owner. This
+    # query is auto-scoped to the current owner by WP3's filter; IntegrityError stays
+    # as a race backstop.
+    if session.exec(select(Person).where(Person.sage_employee_name == person.sage_employee_name)).first():
+        raise HTTPException(409, "sage_employee_name already exists.")
     try:
         session.add(person)
         session.flush()
@@ -159,6 +164,15 @@ def update_person(person_id: int, data: Person, session: SessionDep):
     update = data.model_dump(exclude_unset=True, exclude={"id"})
     for field, value in update.items():
         setattr(person, field, value)
+    # App-level duplicate check (doc 25): reject a sage_employee_name already used by
+    # another of this owner's persons. Auto-scoped to the owner by WP3's filter.
+    dup = session.exec(
+        select(Person).where(
+            Person.sage_employee_name == person.sage_employee_name, Person.id != person_id
+        )
+    ).first()
+    if dup:
+        raise HTTPException(409, "sage_employee_name already exists.")
     try:
         session.add(person)
         session.commit()

--- a/backend/app/routers/programs.py
+++ b/backend/app/routers/programs.py
@@ -4,11 +4,12 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.program import Program
 from app.models.project import Project
 
-router = APIRouter(prefix="/programs", tags=["programs"])
+router = APIRouter(prefix="/programs", tags=["programs"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
@@ -57,15 +58,18 @@ def update_program(program_id: int, data: Program, session: SessionDep):
     if not program:
         raise HTTPException(404, "Program not found.")
     update = data.model_dump(exclude_unset=True, exclude={"id"})
-    for field, value in update.items():
-        setattr(program, field, value)
     # App-level duplicate check (doc 25): reject a program_number already used by
-    # another of this owner's programs. Auto-scoped to the owner by WP3's filter.
+    # another of this owner's programs. Auto-scoped to the owner by WP3's filter. Run
+    # BEFORE mutating `program`, else the autoflush the query triggers would write the
+    # conflicting value and trip the per-owner UNIQUE constraint (500 instead of 409).
+    new_number = update.get("program_number", program.program_number)
     dup = session.exec(
-        select(Program).where(Program.program_number == program.program_number, Program.id != program_id)
+        select(Program).where(Program.program_number == new_number, Program.id != program_id)
     ).first()
     if dup:
         raise HTTPException(409, "Program number already exists.")
+    for field, value in update.items():
+        setattr(program, field, value)
     try:
         session.add(program)
         session.commit()

--- a/backend/app/routers/programs.py
+++ b/backend/app/routers/programs.py
@@ -21,6 +21,11 @@ def list_programs(session: SessionDep, skip: int = 0, limit: int = 100):
 @router.post("", response_model=Program, status_code=201)
 def create_program(program: Program, session: SessionDep):
     program.id = None
+    # App-level duplicate check (doc 25): program_number is unique per-owner. This
+    # query is auto-scoped to the current owner by WP3's filter; IntegrityError stays
+    # as a race backstop.
+    if session.exec(select(Program).where(Program.program_number == program.program_number)).first():
+        raise HTTPException(409, "Program number already exists.")
     try:
         session.add(program)
         session.commit()
@@ -54,6 +59,13 @@ def update_program(program_id: int, data: Program, session: SessionDep):
     update = data.model_dump(exclude_unset=True, exclude={"id"})
     for field, value in update.items():
         setattr(program, field, value)
+    # App-level duplicate check (doc 25): reject a program_number already used by
+    # another of this owner's programs. Auto-scoped to the owner by WP3's filter.
+    dup = session.exec(
+        select(Program).where(Program.program_number == program.program_number, Program.id != program_id)
+    ).first()
+    if dup:
+        raise HTTPException(409, "Program number already exists.")
     try:
         session.add(program)
         session.commit()

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -7,6 +7,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Field, Session, SQLModel, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.billing import BillingPosition
 from app.models.enums import MilestoneStatus
@@ -31,7 +32,7 @@ from app.services.milestones import (
     set_position_mode,
 )
 
-router = APIRouter(prefix="/projects", tags=["projects"])
+router = APIRouter(prefix="/projects", tags=["projects"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
@@ -181,15 +182,18 @@ def update_project(project_id: int, data: Project, session: SessionDep):
     old_start, old_end = project.start_date, project.end_date
     # position_mode is toggled only via the guarded /position-mode endpoint (§21 WP8).
     update = data.model_dump(exclude_unset=True, exclude={"id", "position_mode"})
-    for field, value in update.items():
-        setattr(project, field, value)
     # App-level duplicate check (doc 25): reject a project_number already used by
-    # another of this owner's projects. Auto-scoped to the owner by WP3's filter.
+    # another of this owner's projects. Auto-scoped to the owner by WP3's filter. Run
+    # BEFORE mutating `project`, else the autoflush the query triggers would write the
+    # conflicting value and trip the per-owner UNIQUE constraint (500 instead of 409).
+    new_number = update.get("project_number", project.project_number)
     dup = session.exec(
-        select(Project).where(Project.project_number == project.project_number, Project.id != project_id)
+        select(Project).where(Project.project_number == new_number, Project.id != project_id)
     ).first()
     if dup:
         raise HTTPException(409, "Project number already exists.")
+    for field, value in update.items():
+        setattr(project, field, value)
     try:
         session.add(project)
         session.commit()

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -150,6 +150,11 @@ def get_project_stats(session: SessionDep):
 @router.post("", response_model=Project, status_code=201)
 def create_project(project: Project, session: SessionDep):
     project.id = None
+    # App-level duplicate check (doc 25): uniqueness of project_number is per-owner
+    # (owner_id, project_number). This query is auto-scoped to the current owner by
+    # the central filter (WP3); the IntegrityError catch stays as a race backstop.
+    if session.exec(select(Project).where(Project.project_number == project.project_number)).first():
+        raise HTTPException(409, "Project number already exists.")
     try:
         session.add(project)
         session.commit()
@@ -178,6 +183,13 @@ def update_project(project_id: int, data: Project, session: SessionDep):
     update = data.model_dump(exclude_unset=True, exclude={"id", "position_mode"})
     for field, value in update.items():
         setattr(project, field, value)
+    # App-level duplicate check (doc 25): reject a project_number already used by
+    # another of this owner's projects. Auto-scoped to the owner by WP3's filter.
+    dup = session.exec(
+        select(Project).where(Project.project_number == project.project_number, Project.id != project_id)
+    ).first()
+    if dup:
+        raise HTTPException(409, "Project number already exists.")
     try:
         session.add(project)
         session.commit()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, SQLModel, select
 
-from app.auth.deps import owner_context
+from app.auth.deps import owner_context, require_superuser
 from app.db import ensure_owner_settings, get_session
 from app.models.setting import Setting
 from app.services import db_management
@@ -49,18 +49,20 @@ def get_settings(session: SessionDep):
 # ---------------------------------------------------------------------------
 
 
-@router.get("/database-path", response_model=DbPathInfo)
+@router.get("/database-path", response_model=DbPathInfo, dependencies=[Depends(require_superuser)])
 def get_database_path():
-    """Return the current database file location."""
+    """Return the current database file location. Admin-only (#53)."""
     return db_management.get_db_info()
 
 
-@router.put("/database-path", response_model=DbPathResult)
+@router.put("/database-path", response_model=DbPathResult, dependencies=[Depends(require_superuser)])
 def set_database_path(body: DbPathUpdate):
     """Copy the database to a new directory and update the path pointer.
 
-    The backend must be restarted for the change to take full effect.
-    Returns restart_required=True and a cloud_warning flag when the target
+    Admin-only (#53): the database path is an instance-wide setting — the copy
+    affects every tenant and needs a backend restart, so it must not be reachable
+    by a regular user. The backend must be restarted for the change to take full
+    effect. Returns restart_required=True and a cloud_warning flag when the target
     path looks like a cloud-sync folder (OneDrive, Dropbox, etc.).
     """
     try:

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -4,11 +4,12 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, SQLModel, select
 
+from app.auth.deps import owner_context
 from app.db import get_session
 from app.models.setting import Setting
 from app.services import db_management
 
-router = APIRouter(prefix="/settings", tags=["settings"])
+router = APIRouter(prefix="/settings", tags=["settings"], dependencies=[Depends(owner_context)])
 
 SessionDep = Annotated[Session, Depends(get_session)]
 

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, SQLModel, select
 
 from app.auth.deps import owner_context
-from app.db import get_session
+from app.db import ensure_owner_settings, get_session
 from app.models.setting import Setting
 from app.services import db_management
 
@@ -37,6 +37,9 @@ class DbPathResult(SQLModel):
 
 @router.get("", response_model=dict[str, str])
 def get_settings(session: SessionDep):
+    # Per-owner (doc 25): seed this owner's defaults on first access, then return
+    # only their rows (auto-scoped by the central filter).
+    ensure_owner_settings(session)
     rows = session.exec(select(Setting)).all()
     return {row.key: row.value for row in rows}
 
@@ -75,7 +78,10 @@ def set_database_path(body: DbPathUpdate):
 
 @router.put("/{key}", response_model=Setting)
 def update_setting(key: str, body: SettingUpdate, session: SessionDep):
-    setting = session.get(Setting, key)
+    # Per-owner (doc 25): ensure this owner's defaults exist, then look the key up
+    # scoped to the owner (key is no longer the PK, so session.get can't be used).
+    ensure_owner_settings(session)
+    setting = session.exec(select(Setting).where(Setting.key == key)).first()
     if not setting:
         raise HTTPException(404, f"Setting '{key}' not found.")
     setting.value = body.value

--- a/backend/app/services/holiday_region.py
+++ b/backend/app/services/holiday_region.py
@@ -13,13 +13,13 @@ from __future__ import annotations
 
 from datetime import date
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.config import settings as config
 from app.models.person import Person
 from app.models.setting import Setting
 
-# Setting keys (seeded in db.seed_default_settings)
+# Setting keys (seeded per owner in db.ensure_owner_settings)
 KEY_COUNTRY = "holiday_country"
 KEY_STATE = "holiday_state"
 KEY_EXTRA = "holiday_extra"  # CSV of activated catalog keys below
@@ -35,7 +35,9 @@ EXTRA_HOLIDAY_CATALOG: dict[str, dict] = {
 
 
 def _get(session: Session, key: str, default: str) -> str:
-    row = session.get(Setting, key)
+    # Per-owner setting (doc 25): key is no longer the PK; the query is auto-scoped
+    # to the current owner by the central filter.
+    row = session.exec(select(Setting).where(Setting.key == key)).first()
     return row.value if row and row.value else default
 
 

--- a/backend/app/services/milestones.py
+++ b/backend/app/services/milestones.py
@@ -206,7 +206,9 @@ def _estimated_absence_override(
 
 
 def _get_setting_float(session: Session, key: str, default: float) -> float:
-    setting = session.get(Setting, key)
+    # Per-owner setting (doc 25): key is no longer the PK; the query is auto-scoped
+    # to the current owner by the central filter.
+    setting = session.exec(select(Setting).where(Setting.key == key)).first()
     if setting is None:
         return default
     try:

--- a/backend/app/tenancy.py
+++ b/backend/app/tenancy.py
@@ -1,0 +1,155 @@
+"""Central owner-based row filter — multi-user isolation (doc 25, WP3).
+
+Every ownable row carries an ``owner_id``. Instead of hand-writing
+``.where(Model.owner_id == current_user)`` on every query (error-prone, one
+forgotten filter = a data leak), the owner is bound ONCE to the SQLAlchemy
+``Session`` (``session.info["owner"]``) and two global event listeners enforce
+it for the whole session:
+
+* ``do_orm_execute`` — appends ``with_loader_criteria(owner_id == uid)`` to every
+  ORM SELECT, so reads only ever return the current owner's rows.
+* ``before_flush`` — stamps ``owner_id`` on freshly-inserted ownable rows, so
+  callers never set it by hand and can't accidentally set someone else's.
+
+Why ``session.info`` and not a ``ContextVar``: FastAPI runs sync endpoints and
+their ``yield`` dependencies in a threadpool, and a ContextVar set inside one
+threadpool task does not reliably propagate to the task running the endpoint.
+The Session, by contrast, is the exact object every query runs on — binding the
+owner to it is leak-proof by construction.
+
+Superusers (admins) bypass the read filter and see everything. Sessions with no
+owner bound (startup seeding, auth lookups, maintenance scripts) are unfiltered;
+the actual access boundary for owned data is the ``owner_context`` dependency
+that guards every CRUD router (``app/auth/deps.py``).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session as SASession, with_loader_criteria
+from sqlalchemy.orm.attributes import get_history
+
+from app.models.billing import BillingPosition
+from app.models.invoice import InvoicePersonEntry, MonthlyInvoice
+from app.models.membership import ProjectMembership
+from app.models.milestone import Milestone, MilestonePersonBudget
+from app.models.person import Person, PersonAbsence, VacationContingent
+from app.models.program import Program
+from app.models.project import Project
+from app.models.timebooking import ImportBatch, SagePositionMapping, SageProjectMapping, TimeBooking
+
+# Every table=True model carrying an owner_id column. The filter is applied for
+# each of these on every SELECT; SQLAlchemy silently ignores the ones not present
+# in a given statement, so listing all is safe (and keeps this the single source
+# of truth for "what is ownable"). Setting is added here in WP3 step 3b.
+OWNABLE_MODELS: tuple[type, ...] = (
+    Program,
+    Project,
+    Person,
+    VacationContingent,
+    PersonAbsence,
+    BillingPosition,
+    Milestone,
+    MilestonePersonBudget,
+    ProjectMembership,
+    MonthlyInvoice,
+    InvoicePersonEntry,
+    ImportBatch,
+    SageProjectMapping,
+    SagePositionMapping,
+    TimeBooking,
+)
+
+_INFO_KEY = "owner"
+_BYPASS_KEY = "owner_filter_bypass"
+
+
+@dataclass(frozen=True)
+class OwnerContext:
+    """The identity a Session acts on behalf of."""
+
+    user_id: int
+    is_superuser: bool = False
+
+
+def bind_owner(session: SASession, user_id: int, is_superuser: bool = False) -> None:
+    """Bind an owner to this session for the remainder of its life."""
+    session.info[_INFO_KEY] = OwnerContext(user_id=user_id, is_superuser=is_superuser)
+
+
+def clear_owner(session: SASession) -> None:
+    session.info.pop(_INFO_KEY, None)
+
+
+def get_owner(session: SASession) -> OwnerContext | None:
+    return session.info.get(_INFO_KEY)
+
+
+@contextmanager
+def bypass_owner_filter(session: SASession):
+    """Temporarily run unfiltered queries on an owner-bound session.
+
+    For rare maintenance/admin code that must see across owners on a session
+    that already has an owner bound. Restores the previous state on exit.
+    """
+    previous = session.info.get(_BYPASS_KEY, False)
+    session.info[_BYPASS_KEY] = True
+    try:
+        yield
+    finally:
+        session.info[_BYPASS_KEY] = previous
+
+
+@event.listens_for(SASession, "do_orm_execute")
+def _apply_owner_filter(state) -> None:
+    """Scope every ORM SELECT to the session's owner (unless superuser/unbound)."""
+    if not state.is_select:
+        return
+    # Relationship/column lazy-loads fetch attributes of an already-loaded (thus
+    # already-authorized) parent row; re-filtering them is both unnecessary and
+    # can raise on entities that don't carry owner_id.
+    if state.is_relationship_load or state.is_column_load:
+        return
+    session = state.session
+    if session.info.get(_BYPASS_KEY):
+        return
+    owner: OwnerContext | None = session.info.get(_INFO_KEY)
+    if owner is None or owner.is_superuser:
+        return
+    uid = owner.user_id
+    for model in OWNABLE_MODELS:
+        state.statement = state.statement.options(
+            with_loader_criteria(model, model.owner_id == uid, include_aliases=True)
+        )
+
+
+@event.listens_for(SASession, "before_flush")
+def _enforce_owner_on_write(session: SASession, _flush_context, _instances) -> None:
+    """Enforce the owner invariant on writes: owner_id is server-controlled.
+
+    * INSERT — every new ownable row is stamped with the session owner, ignoring
+      any owner_id the client may have sent (these models double as request
+      bodies, so a payload could otherwise smuggle one in).
+    * UPDATE — owner_id is never editable via CRUD. If a flush would change it
+      (notably: ``model_dump(exclude_unset=True)`` on a ValidatedSQLModel re-marks
+      every field as "set", so an update re-sends owner_id=None and would blank
+      it), the original value is restored. Without this, an updated row would
+      silently fall out of its owner's view.
+    """
+    if session.info.get(_BYPASS_KEY):
+        return
+    owner: OwnerContext | None = session.info.get(_INFO_KEY)
+    if owner is None:
+        return
+    for obj in session.new:
+        if isinstance(obj, OWNABLE_MODELS):
+            obj.owner_id = owner.user_id
+    for obj in session.dirty:
+        if isinstance(obj, OWNABLE_MODELS):
+            history = get_history(obj, "owner_id")
+            # history.deleted holds the pre-flush value when owner_id was changed.
+            if history.deleted and history.deleted[0] is not None:
+                obj.owner_id = history.deleted[0]

--- a/backend/app/tenancy.py
+++ b/backend/app/tenancy.py
@@ -39,12 +39,13 @@ from app.models.milestone import Milestone, MilestonePersonBudget
 from app.models.person import Person, PersonAbsence, VacationContingent
 from app.models.program import Program
 from app.models.project import Project
+from app.models.setting import Setting
 from app.models.timebooking import ImportBatch, SagePositionMapping, SageProjectMapping, TimeBooking
 
 # Every table=True model carrying an owner_id column. The filter is applied for
 # each of these on every SELECT; SQLAlchemy silently ignores the ones not present
 # in a given statement, so listing all is safe (and keeps this the single source
-# of truth for "what is ownable"). Setting is added here in WP3 step 3b.
+# of truth for "what is ownable").
 OWNABLE_MODELS: tuple[type, ...] = (
     Program,
     Project,
@@ -61,6 +62,7 @@ OWNABLE_MODELS: tuple[type, ...] = (
     SageProjectMapping,
     SagePositionMapping,
     TimeBooking,
+    Setting,
 )
 
 _INFO_KEY = "owner"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "httpx>=0.28",
     "python-multipart>=0.0.20",
     "thefuzz[speedup]>=0.22",
+    "fastapi-users>=15.0.5",
 ]
 
 [dependency-groups]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,15 +3,31 @@ Shared pytest fixtures for all test suites.
 
 The in-memory SQLite engine fixture ensures tests never touch disk and
 are fully isolated from each other.
+
+Multi-user (doc 25, WP3): the central owner-filter is driven by an owner bound
+onto the Session (``session.info["owner"]``). The ``client`` fixture binds a
+default test owner and overrides the ``owner_context`` auth dependency so the
+huge existing integration suite keeps passing without real login cookies — every
+row a test creates is owned by, and visible to, that one test owner, so the
+filter is transparent. Pure model/unit tests that use only the ``session``
+fixture get NO owner bound, so they can exercise raw cross-owner behaviour.
+Use ``client_for(user_id=..., is_superuser=...)`` to simulate other owners/admin.
 """
 
 import pytest
+from fastapi import Request
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
 from sqlmodel.pool import StaticPool
 
-from app.main import app
+from app.auth.deps import owner_context
 from app.db import get_session
+from app.main import app
+from app.models.user import User
+from app.tenancy import bind_owner, clear_owner
+
+# Default identity every `client`-based test acts as.
+TEST_OWNER_ID = 1
 
 
 @pytest.fixture(name="engine")
@@ -29,18 +45,85 @@ def engine_fixture():
 
 @pytest.fixture(name="session")
 def session_fixture(engine):
-    """Database session bound to the in-memory engine."""
+    """Database session bound to the in-memory engine (no owner bound)."""
     with Session(engine) as session:
         yield session
 
 
-@pytest.fixture(name="client")
-def client_fixture(session):
-    """TestClient with DB dependency overridden to use the in-memory session."""
+def _fake_owner(user_id: int, is_superuser: bool) -> User:
+    """A User instance for dependency return values — never persisted."""
+    return User(
+        id=user_id,
+        email=f"owner{user_id}@test.local",
+        hashed_password="x",
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+    )
+
+
+def _bind_client(session, user_id: int, is_superuser: bool) -> TestClient:
+    """Wire dependency overrides for a client acting as the given owner."""
     def override_get_session():
         yield session
 
+    def override_owner_context():
+        # Bind on every request so switching owners mid-test takes effect, and
+        # so handlers that inject `Depends(owner_context)` receive a user.
+        bind_owner(session, user_id=user_id, is_superuser=is_superuser)
+        return _fake_owner(user_id, is_superuser)
+
     app.dependency_overrides[get_session] = override_get_session
-    with TestClient(app) as c:
+    app.dependency_overrides[owner_context] = override_owner_context
+    # Bind immediately too, so direct `session.add(...)` in the test body (before
+    # the first request) is owner-scoped and stamped consistently.
+    bind_owner(session, user_id=user_id, is_superuser=is_superuser)
+    return TestClient(app)
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    """TestClient acting as the default test owner (id=1, non-superuser)."""
+    with _bind_client(session, TEST_OWNER_ID, is_superuser=False) as c:
         yield c
     app.dependency_overrides.clear()
+    clear_owner(session)
+
+
+@pytest.fixture(name="client_for")
+def client_for_fixture(session):
+    """Factory: build independent TestClients acting as different owners / admin.
+
+    All clients share the one in-memory session, so cross-owner isolation can be
+    asserted against a single database. Each client tags its requests with owner
+    headers; a single override binds the session owner PER REQUEST from those
+    headers, so interleaving calls from several owners resolves correctly (a
+    per-client closure override would not — there is only one override slot).
+    """
+    def override_get_session():
+        yield session
+
+    def override_owner_context(request: Request):
+        user_id = int(request.headers["x-test-owner-id"])
+        is_superuser = request.headers.get("x-test-superuser") == "1"
+        bind_owner(session, user_id=user_id, is_superuser=is_superuser)
+        return _fake_owner(user_id, is_superuser)
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[owner_context] = override_owner_context
+
+    created: list[TestClient] = []
+
+    def _make(user_id: int = TEST_OWNER_ID, is_superuser: bool = False) -> TestClient:
+        c = TestClient(app, headers={
+            "x-test-owner-id": str(user_id),
+            "x-test-superuser": "1" if is_superuser else "0",
+        })
+        created.append(c)
+        return c
+
+    yield _make
+    for c in created:
+        c.close()
+    app.dependency_overrides.clear()
+    clear_owner(session)

--- a/backend/tests/unit/test_auth.py
+++ b/backend/tests/unit/test_auth.py
@@ -18,6 +18,9 @@ from app.models.user import User
 
 _PW = PasswordHelper()
 
+# A password that satisfies the policy (#53): >=12 chars, upper+lower, digit, special.
+_GOOD_PW = "Pw123456789!"
+
 
 def _make_invite(session, token="invite-abc", expires_in_days=14, used_by=None):
     inv = InviteToken(
@@ -67,7 +70,7 @@ def test_register_with_valid_invite_succeeds_and_consumes_token(client, session)
     _make_invite(session, token="good-token")
     r = client.post(
         "/auth/register",
-        json={"email": "new@example.com", "password": "pw12345678", "invite_token": "good-token"},
+        json={"email": "new@example.com", "password": _GOOD_PW, "invite_token": "good-token"},
     )
     assert r.status_code == 201, r.text
     assert r.json()["email"] == "new@example.com"
@@ -76,7 +79,7 @@ def test_register_with_valid_invite_succeeds_and_consumes_token(client, session)
     # Token is now used → second attempt fails.
     r2 = client.post(
         "/auth/register",
-        json={"email": "other@example.com", "password": "pw12345678", "invite_token": "good-token"},
+        json={"email": "other@example.com", "password": _GOOD_PW, "invite_token": "good-token"},
     )
     assert r2.status_code == 400
 
@@ -95,12 +98,48 @@ def test_self_register_cannot_set_superuser(client, session):
     r = client.post(
         "/auth/register",
         json={
-            "email": "sneaky@example.com", "password": "pw12345678",
+            "email": "sneaky@example.com", "password": _GOOD_PW,
             "invite_token": "t2", "is_superuser": True,
         },
     )
     assert r.status_code == 201
     assert r.json()["is_superuser"] is False
+
+
+# ── password policy + domain allowlist + consume-last regression (#53) ─────────
+
+def test_register_weak_password_rejected_and_keeps_token(client, session):
+    """A weak password is rejected AND must not burn the invite token."""
+    _make_invite(session, token="weak-token")
+    r = client.post(
+        "/auth/register",
+        json={"email": "weak@example.com", "password": "short", "invite_token": "weak-token"},
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"]["code"] == "REGISTER_INVALID_PASSWORD"
+    # Token was NOT consumed → the same token now works with a strong password.
+    r2 = client.post(
+        "/auth/register",
+        json={"email": "weak@example.com", "password": _GOOD_PW, "invite_token": "weak-token"},
+    )
+    assert r2.status_code == 201, r2.text
+
+
+def test_register_disallowed_domain_rejected_and_keeps_token(client, session, monkeypatch):
+    from app.config import settings as app_settings
+    monkeypatch.setattr(app_settings, "auth_allowed_email_domains", "infoteam.de")
+    _make_invite(session, token="dom-token")
+    r = client.post(
+        "/auth/register",
+        json={"email": "x@example.com", "password": _GOOD_PW, "invite_token": "dom-token"},
+    )
+    assert r.status_code == 400
+    # Token survives the rejection → an allowed domain can still use it.
+    r2 = client.post(
+        "/auth/register",
+        json={"email": "y@infoteam.de", "password": _GOOD_PW, "invite_token": "dom-token"},
+    )
+    assert r2.status_code == 201, r2.text
 
 
 # ── login / session ──────────────────────────────────────────────────────────

--- a/backend/tests/unit/test_auth.py
+++ b/backend/tests/unit/test_auth.py
@@ -1,0 +1,183 @@
+"""Auth flow (doc 25, WP2): invite-gated registration, login/session, admin.
+
+Uses the shared in-memory `client`/`session` fixtures (conftest). All auth DB
+access flows through the overridden get_session, so everything stays in-memory.
+"""
+
+from datetime import timedelta
+
+import pytest
+from fastapi_users.password import PasswordHelper
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import app.auth.bootstrap as bootstrap
+from app.auth.manager import utcnow_naive
+from app.models.invite_token import InviteToken
+from app.models.user import User
+
+_PW = PasswordHelper()
+
+
+def _make_invite(session, token="invite-abc", expires_in_days=14, used_by=None):
+    inv = InviteToken(
+        token=token,
+        created_at=utcnow_naive(),
+        used_by=used_by,
+        expires_at=(utcnow_naive() + timedelta(days=expires_in_days)) if expires_in_days else None,
+    )
+    session.add(inv)
+    session.commit()
+    return inv
+
+
+def _make_user(session, email, password, superuser=False):
+    u = User(
+        email=email,
+        hashed_password=_PW.hash(password),
+        is_active=True,
+        is_superuser=superuser,
+        is_verified=True,
+    )
+    session.add(u)
+    session.commit()
+    return u
+
+
+def _login(client, email, password):
+    return client.post("/auth/login", data={"username": email, "password": password})
+
+
+# ── registration gate ────────────────────────────────────────────────────────
+
+def test_register_without_invite_token_rejected(client):
+    r = client.post("/auth/register", json={"email": "x@example.com", "password": "pw12345678"})
+    assert r.status_code == 422  # invite_token is a required field
+
+
+def test_register_with_invalid_invite_rejected(client):
+    r = client.post(
+        "/auth/register",
+        json={"email": "x@example.com", "password": "pw12345678", "invite_token": "nope"},
+    )
+    assert r.status_code == 400
+
+
+def test_register_with_valid_invite_succeeds_and_consumes_token(client, session):
+    _make_invite(session, token="good-token")
+    r = client.post(
+        "/auth/register",
+        json={"email": "new@example.com", "password": "pw12345678", "invite_token": "good-token"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["email"] == "new@example.com"
+    assert r.json()["is_superuser"] is False  # self-register cannot elevate
+
+    # Token is now used → second attempt fails.
+    r2 = client.post(
+        "/auth/register",
+        json={"email": "other@example.com", "password": "pw12345678", "invite_token": "good-token"},
+    )
+    assert r2.status_code == 400
+
+
+def test_register_with_expired_invite_rejected(client, session):
+    _make_invite(session, token="old", expires_in_days=-1)
+    r = client.post(
+        "/auth/register",
+        json={"email": "y@example.com", "password": "pw12345678", "invite_token": "old"},
+    )
+    assert r.status_code == 400
+
+
+def test_self_register_cannot_set_superuser(client, session):
+    _make_invite(session, token="t2")
+    r = client.post(
+        "/auth/register",
+        json={
+            "email": "sneaky@example.com", "password": "pw12345678",
+            "invite_token": "t2", "is_superuser": True,
+        },
+    )
+    assert r.status_code == 201
+    assert r.json()["is_superuser"] is False
+
+
+# ── login / session ──────────────────────────────────────────────────────────
+
+def test_login_sets_cookie_and_me_returns_user(client, session):
+    _make_user(session, "u@example.com", "pw12345678")
+    r = _login(client, "u@example.com", "pw12345678")
+    assert r.status_code in (200, 204)
+    assert "projektplannerauth" in r.cookies or any(
+        "projektplannerauth" in c for c in r.headers.get_list("set-cookie")
+    )
+    me = client.get("/users/me")
+    assert me.status_code == 200
+    assert me.json()["email"] == "u@example.com"
+
+
+def test_me_without_login_unauthorized(client):
+    assert client.get("/users/me").status_code == 401
+
+
+def test_login_wrong_password_rejected(client, session):
+    _make_user(session, "w@example.com", "correct-pw")
+    assert _login(client, "w@example.com", "wrong-pw").status_code == 400
+
+
+# ── invite management (admin only) ────────────────────────────────────────────
+
+def test_create_invite_requires_superuser(client, session):
+    _make_user(session, "plain@example.com", "pw12345678", superuser=False)
+    _login(client, "plain@example.com", "pw12345678")
+    assert client.post("/auth/invites", json={"expires_in_days": 7}).status_code == 403
+
+
+def test_create_invite_unauthenticated_rejected(client):
+    assert client.post("/auth/invites", json={"expires_in_days": 7}).status_code == 401
+
+
+def test_admin_can_create_and_list_invites(client, session):
+    _make_user(session, "admin@example.com", "pw12345678", superuser=True)
+    _login(client, "admin@example.com", "pw12345678")
+    created = client.post("/auth/invites", json={"expires_in_days": 7})
+    assert created.status_code == 201, created.text
+    token = created.json()["token"]
+    assert token
+
+    listed = client.get("/auth/invites")
+    assert listed.status_code == 200
+    assert any(t["token"] == token for t in listed.json())
+
+
+# ── admin bootstrap ───────────────────────────────────────────────────────────
+
+@pytest.fixture(name="boot_engine")
+def boot_engine_fixture(monkeypatch):
+    eng = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(eng)
+    monkeypatch.setattr(bootstrap, "engine", eng)
+    yield eng
+
+
+def test_seed_admin_noop_without_env(boot_engine, monkeypatch):
+    monkeypatch.setattr(bootstrap.settings, "admin_email", "")
+    monkeypatch.setattr(bootstrap.settings, "admin_password", "")
+    bootstrap.seed_admin_user()
+    with Session(boot_engine) as s:
+        assert s.exec(select(User)).first() is None
+
+
+def test_seed_admin_creates_superuser_once(boot_engine, monkeypatch):
+    monkeypatch.setattr(bootstrap.settings, "admin_email", "root@example.com")
+    monkeypatch.setattr(bootstrap.settings, "admin_password", "pw12345678")
+    bootstrap.seed_admin_user()
+    bootstrap.seed_admin_user()  # idempotent — must not create a second user
+    with Session(boot_engine) as s:
+        users = s.exec(select(User)).all()
+        assert len(users) == 1
+        assert users[0].is_superuser is True
+        assert users[0].email == "root@example.com"

--- a/backend/tests/unit/test_db_seeding.py
+++ b/backend/tests/unit/test_db_seeding.py
@@ -1,90 +1,80 @@
+"""Per-owner default-settings seeding (#42, doc 25 WP3 step 3b).
+
+Settings are per-owner now, so ``ensure_owner_settings`` seeds a given owner's
+defaults on demand (from an owner-bound session): it must be idempotent, must
+not overwrite existing values, must isolate owners, and must swallow the
+concurrent-insert race (two requests seeding a brand-new owner at once).
 """
-Unit tests for default-settings seeding (#42).
 
-seed_default_settings must be idempotent and multi-process safe: repeated
-startups add no duplicates, and a concurrent insert by another worker (which
-trips a UNIQUE constraint) must be swallowed instead of crashing startup.
-"""
+from sqlmodel import select
 
-import pytest
-from sqlmodel import Session, SQLModel, create_engine, select
-from sqlmodel.pool import StaticPool
-
-import app.db as db_module
-from app.db import seed_default_settings
+from app.db import DEFAULT_SETTINGS, ensure_owner_settings
 from app.models.setting import Setting
+from app.tenancy import bind_owner, bypass_owner_filter
 
 
-@pytest.fixture(name="seed_engine")
-def seed_engine_fixture(monkeypatch):
-    """Fresh in-memory engine wired into app.db so seeding targets it."""
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SQLModel.metadata.create_all(engine)
-    monkeypatch.setattr(db_module, "engine", engine)
-    yield engine
-    SQLModel.metadata.drop_all(engine)
+def _all_rows(session):
+    with bypass_owner_filter(session):
+        return session.exec(select(Setting)).all()
 
 
-def _all_settings(engine) -> list[Setting]:
-    with Session(engine) as session:
-        return list(session.exec(select(Setting)).all())
+def test_ensure_seeds_all_defaults_for_owner(session):
+    bind_owner(session, user_id=1)
+    ensure_owner_settings(session)
+
+    rows = {s.key: s.value for s in session.exec(select(Setting)).all()}
+    assert rows == DEFAULT_SETTINGS
+    assert all(s.owner_id == 1 for s in session.exec(select(Setting)).all())
 
 
-def test_seed_populates_all_defaults(seed_engine) -> None:
-    seed_default_settings()
+def test_ensure_is_idempotent(session):
+    bind_owner(session, user_id=1)
+    ensure_owner_settings(session)
+    ensure_owner_settings(session)
+    ensure_owner_settings(session)
 
-    rows = {s.key: s.value for s in _all_settings(seed_engine)}
-    assert rows == {
-        "default_vacation_days": "30",
-        "sick_days_per_year": "10",
-        "training_days_per_year": "5",
-        "holiday_country": "DE",
-        "holiday_state": "BY",
-        "holiday_extra": "",
-    }
+    assert len(session.exec(select(Setting)).all()) == len(DEFAULT_SETTINGS)
 
 
-def test_seed_is_idempotent_across_repeated_starts(seed_engine) -> None:
-    seed_default_settings()
-    seed_default_settings()
-    seed_default_settings()
+def test_ensure_does_not_overwrite_existing_values(session):
+    bind_owner(session, user_id=1)
+    session.add(Setting(key="default_vacation_days", value="42"))
+    session.commit()
 
-    assert len(_all_settings(seed_engine)) == 6
+    ensure_owner_settings(session)
 
-
-def test_seed_does_not_overwrite_existing_values(seed_engine) -> None:
-    with Session(seed_engine) as session:
-        session.add(Setting(key="default_vacation_days", value="42"))
-        session.commit()
-
-    seed_default_settings()
-
-    with Session(seed_engine) as session:
-        assert session.get(Setting, "default_vacation_days").value == "42"
+    row = session.exec(select(Setting).where(Setting.key == "default_vacation_days")).first()
+    assert row.value == "42"
+    assert len(session.exec(select(Setting)).all()) == len(DEFAULT_SETTINGS)
 
 
-def test_seed_swallows_concurrent_insert_race(seed_engine, monkeypatch) -> None:
-    """Simulate the worker race: rows already exist, but the pre-check reports
-    them missing (as it would on a truly empty DB seen by two workers at once),
-    forcing the INSERT path. The resulting IntegrityError must be swallowed."""
-    with Session(seed_engine) as session:
-        for key in ("default_vacation_days", "holiday_country"):
-            session.add(Setting(key=key, value="preexisting"))
-        session.commit()
+def test_ensure_seeds_each_owner_independently(session):
+    bind_owner(session, user_id=1)
+    ensure_owner_settings(session)
+    bind_owner(session, user_id=2)
+    ensure_owner_settings(session)
 
-    # Force every pre-check to miss, so seeding attempts the duplicate INSERTs.
-    monkeypatch.setattr(Session, "get", lambda *_a, **_k: None)
+    # Owner 2 sees only their own copy.
+    assert len(session.exec(select(Setting)).all()) == len(DEFAULT_SETTINGS)
+    all_rows = _all_rows(session)
+    assert len(all_rows) == 2 * len(DEFAULT_SETTINGS)
+    assert {s.owner_id for s in all_rows} == {1, 2}
 
-    # Must not raise despite the UNIQUE constraint collisions.
-    seed_default_settings()
 
-    # Pre-existing rows survive, all six keys are present exactly once.
-    rows = {s.key: s.value for s in _all_settings(seed_engine)}
-    assert len(rows) == 6
-    assert rows["default_vacation_days"] == "preexisting"
-    assert rows["holiday_country"] == "preexisting"
-    assert rows["holiday_extra"] == ""
+def test_ensure_swallows_concurrent_insert_race(session, monkeypatch):
+    """Rows already exist, but the existence pre-check is forced to miss (as it
+    would if two requests both saw an empty owner at once), so ensure retries the
+    INSERTs and trips the per-owner UNIQUE constraint — which must be swallowed."""
+    bind_owner(session, user_id=1)
+    ensure_owner_settings(session)  # 6 rows now exist for owner 1
+
+    class _Empty:
+        def all(self):
+            return []
+
+    monkeypatch.setattr(session, "exec", lambda *_a, **_k: _Empty())
+    ensure_owner_settings(session)  # must not raise despite UNIQUE collisions
+    monkeypatch.undo()
+
+    rows = {s.key: s.value for s in session.exec(select(Setting)).all()}
+    assert rows == DEFAULT_SETTINGS

--- a/backend/tests/unit/test_db_seeding.py
+++ b/backend/tests/unit/test_db_seeding.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for default-settings seeding (#42).
+
+seed_default_settings must be idempotent and multi-process safe: repeated
+startups add no duplicates, and a concurrent insert by another worker (which
+trips a UNIQUE constraint) must be swallowed instead of crashing startup.
+"""
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+import app.db as db_module
+from app.db import seed_default_settings
+from app.models.setting import Setting
+
+
+@pytest.fixture(name="seed_engine")
+def seed_engine_fixture(monkeypatch):
+    """Fresh in-memory engine wired into app.db so seeding targets it."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    monkeypatch.setattr(db_module, "engine", engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+def _all_settings(engine) -> list[Setting]:
+    with Session(engine) as session:
+        return list(session.exec(select(Setting)).all())
+
+
+def test_seed_populates_all_defaults(seed_engine) -> None:
+    seed_default_settings()
+
+    rows = {s.key: s.value for s in _all_settings(seed_engine)}
+    assert rows == {
+        "default_vacation_days": "30",
+        "sick_days_per_year": "10",
+        "training_days_per_year": "5",
+        "holiday_country": "DE",
+        "holiday_state": "BY",
+        "holiday_extra": "",
+    }
+
+
+def test_seed_is_idempotent_across_repeated_starts(seed_engine) -> None:
+    seed_default_settings()
+    seed_default_settings()
+    seed_default_settings()
+
+    assert len(_all_settings(seed_engine)) == 6
+
+
+def test_seed_does_not_overwrite_existing_values(seed_engine) -> None:
+    with Session(seed_engine) as session:
+        session.add(Setting(key="default_vacation_days", value="42"))
+        session.commit()
+
+    seed_default_settings()
+
+    with Session(seed_engine) as session:
+        assert session.get(Setting, "default_vacation_days").value == "42"
+
+
+def test_seed_swallows_concurrent_insert_race(seed_engine, monkeypatch) -> None:
+    """Simulate the worker race: rows already exist, but the pre-check reports
+    them missing (as it would on a truly empty DB seen by two workers at once),
+    forcing the INSERT path. The resulting IntegrityError must be swallowed."""
+    with Session(seed_engine) as session:
+        for key in ("default_vacation_days", "holiday_country"):
+            session.add(Setting(key=key, value="preexisting"))
+        session.commit()
+
+    # Force every pre-check to miss, so seeding attempts the duplicate INSERTs.
+    monkeypatch.setattr(Session, "get", lambda *_a, **_k: None)
+
+    # Must not raise despite the UNIQUE constraint collisions.
+    seed_default_settings()
+
+    # Pre-existing rows survive, all six keys are present exactly once.
+    rows = {s.key: s.value for s in _all_settings(seed_engine)}
+    assert len(rows) == 6
+    assert rows["default_vacation_days"] == "preexisting"
+    assert rows["holiday_country"] == "preexisting"
+    assert rows["holiday_extra"] == ""

--- a/backend/tests/unit/test_models_owner_tenancy.py
+++ b/backend/tests/unit/test_models_owner_tenancy.py
@@ -1,0 +1,138 @@
+"""Multi-user tenancy schema (doc 25, WP1).
+
+Verifies that ownable entities carry owner_id, that the four formerly-global
+unique fields are now unique PER OWNER (same value allowed across owners,
+rejected within one owner), and that reference/auth tables stay as designed.
+"""
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, SQLModel, create_engine, select
+from sqlmodel.pool import StaticPool
+
+from app.models.invite_token import InviteToken
+from app.models.person import Person
+from app.models.program import Program
+from app.models.project import Project
+from app.models.timebooking import SageProjectMapping
+from app.models.user import User
+
+OWNABLE_TABLES = [
+    "program", "project", "person", "vacation_contingent", "person_absence",
+    "billing_position", "project_membership", "milestone", "milestone_person_budget",
+    "monthly_invoice", "invoice_person_entry", "import_batch",
+    "sage_project_mapping", "sage_position_mapping", "time_booking",
+]
+NON_OWNABLE_TABLES = ["holiday", "user", "invite_token"]
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+# ── owner_id presence ─────────────────────────────────────────────────────────
+
+def test_ownable_tables_have_owner_id(engine):
+    insp = inspect(engine)
+    for table in OWNABLE_TABLES:
+        cols = {c["name"] for c in insp.get_columns(table)}
+        assert "owner_id" in cols, f"{table} must carry owner_id"
+
+
+def test_reference_and_auth_tables_have_no_owner_id(engine):
+    insp = inspect(engine)
+    for table in NON_OWNABLE_TABLES:
+        cols = {c["name"] for c in insp.get_columns(table)}
+        assert "owner_id" not in cols, f"{table} must NOT carry owner_id"
+
+
+# ── per-owner uniqueness ────────────────────────────────────────────────────────
+
+def _two_owners(session: Session) -> tuple[int, int]:
+    a = User(email="a@example.com", hashed_password="x")
+    b = User(email="b@example.com", hashed_password="x")
+    session.add(a)
+    session.add(b)
+    session.commit()
+    return a.id, b.id  # type: ignore[return-value]
+
+
+def test_program_number_unique_per_owner_not_globally(engine):
+    with Session(engine) as session:
+        o1, o2 = _two_owners(session)
+        session.add(Program(owner_id=o1, program_number="P1", name="A", customer="C"))
+        session.add(Program(owner_id=o2, program_number="P1", name="B", customer="C"))
+        session.commit()  # same number, different owners → allowed
+        assert len(session.exec(select(Program)).all()) == 2
+
+        session.add(Program(owner_id=o1, program_number="P1", name="dup", customer="C"))
+        with pytest.raises(IntegrityError):
+            session.commit()  # same number, same owner → rejected
+
+
+def test_project_number_unique_per_owner_not_globally(engine):
+    with Session(engine) as session:
+        o1, o2 = _two_owners(session)
+        from datetime import date
+        common = dict(name="X", start_date=date(2026, 1, 1), end_date=date(2026, 12, 31), total_budget_euros=1000.0)
+        session.add(Project(owner_id=o1, project_number="PR1", **common))
+        session.add(Project(owner_id=o2, project_number="PR1", **common))
+        session.commit()
+        assert len(session.exec(select(Project)).all()) == 2
+
+        session.add(Project(owner_id=o1, project_number="PR1", **common))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_person_sage_name_unique_per_owner_not_globally(engine):
+    with Session(engine) as session:
+        o1, o2 = _two_owners(session)
+        session.add(Person(owner_id=o1, name="A", sage_employee_name="Meier", default_weekly_hours=40))
+        session.add(Person(owner_id=o2, name="B", sage_employee_name="Meier", default_weekly_hours=40))
+        session.commit()
+        assert len(session.exec(select(Person)).all()) == 2
+
+        session.add(Person(owner_id=o1, name="C", sage_employee_name="Meier", default_weekly_hours=40))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_sage_project_mapping_name_unique_per_owner_not_globally(engine):
+    with Session(engine) as session:
+        o1, o2 = _two_owners(session)
+        session.add(SageProjectMapping(owner_id=o1, sage_project_name="Sage-A", project_id=1))
+        session.add(SageProjectMapping(owner_id=o2, sage_project_name="Sage-A", project_id=1))
+        session.commit()
+        assert len(session.exec(select(SageProjectMapping)).all()) == 2
+
+        session.add(SageProjectMapping(owner_id=o1, sage_project_name="Sage-A", project_id=1))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+# ── auth tables ─────────────────────────────────────────────────────────────────
+
+def test_user_email_unique(engine):
+    with Session(engine) as session:
+        session.add(User(email="dup@example.com", hashed_password="x"))
+        session.commit()
+        session.add(User(email="dup@example.com", hashed_password="y"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_invite_token_unique(engine):
+    with Session(engine) as session:
+        session.add(InviteToken(token="abc"))
+        session.commit()
+        session.add(InviteToken(token="abc"))
+        with pytest.raises(IntegrityError):
+            session.commit()

--- a/backend/tests/unit/test_password_policy.py
+++ b/backend/tests/unit/test_password_policy.py
@@ -1,0 +1,29 @@
+"""Unit tests for the shared password policy (#53)."""
+
+from app.auth.password_policy import PASSWORD_MIN_LENGTH, is_password_valid, password_problems
+
+
+def test_strong_password_has_no_problems():
+    assert password_problems("Pw123456789!") == []
+    assert is_password_valid("Pw123456789!") is True
+
+
+def test_too_short_is_flagged():
+    problems = password_problems("Aa1!")
+    assert any("Zeichen" in p for p in problems)
+    assert is_password_valid("Aa1!") is False
+
+
+def test_missing_classes_are_flagged():
+    # long but only lowercase letters → missing upper, digit, special
+    problems = password_problems("abcdefghijklmnop")
+    assert any("Groß- und Kleinbuchstaben" in p for p in problems)
+    assert any("Ziffer" in p for p in problems)
+    assert any("Sonderzeichen" in p for p in problems)
+
+
+def test_min_length_boundary():
+    just_short = "Aa1!" + "x" * (PASSWORD_MIN_LENGTH - 5)
+    just_right = "Aa1!" + "x" * (PASSWORD_MIN_LENGTH - 4)
+    assert is_password_valid(just_short) is False
+    assert is_password_valid(just_right) is True

--- a/backend/tests/unit/test_routers_settings.py
+++ b/backend/tests/unit/test_routers_settings.py
@@ -74,12 +74,13 @@ def test_update_setting_not_found(client):
 
 
 # ---------------------------------------------------------------------------
-# GET /settings/database-path
+# GET /settings/database-path — admin-only (#53)
 # ---------------------------------------------------------------------------
 
 
-def test_get_database_path_returns_info(client):
-    r = client.get("/settings/database-path")
+def test_get_database_path_returns_info(client_for):
+    admin = client_for(is_superuser=True)
+    r = admin.get("/settings/database-path")
     assert r.status_code == 200
     data = r.json()
     assert "path" in data
@@ -88,17 +89,26 @@ def test_get_database_path_returns_info(client):
     assert isinstance(data["cloud_warning"], bool)
 
 
-def test_get_database_path_url_is_sqlite(client):
-    r = client.get("/settings/database-path")
+def test_get_database_path_url_is_sqlite(client_for):
+    admin = client_for(is_superuser=True)
+    r = admin.get("/settings/database-path")
     assert r.json()["url"].startswith("sqlite:///")
 
 
+def test_database_path_forbidden_for_non_admin(client_for):
+    """A regular (non-admin) user must not reach the instance-wide DB-path routes."""
+    member = client_for(is_superuser=False)
+    assert member.get("/settings/database-path").status_code == 403
+    assert member.put("/settings/database-path", json={"directory": "/tmp/x"}).status_code == 403
+
+
 # ---------------------------------------------------------------------------
-# PUT /settings/database-path
+# PUT /settings/database-path — admin-only (#53)
 # ---------------------------------------------------------------------------
 
 
-def test_set_database_path_copies_and_updates(client, tmp_path):
+def test_set_database_path_copies_and_updates(client_for, tmp_path):
+    admin = client_for(is_superuser=True)
     # Create a fake source DB file so shutil.copy2 has something to copy
     fake_db = tmp_path / "source" / "projektplanner.db"
     fake_db.parent.mkdir()
@@ -111,7 +121,7 @@ def test_set_database_path_copies_and_updates(client, tmp_path):
         patch("app.services.db_management._CONFIG_FILE", config_file),
         patch("app.services.db_management._live_db_path", return_value=fake_db),
     ):
-        r = client.put("/settings/database-path", json={"directory": str(target_dir)})
+        r = admin.put("/settings/database-path", json={"directory": str(target_dir)})
 
     assert r.status_code == 200
     data = r.json()
@@ -123,12 +133,14 @@ def test_set_database_path_copies_and_updates(client, tmp_path):
     assert "database_url" in cfg
 
 
-def test_set_database_path_empty_dir_returns_422(client):
-    r = client.put("/settings/database-path", json={"directory": "   "})
+def test_set_database_path_empty_dir_returns_422(client_for):
+    admin = client_for(is_superuser=True)
+    r = admin.put("/settings/database-path", json={"directory": "   "})
     assert r.status_code == 422
 
 
-def test_set_database_path_same_dir_returns_422(client, tmp_path):
+def test_set_database_path_same_dir_returns_422(client_for, tmp_path):
+    admin = client_for(is_superuser=True)
     fake_db = tmp_path / "projektplanner.db"
     fake_db.write_bytes(b"SQLite format 3\x00")
     config_file = tmp_path / "data_config.json"
@@ -137,12 +149,13 @@ def test_set_database_path_same_dir_returns_422(client, tmp_path):
         patch("app.services.db_management._CONFIG_FILE", config_file),
         patch("app.services.db_management._live_db_path", return_value=fake_db),
     ):
-        r = client.put("/settings/database-path", json={"directory": str(tmp_path)})
+        r = admin.put("/settings/database-path", json={"directory": str(tmp_path)})
 
     assert r.status_code == 422
 
 
-def test_set_database_path_cloud_warning(client, tmp_path):
+def test_set_database_path_cloud_warning(client_for, tmp_path):
+    admin = client_for(is_superuser=True)
     fake_db = tmp_path / "projektplanner.db"
     fake_db.write_bytes(b"SQLite format 3\x00")
     config_file = tmp_path / "data_config.json"
@@ -152,7 +165,7 @@ def test_set_database_path_cloud_warning(client, tmp_path):
         patch("app.services.db_management._CONFIG_FILE", config_file),
         patch("app.services.db_management._live_db_path", return_value=fake_db),
     ):
-        r = client.put("/settings/database-path", json={"directory": str(onedrive_dir)})
+        r = admin.put("/settings/database-path", json={"directory": str(onedrive_dir)})
 
     assert r.status_code == 200
     assert r.json()["cloud_warning"] is True

--- a/backend/tests/unit/test_tenancy.py
+++ b/backend/tests/unit/test_tenancy.py
@@ -116,3 +116,19 @@ def test_superuser_sees_all_owners(client_for):
 
     numbers = {p["program_number"] for p in admin.get("/programs").json()}
     assert numbers == {"A-1", "B-1"}
+
+
+# ── per-owner settings (step 3b) ──────────────────────────────────────────────
+
+def test_settings_are_per_owner(client_for):
+    alice = client_for(user_id=1)
+    bob = client_for(user_id=2)
+
+    # First GET seeds each owner's own copy of the defaults.
+    assert alice.get("/settings").json()["default_vacation_days"] == "30"
+    assert bob.get("/settings").json()["default_vacation_days"] == "30"
+
+    # Alice changes hers; Bob's copy is untouched.
+    assert alice.put("/settings/default_vacation_days", json={"value": "25"}).status_code == 200
+    assert alice.get("/settings").json()["default_vacation_days"] == "25"
+    assert bob.get("/settings").json()["default_vacation_days"] == "30"

--- a/backend/tests/unit/test_tenancy.py
+++ b/backend/tests/unit/test_tenancy.py
@@ -1,0 +1,118 @@
+"""Owner-based multi-user isolation (doc 25, WP3).
+
+Exercises the central filter end-to-end via the API: every CRUD router is
+auth-guarded, reads are scoped to the caller's owner, inserts are stamped,
+owner_id is not client-editable, per-owner uniqueness holds, and superusers
+bypass the filter. The `client_for` factory builds clients acting as different
+owners against one shared in-memory database, so cross-owner leakage is
+directly observable.
+"""
+
+from fastapi.testclient import TestClient
+from sqlmodel import select
+
+from app.db import get_session
+from app.main import app
+from app.models.program import Program
+from app.tenancy import bypass_owner_filter
+
+
+def _program(number: str, name: str = "Prog", customer: str = "ACME") -> dict:
+    return {"program_number": number, "name": name, "customer": customer}
+
+
+# ── auth guard ────────────────────────────────────────────────────────────────
+
+def test_crud_routers_require_authentication(session):
+    """Without an authenticated user, an owned-resource router returns 401."""
+    def override_get_session():
+        yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    try:
+        with TestClient(app) as c:
+            assert c.get("/programs").status_code == 401
+            assert c.post("/programs", json=_program("P1")).status_code == 401
+            assert c.get("/projects").status_code == 401
+            assert c.get("/persons").status_code == 401
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── read isolation ──────────────────────────────────────────────────────────
+
+def test_owner_only_sees_own_rows(client_for):
+    alice = client_for(user_id=1)
+    bob = client_for(user_id=2)
+
+    created = alice.post("/programs", json=_program("A-1")).json()
+    assert alice.get("/programs").json()  # alice sees her program
+    assert len(alice.get("/programs").json()) == 1
+
+    # Bob sees nothing of Alice's — neither in the list nor by direct id.
+    assert bob.get("/programs").json() == []
+    assert bob.get(f"/programs/{created['id']}").status_code == 404
+
+
+def test_insert_is_stamped_with_caller_owner(client_for, session):
+    alice = client_for(user_id=1)
+    bob = client_for(user_id=2)
+    a = alice.post("/programs", json=_program("A-1")).json()
+    b = bob.post("/programs", json=_program("B-1")).json()
+
+    with bypass_owner_filter(session):
+        by_id = {p.id: p for p in session.exec(select(Program)).all()}
+    assert by_id[a["id"]].owner_id == 1
+    assert by_id[b["id"]].owner_id == 2
+
+
+def test_client_cannot_smuggle_owner_id_on_create(client_for, session):
+    """A payload-supplied owner_id is ignored — the caller is always the owner."""
+    alice = client_for(user_id=1)
+    created = alice.post("/programs", json={**_program("A-1"), "owner_id": 999}).json()
+    with bypass_owner_filter(session):
+        row = session.get(Program, created["id"])
+    assert row.owner_id == 1
+
+
+def test_owner_id_not_editable_via_update(client_for, session):
+    alice = client_for(user_id=1)
+    created = alice.post("/programs", json=_program("A-1")).json()
+
+    # Try to hand the row to owner 2 via the update body.
+    r = alice.put(f"/programs/{created['id']}", json={**_program("A-1", name="Renamed"), "owner_id": 2})
+    assert r.status_code == 200
+    assert r.json()["name"] == "Renamed"  # the legit change stuck
+    assert r.json()["owner_id"] == 1      # ownership did not
+
+    with bypass_owner_filter(session):
+        assert session.get(Program, created["id"]).owner_id == 1
+    # Still visible to its real owner.
+    assert alice.get(f"/programs/{created['id']}").status_code == 200
+
+
+# ── per-owner uniqueness ──────────────────────────────────────────────────────
+
+def test_same_number_allowed_across_owners_but_not_within(client_for):
+    alice = client_for(user_id=1)
+    bob = client_for(user_id=2)
+
+    assert alice.post("/programs", json=_program("SHARED")).status_code == 201
+    # Different owner, same number → fine (isolation, no leak of existence).
+    assert bob.post("/programs", json=_program("SHARED")).status_code == 201
+    # Same owner, same number → rejected.
+    assert alice.post("/programs", json=_program("SHARED")).status_code == 409
+
+
+# ── superuser bypass ──────────────────────────────────────────────────────────
+
+def test_superuser_sees_all_owners(client_for):
+    alice = client_for(user_id=1)
+    bob = client_for(user_id=2)
+    admin = client_for(user_id=99, is_superuser=True)
+
+    alice.post("/programs", json=_program("A-1"))
+    bob.post("/programs", json=_program("B-1"))
+
+    numbers = {p["program_number"] for p in admin.get("/programs").json()}
+    assert numbers == {"A-1", "B-1"}

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -53,12 +53,206 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
@@ -167,6 +361,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -254,6 +498,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/79/66567c39c5fab6dbebf9e40b3a3fcb0e2ec359517c87a67434c76b06e60b/fastapi_cloud_cli-0.17.0.tar.gz", hash = "sha256:2b6c241b63427023bd1e23b3251f23234aba4b05428b245a050e92db1389823c", size = 47276, upload-time = "2026-04-15T13:17:56.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/31/fa442466bacadffec3d6611509d6ea391b6ca01b6ee0d4af835bfdea3483/fastapi_cloud_cli-0.17.0-py3-none-any.whl", hash = "sha256:b496e6998f037f572ab06a233ce257828b4c701488ce500b5c9d725e970a7cb1", size = 33936, upload-time = "2026-04-15T13:17:55.112Z" },
+]
+
+[[package]]
+name = "fastapi-users"
+version = "15.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "email-validator" },
+    { name = "fastapi" },
+    { name = "makefun" },
+    { name = "pwdlib", extra = ["argon2", "bcrypt"] },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/79/98b9d733274cfe0c776fde637dc53b421a0142f51a9e3e9fecd72741f7c1/fastapi_users-15.0.5.tar.gz", hash = "sha256:097f69701894e650c346df89b1cdb0a09cf139234f4cb9a8ece275af4e98e202", size = 121394, upload-time = "2026-03-27T09:01:17.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/8e/1ed6bbe36c486b98217c4be6769d61fcb98c38b334fb39706de661a905b6/fastapi_users-15.0.5-py3-none-any.whl", hash = "sha256:10fd4f3e85ed66f694a6ca2ecac609af4e59d1f9ec64d1557f5912dccfd87c7f", size = 39038, upload-time = "2026-03-27T09:01:16.158Z" },
 ]
 
 [[package]]
@@ -540,6 +801,15 @@ wheels = [
 ]
 
 [[package]]
+name = "makefun"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -703,6 +973,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "fastapi-users" },
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -723,6 +994,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115" },
+    { name = "fastapi-users", specifier = ">=15.0.5" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -737,6 +1009,32 @@ dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=6.0" },
+]
+
+[[package]]
+name = "pwdlib"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/41/a7c0d8a003c36ce3828ae3ed0391fe6a15aad65f082dbd6bec817ea95c0b/pwdlib-0.3.0.tar.gz", hash = "sha256:6ca30f9642a1467d4f5d0a4d18619de1c77f17dfccb42dd200b144127d3c83fc", size = 215810, upload-time = "2025-10-25T12:44:24.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/0c/9086a357d02a050fbb3270bf5043ac284dbfb845670e16c9389a41defc9e/pwdlib-0.3.0-py3-none-any.whl", hash = "sha256:f86c15c138858c09f3bba0a10984d4f9178158c55deaa72eac0210849b1a140d", size = 8633, upload-time = "2025-10-25T12:44:23.406Z" },
+]
+
+[package.optional-dependencies]
+argon2 = [
+    { name = "argon2-cffi" },
+]
+bcrypt = [
+    { name = "bcrypt" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -868,6 +1166,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]

--- a/deploy/server-secrets.env.example
+++ b/deploy/server-secrets.env.example
@@ -1,0 +1,28 @@
+# Server-side secrets for docker-compose.server.yml (NOT in the repo/image).
+#
+# Copy this to the host secrets dir and fill in real values BEFORE the first
+# `docker compose -f docker-compose.server.yml up`:
+#
+#   cp deploy/server-secrets.env.example /home/sfalkner/pp-secrets/server.env
+#   # then edit /home/sfalkner/pp-secrets/server.env and set real values
+#
+# The compose file loads this via `env_file`, so it survives code redeploys and
+# never lands in git or the image. Keep file perms tight (chmod 600).
+
+# ── First-admin bootstrap (#53) ───────────────────────────────────────────────
+# On the VERY FIRST start with an empty DB, the backend creates EXACTLY ONE
+# superuser from these values. This is the only entry point — registration is
+# invite-only and invites are minted by an admin. Idempotent: once any user
+# exists these are ignored, so they may be rotated/removed afterwards.
+# NOTE: the bootstrap bypasses the password policy — still choose a strong one.
+ADMIN_EMAIL=admin@infoteam.de
+ADMIN_PASSWORD=set-a-strong-password-here
+
+# ── Session signing key (REQUIRED in production) ──────────────────────────────
+# Signs the session JWT. MUST be a long random value — NEVER the dev default.
+# Generate one with:  openssl rand -hex 32
+AUTH_SECRET=generate-with-openssl-rand-hex-32
+
+# ── Optional: restrict self-registration to these e-mail domains ──────────────
+# Comma-separated, empty = any domain allowed. Does not affect the bootstrap admin.
+AUTH_ALLOWED_EMAIL_DOMAINS=infoteam.de

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,8 +23,10 @@ services:
     volumes:
       - backend_data:/app/data
     # Apply migrations before serving so schema changes land on deploy.
-    # Single worker: internal low-traffic app + the startup default-seeding isn't yet
-    # safe under concurrent workers (see follow-up). 1 worker = deterministic startup.
+    # Startup default-seeding is now idempotent/multi-process safe (#42), so >1
+    # worker no longer crashes on first start. We still keep 1 worker on purpose:
+    # this is an internal low-traffic app on SQLite, where a single writer avoids
+    # lock contention. Bump only if load actually warrants it.
     command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1"
     expose:
       - "8000"

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -9,17 +9,28 @@
 # Host-side secrets (NOT in the repo), created once at /home/sfalkner/pp-secrets:
 #   cert.pem, key.pem   — TLS certificate + key (self-signed or internal CA)
 #   htpasswd            — login credentials (create with `htpasswd`, password is yours)
+#   server.env          — app secrets: first-admin bootstrap + AUTH_SECRET
+#                         (copy from deploy/server-secrets.env.example, then edit)
 services:
   backend:
     build:
       context: ./backend
       target: prod
     restart: unless-stopped
+    # App secrets (first-admin bootstrap, AUTH_SECRET, domain allowlist). Absolute
+    # host path so it lives with the other secrets and survives redeploys. Compose
+    # errors if the file is missing → you cannot deploy without deciding the admin
+    # credentials (better than a silent invite-only lockout on an empty DB).
+    env_file:
+      - /home/sfalkner/pp-secrets/server.env
     environment:
       - DATABASE_URL=sqlite:///./data/projektplanner.db
       - DEFAULT_HOLIDAY_COUNTRY=DE
       - DEFAULT_HOLIDAY_STATE=BY
       - DEBUG=false
+      # Behind the TLS-terminating proxy (all traffic is forced to HTTPS), so the
+      # session cookie is marked Secure. Not a secret → kept inline.
+      - AUTH_COOKIE_SECURE=true
     volumes:
       - backend_data:/app/data
     command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1"

--- a/docs/implementation/25-multi-user-tenancy.md
+++ b/docs/implementation/25-multi-user-tenancy.md
@@ -117,7 +117,7 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 | WP | Inhalt | Kern-Artefakte |
 |---|---|---|
 | **WP1** ✅ | Datenmodell: `user`, `invite_token`; `owner_id` auf besitzbaren Entitäten; Unique-Constraints pro Owner; Referenzdaten-Grenze fixieren; Alembic-Migration (frische DB) | `models/*`, Alembic |
-| **WP2** | Auth-Backend: `fastapi-users`, Session-Cookie, Invite-Token-Flow, Admin-Flag | `routers/auth.py`, `main.py` |
+| **WP2** ✅ | Auth-Backend: `fastapi-users`, Session-Cookie, Invite-Token-Flow, Admin-Flag | `routers/auth.py`, `main.py` |
 | **WP3** | Zentraler Owner-Filter (ContextVar + `do_orm_execute`), Auto-Set von `owner_id` beim Insert; Admin-Bypass | `db.py` |
 | **WP4** | Frontend: Login/Registrierung (Invite), Auth-Guard/Redirect, Logout, Account-Menü | `frontend/` |
 | **WP5** | Datenexport/-löschung pro User; DSGVO-Export pro `Person` (separat) | `routers/account.py`, `frontend/` |
@@ -131,6 +131,16 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 - **App-Level-Duplikatprüfung** in den vier CRUD-Routern (create+update) statt Verlass auf den DB-Constraint — verhält sich in WP1 (owner NULL) korrekt und wird in WP3 automatisch owner-gescoped.
 - **Alembic** `e7a1c9d2f3b4` (batch-Mode, Guards, Up-/Downgrade gegen Wegwerf-DB validiert). Prod baut per `alembic upgrade head`, daher vollständige Migration.
 - **Tests:** `tests/unit/test_models_owner_tenancy.py` (owner_id-Präsenz, Per-Owner-Eindeutigkeit, Auth-Tabellen). Suite: 554 grün.
+
+### Umsetzungsstand WP2 (auf `dev`)
+- **Bibliothek:** `fastapi-users` 15 (pwdlib argon2/bcrypt, pyjwt). Neue Dependency in `pyproject.toml`.
+- **Sync-Adapter:** `app/auth/user_db.py` implementiert die `BaseUserDatabase` synchron auf der bestehenden sync-`Session` — vermeidet eine zweite async-Engine (aiosqlite) auf derselben SQLite-Datei (Locking-Risiko). Methoden sind `async def`, führen aber sync-Queries aus (für diese Last unkritisch).
+- **Transport/Strategy:** httpOnly-**Session-Cookie** (`projektplannerauth`, secure/samesite konfigurierbar) mit **JWT** (HS256, 12 h, kein Refresh). Logout löscht das Cookie; das kurzlebige JWT läuft dann aus. Bewusst gewählt statt DB-Sessions (keine Extra-Tabelle) und statt Bearer/localStorage (XSS-sicher).
+- **Registrierungs-Gate:** `UserManager.create` validiert & verbraucht das Einmal-Invite-Token (`app/auth/manager.py`), erst nach erfolgreicher Erstellung wird es als benutzt markiert. Selbst-Registrierung kann sich **nicht** zum Admin machen (`safe=True`).
+- **Admin:** `is_superuser`. Invite-Verwaltung nur für Admins (`POST/GET /auth/invites`). **First-Admin-Bootstrap** (`app/auth/bootstrap.py`): via `ADMIN_EMAIL`/`ADMIN_PASSWORD` bei leerer User-Tabelle beim Start — löst die Henne-Ei-Situation.
+- **Routen:** `routers/auth.py` mountet `POST /auth/register`, `POST /auth/login`, `POST /auth/logout`, `GET/PATCH /users/me`, `GET/…/users/{id}`, plus `/auth/invites`. Passwort-Reset/Verify-Router bewusst noch weggelassen (Admin-gestützter Reset später).
+- **Noch nicht:** Der Owner-Filter greift erst in **WP3** — die CRUD-Endpunkte sind aktuell noch nicht auth-geschützt/gefiltert. Config: `AUTH_SECRET` (in Prod setzen!), Cookie-/Session-Flags, Admin-Bootstrap in `.env.example`.
+- **Tests:** `tests/unit/test_auth.py` (Invite-Gate, Login/Session, /users/me, Admin-only Invites, Bootstrap-Idempotenz). Suite: 567 grün, Coverage 91%.
 
 ---
 

--- a/docs/implementation/25-multi-user-tenancy.md
+++ b/docs/implementation/25-multi-user-tenancy.md
@@ -119,7 +119,7 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 | **WP1** ✅ | Datenmodell: `user`, `invite_token`; `owner_id` auf besitzbaren Entitäten; Unique-Constraints pro Owner; Referenzdaten-Grenze fixieren; Alembic-Migration (frische DB) | `models/*`, Alembic |
 | **WP2** ✅ | Auth-Backend: `fastapi-users`, Session-Cookie, Invite-Token-Flow, Admin-Flag | `routers/auth.py`, `main.py` |
 | **WP3** ✅ | Zentraler Owner-Filter (`session.info` + `do_orm_execute`), Auto-Set von `owner_id` beim Insert, Auth-Schutz aller CRUD-Router, `Setting` pro Owner; Admin-Bypass | `tenancy.py`, `auth/deps.py`, `routers/*` |
-| **WP4** | Frontend: Login/Registrierung (Invite), Auth-Guard/Redirect, Logout, Account-Menü | `frontend/` |
+| **WP4** ✅ | Frontend: Login/Registrierung (Invite), Auth-Guard/Redirect, Logout, Account-Menü, Admin-Invite-Verwaltung | `frontend/src/auth/*`, `frontend/src/pages/{Login,Register,Invites}Page.tsx`, `api.ts`, `App.tsx` |
 | **WP5** | Datenexport/-löschung pro User; DSGVO-Export pro `Person` (separat) | `routers/account.py`, `frontend/` |
 | **WP6** | Deployment: verschlüsseltes Volume + verschlüsselte Backups; Proxy-Basic-Auth durch App-Login ersetzen | `docker-compose.server.yml`, `deploy/` |
 | **später** | Übergang Modell A: Teams/Rollen/Sichtbarkeit als ACL-Schicht über `owner_id` (Filter aufweichen) | — |
@@ -153,6 +153,15 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 - **Tests:** `tests/unit/test_tenancy.py` (Auth-Pflicht, Lese-Isolation, Auto-Stempel, owner_id nicht schmuggel-/änderbar, per-Owner-Eindeutigkeit, Admin-Bypass, Settings pro Owner), `test_db_seeding.py` neu auf per-Owner. `conftest`: `client` (Owner 1), `client_for` (header-getaggte Mehr-Owner-Clients gegen eine DB). Suite: 576 grün, Coverage 91%.
 - **Noch offen (WP4+):** Frontend hat noch keinen Login/Guard; `owner_id` bleibt nullable (spätere NOT-NULL-Verschärfung möglich); `AUTH_SECRET` vor Prod setzen.
 
+### Umsetzungsstand WP4 (auf `dev`)
+- **Auth-State im Client:** `frontend/src/auth/AuthContext.tsx` bootstrappt den User einmal aus `GET /users/me` (httpOnly-Cookie, der Client sieht nie ein Token). Ein globales `auth:unauthorized`-Event (im API-Layer bei **jedem** 401 gefeuert, außer beim Bootstrap-`me()`) setzt den User zurück → der Guard leitet bei abgelaufener Session zur Anmeldung.
+- **Guards:** `RequireAuth` (Spinner während Bootstrap, sonst Redirect nach `/login` mit gemerktem Ziel) und `RequireAdmin` (Superuser-only, sonst zurück auf `/calendar`). Öffentliche Routen `/login` und `/register` liegen außerhalb des Guards; die gesamte App-Shell dahinter.
+- **Login/Registrierung:** `LoginPage` (form-kodierter OAuth2-Login, dann `refresh()` + Redirect aufs Ziel), `RegisterPage` (E-Mail/Passwort/Invite-Token; nach Erfolg direkt Auto-Login, da `register` keine Session öffnet; Backend-400 → sprechende deutsche Meldungen für ungültiges/verbrauchtes/abgelaufenes Token, schwaches Passwort, Dublette).
+- **Account-Menü** in der Sidebar: E-Mail, Administrator-Badge (nur Superuser), Abmelden. **Einladungen-Nav + `InvitesPage`** nur für Admins (Token erzeugen, Liste mit Status offen/verwendet/abgelaufen, Copy-to-Clipboard).
+- **API-Layer** (`api.ts`): neuer `auth`-Namespace (`me/login/logout/register/invites`); `me()` nutzt bare-fetch (401 = ausgeloggt, kein Event); alle anderen 401 → `AUTH_UNAUTHORIZED_EVENT`.
+- **Tests:** `frontend/src/auth/__tests__/auth.test.tsx` (API-Formkodierung, `me()`-401-ohne-Event, Auth-/Admin-Guard-Redirects, Login-Erfolg/Fehlbedienung, Session-Ablauf per Event). Suite: **36 grün**. Browser-verifiziert: Guard-Redirect, echter UI-Login mit Ziel-Redirect, Admin-Token → Registrierung → Auto-Login als Nicht-Admin, Nicht-Admin von `/invites` abgewiesen, Logout.
+- **Noch offen (WP5+):** Datenexport/-löschung im Account-Menü; Passwort-Reset-UI; ggf. „Angemeldet bleiben".
+
 ---
 
 ## 8. Offene Punkte für die Umsetzungsphase
@@ -161,3 +170,4 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 - ~~`owner_id` ist in WP1 **nullable**; WP3 setzt es beim Insert automatisch und erzwingt den Filter.~~ **Umgesetzt (WP3):** Auto-Set + zentraler Filter aktiv. `owner_id` bleibt vorerst nullable; eine spätere Migration kann auf NOT NULL verschärfen, sobald jede Zeile nachweislich einen Owner hat.
 - Invite-Token: Ablaufzeit, Mehrfach-Kontingent (1 Token = 1 Account) — Default: einmalig, mit Ablauf (WP2).
 - Passwort-Policy / Reset-Weg ohne SMTP (Admin-gestützter Reset?) (WP2).
+- **Bestehende Dev-DBs migrieren (bei WP4-Browserverifikation entdeckt):** Der Startup nutzt `create_db_and_tables()` (`create_all`) — legt **neue Tabellen** an (`user`, `invite_token`), ergänzt aber **keine Spalten** auf bestehenden Tabellen. Eine Dev-DB, die vor WP1 angelegt wurde (Alembic-Stand vor `e7a1c9d2f3b4`), hat daher **kein `owner_id`** → für Nicht-Admins schlägt jede gefilterte Query fehl (500), Superuser (Bypass) merken es nicht. Fix: `alembic upgrade head` auf die Dev-DB (bzw. frische DB, da die gehostete Instanz ohnehin leer startet, §1). Prod ist nicht betroffen (baut per `alembic upgrade head`).

--- a/docs/implementation/25-multi-user-tenancy.md
+++ b/docs/implementation/25-multi-user-tenancy.md
@@ -84,7 +84,7 @@ Diese Constraints sind heute **global** und würden Isolation brechen (User2 kö
 
 **Bleibt global** (Referenzdatum, kein Nutzerbesitz): `Holiday` `(holiday_date, country, state)` (`models/holiday.py:20`).
 
-**`Setting`:** Zielbild ist **pro Owner** (Nutzerentscheidung 2026-07-22). In **WP1 bleibt `setting` global**, weil „Defaults pro Account seeden" einen User-Kontext braucht, den es erst mit Auth (WP2) gibt — und das idempotente Seeding (#42) an `session.get(Setting, key)` hängt. Die Umstellung `Setting`-PK → `(owner_id, key)` + per-Account-Seeding erfolgt in **WP3** zusammen mit dem Auto-Set/Filter.
+**`Setting`:** **pro Owner** (Nutzerentscheidung 2026-07-22) — umgesetzt in **WP3 (Schritt 3b)**: Surrogat-`id`-PK + `owner_id` + `UNIQUE(owner_id, key)` (eine `(owner_id, key)`-Composite-PK scheidet aus, da `owner_id` nullable). Kein globales Startup-Seeding mehr; `db.ensure_owner_settings` seedet die Defaults pro Owner beim ersten Zugriff (owner-gescoped + `before_flush`-Stempel, race-safe). Die Lesepfade (milestones/persons/holiday_region) fallen bei fehlendem Key auf dieselben Defaults zurück, daher Verhalten vor/nach Seeding identisch.
 
 Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — auf `project_id`/`person_id` gekeyt) sind bereits über ihren Eltern-Owner geschützt und brauchen i. d. R. **keinen** eigenen `owner_id`, solange der Filter über den Join greift. Ob `owner_id` dennoch denormalisiert wird (einfacherer Filter, mehr Speicher), ist eine WP1-Abwägung.
 
@@ -118,7 +118,7 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 |---|---|---|
 | **WP1** ✅ | Datenmodell: `user`, `invite_token`; `owner_id` auf besitzbaren Entitäten; Unique-Constraints pro Owner; Referenzdaten-Grenze fixieren; Alembic-Migration (frische DB) | `models/*`, Alembic |
 | **WP2** ✅ | Auth-Backend: `fastapi-users`, Session-Cookie, Invite-Token-Flow, Admin-Flag | `routers/auth.py`, `main.py` |
-| **WP3** | Zentraler Owner-Filter (ContextVar + `do_orm_execute`), Auto-Set von `owner_id` beim Insert; Admin-Bypass | `db.py` |
+| **WP3** ✅ | Zentraler Owner-Filter (`session.info` + `do_orm_execute`), Auto-Set von `owner_id` beim Insert, Auth-Schutz aller CRUD-Router, `Setting` pro Owner; Admin-Bypass | `tenancy.py`, `auth/deps.py`, `routers/*` |
 | **WP4** | Frontend: Login/Registrierung (Invite), Auth-Guard/Redirect, Logout, Account-Menü | `frontend/` |
 | **WP5** | Datenexport/-löschung pro User; DSGVO-Export pro `Person` (separat) | `routers/account.py`, `frontend/` |
 | **WP6** | Deployment: verschlüsseltes Volume + verschlüsselte Backups; Proxy-Basic-Auth durch App-Login ersetzen | `docker-compose.server.yml`, `deploy/` |
@@ -142,11 +142,22 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 - **Noch nicht:** Der Owner-Filter greift erst in **WP3** — die CRUD-Endpunkte sind aktuell noch nicht auth-geschützt/gefiltert. Config: `AUTH_SECRET` (in Prod setzen!), Cookie-/Session-Flags, Admin-Bootstrap in `.env.example`.
 - **Tests:** `tests/unit/test_auth.py` (Invite-Gate, Login/Session, /users/me, Admin-only Invites, Bootstrap-Idempotenz). Suite: 567 grün, Coverage 91%.
 
+### Umsetzungsstand WP3 (auf `dev`)
+- **Bindung an die Session, nicht ContextVar:** Der Owner wird **einmal** an die `Session` gebunden (`session.info["owner"]`, `app/tenancy.py`). Grund: FastAPI fährt sync-Endpunkte und `yield`-Dependencies im Threadpool — ein dort gesetzter `ContextVar` propagiert nicht zuverlässig in den Endpunkt. Die Session ist dagegen exakt das Objekt, auf dem jede Query läuft → leck-sicher by construction.
+- **Zwei globale ORM-Event-Listener** (`tenancy.py`):
+  - `do_orm_execute` hängt für jede der `OWNABLE_MODELS` ein `with_loader_criteria(owner_id == uid, include_aliases=True)` an **jedes SELECT** (Relationship-/Column-Lazy-Loads ausgenommen). Superuser & unbound-Sessions: kein Filter.
+  - `before_flush` erzwingt die Owner-Invariante: neue Zeilen werden gestempelt (Client-gesendetes `owner_id` ignoriert), und bei Updates wird `owner_id` aus der History wiederhergestellt (per CRUD **nicht** änderbar). Fixt u. a. das Blanking durch `model_dump(exclude_unset)` auf `ValidatedSQLModel`.
+- **Auth-Schutz:** `owner_context`-Dependency (`app/auth/deps.py`) hängt an allen **acht** CRUD-Routern (`dependencies=[…]`) → 401 ohne Login, Daten pro Owner isoliert. `/auth`, `/users`, `/health` bleiben ungeschützt.
+- **App-Level-Duplikatprüfung** in den Update-Handlern (program/project/person/mapping) **vor** die Mutation gezogen: sonst schreibt der von der Prüf-Query ausgelöste Autoflush den Konfliktwert und der per-Owner-UNIQUE kippt (500 statt 409).
+- **`Setting` pro Owner (Schritt 3b):** Surrogat-`id`-PK + `owner_id` + `UNIQUE(owner_id, key)`; kein globales Startup-Seeding mehr — `db.ensure_owner_settings` seedet die Defaults pro Owner beim ersten Zugriff (`GET/PUT /settings`, race-safe). Alle `session.get(Setting, key)`-Lesepfade (holiday_region, milestones, persons) auf owner-gescopte Query umgestellt; Fallback-Defaults dort unverändert. Migration `a1b2c3d4e5f6` (Rebuild, reversibel validiert).
+- **Tests:** `tests/unit/test_tenancy.py` (Auth-Pflicht, Lese-Isolation, Auto-Stempel, owner_id nicht schmuggel-/änderbar, per-Owner-Eindeutigkeit, Admin-Bypass, Settings pro Owner), `test_db_seeding.py` neu auf per-Owner. `conftest`: `client` (Owner 1), `client_for` (header-getaggte Mehr-Owner-Clients gegen eine DB). Suite: 576 grün, Coverage 91%.
+- **Noch offen (WP4+):** Frontend hat noch keinen Login/Guard; `owner_id` bleibt nullable (spätere NOT-NULL-Verschärfung möglich); `AUTH_SECRET` vor Prod setzen.
+
 ---
 
 ## 8. Offene Punkte für die Umsetzungsphase
 - ~~`owner_id` denormalisiert auf Kind-Tabellen vs. Filter über Join.~~ **Entschieden (WP1): denormalisiert** — jede besitzbare Tabelle trägt `owner_id`, damit der zentrale Filter (`with_loader_criteria`) uniform ohne Join greift und keine Route ihn „vergessen" kann. Speicher-Overhead bei dieser App-Größe vernachlässigbar.
-- ~~Referenzdaten-Grenze.~~ **Entschieden:** `holiday` bleibt global; `setting` wird in WP3 pro-Owner (s. §5.1).
-- `owner_id` ist in WP1 **nullable**; WP3 setzt es beim Insert automatisch und erzwingt den Filter. Eine spätere Migration kann auf NOT NULL verschärfen, sobald jede Zeile nachweislich einen Owner hat.
+- ~~Referenzdaten-Grenze.~~ **Entschieden:** `holiday` bleibt global; `setting` ist ab WP3 pro-Owner (s. §5.1).
+- ~~`owner_id` ist in WP1 **nullable**; WP3 setzt es beim Insert automatisch und erzwingt den Filter.~~ **Umgesetzt (WP3):** Auto-Set + zentraler Filter aktiv. `owner_id` bleibt vorerst nullable; eine spätere Migration kann auf NOT NULL verschärfen, sobald jede Zeile nachweislich einen Owner hat.
 - Invite-Token: Ablaufzeit, Mehrfach-Kontingent (1 Token = 1 Account) — Default: einmalig, mit Ablauf (WP2).
 - Passwort-Policy / Reset-Weg ohne SMTP (Admin-gestützter Reset?) (WP2).

--- a/docs/implementation/25-multi-user-tenancy.md
+++ b/docs/implementation/25-multi-user-tenancy.md
@@ -162,6 +162,16 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 - **Tests:** `frontend/src/auth/__tests__/auth.test.tsx` (API-Formkodierung, `me()`-401-ohne-Event, Auth-/Admin-Guard-Redirects, Login-Erfolg/Fehlbedienung, Session-Ablauf per Event). Suite: **36 grün**. Browser-verifiziert: Guard-Redirect, echter UI-Login mit Ziel-Redirect, Admin-Token → Registrierung → Auto-Login als Nicht-Admin, Nicht-Admin von `/invites` abgewiesen, Logout.
 - **Noch offen (WP5+):** Datenexport/-löschung im Account-Menü; Passwort-Reset-UI; ggf. „Angemeldet bleiben".
 
+### Nacharbeit: Account-Selbstverwaltung & Härtung (#53, auf `dev`)
+Kleine Härtungs-/Selbstverwaltungs-Punkte aus dem WP4-Review:
+- **Passwort-Policy** (geteilte Regeln): `backend/app/auth/password_policy.py` ist Single Source of Truth (≥12 Zeichen, Groß-/Kleinbuchstaben, Ziffer, Sonderzeichen); autoritativ via `UserManager.validate_password`. Frontend spiegelt die Regeln in `frontend/src/lib/passwordPolicy.ts` + `PasswordChecklist` → **Live-Checkliste** in Registrierung und Konto-Seite (Submit gesperrt bis erfüllt).
+- **E-Mail-Domain-Allowlist:** `AUTH_ALLOWED_EMAIL_DOMAINS` (Env, kommasepariert, leer = alle). Prüfung in `UserManager.create()` **vor** Token-Verbrauch. Defense-in-depth über dem Invite-Token.
+- **DB-Pfad admin-only:** `/settings/database-path` (GET+PUT) jetzt hinter `require_superuser` (instanzweite Aktion). Frontend blendet den Datenbankpfad-Abschnitt für Nicht-Admins aus.
+- **Konto-Seite** (`/account`, `AccountPage`): E-Mail und Passwort ändern via `PATCH /users/me`; aktuelles Passwort wird per Re-Login verifiziert, bevor die Änderung greift.
+- **Invite-Consume-Regression:** bestätigt/getestet, dass ein fehlgeschlagener Register-Versuch (schwaches Passwort, unerlaubte Domain, Dublette) den Token **nicht** verbraucht (validate-first / consume-last).
+- **Tests:** Backend `test_password_policy.py`, erweiterte `test_auth.py` (Policy/Domain/Consume-last) und `test_routers_settings.py` (DB-Pfad 403 für Nicht-Admin); Frontend `passwordPolicy.test.ts` + `AccountPage.test.tsx`. Backend **582 grün / 91 % Coverage**, Frontend **43 grün**. Browser-verifiziert.
+- **Bewusst nicht umgesetzt:** echte E-Mail-Verifikation (kein SMTP im LAN → Invite+Domain als Gate) und frei gewählter Username-Login (E-Mail bleibt Identität).
+
 ---
 
 ## 8. Offene Punkte für die Umsetzungsphase

--- a/docs/implementation/25-multi-user-tenancy.md
+++ b/docs/implementation/25-multi-user-tenancy.md
@@ -82,7 +82,9 @@ Diese Constraints sind heute **global** und würden Isolation brechen (User2 kö
 | `Project.project_number` | `models/project.py:17` `unique=True` | `(owner_id, project_number)` |
 | `SageProjectMapping.sage_project_name` | `models/timebooking.py:37` `unique=True` | `(owner_id, sage_project_name)` |
 
-**Bleibt global** (Referenzdatum, kein Nutzerbesitz): `Holiday` `(holiday_date, country, state)` (`models/holiday.py:20`). Kandidat für „bleibt global": der Feiertags-Cache und ggf. globale Defaults in `settings` — als eigene Entscheidung im WP1 zu fixieren.
+**Bleibt global** (Referenzdatum, kein Nutzerbesitz): `Holiday` `(holiday_date, country, state)` (`models/holiday.py:20`).
+
+**`Setting`:** Zielbild ist **pro Owner** (Nutzerentscheidung 2026-07-22). In **WP1 bleibt `setting` global**, weil „Defaults pro Account seeden" einen User-Kontext braucht, den es erst mit Auth (WP2) gibt — und das idempotente Seeding (#42) an `session.get(Setting, key)` hängt. Die Umstellung `Setting`-PK → `(owner_id, key)` + per-Account-Seeding erfolgt in **WP3** zusammen mit dem Auto-Set/Filter.
 
 Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — auf `project_id`/`person_id` gekeyt) sind bereits über ihren Eltern-Owner geschützt und brauchen i. d. R. **keinen** eigenen `owner_id`, solange der Filter über den Join greift. Ob `owner_id` dennoch denormalisiert wird (einfacherer Filter, mehr Speicher), ist eine WP1-Abwägung.
 
@@ -114,7 +116,7 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 
 | WP | Inhalt | Kern-Artefakte |
 |---|---|---|
-| **WP1** | Datenmodell: `user`, `invite_token`; `owner_id` auf besitzbaren Entitäten; Unique-Constraints pro Owner; Referenzdaten-Grenze fixieren; Alembic-Migration (frische DB) | `models/*`, Alembic |
+| **WP1** ✅ | Datenmodell: `user`, `invite_token`; `owner_id` auf besitzbaren Entitäten; Unique-Constraints pro Owner; Referenzdaten-Grenze fixieren; Alembic-Migration (frische DB) | `models/*`, Alembic |
 | **WP2** | Auth-Backend: `fastapi-users`, Session-Cookie, Invite-Token-Flow, Admin-Flag | `routers/auth.py`, `main.py` |
 | **WP3** | Zentraler Owner-Filter (ContextVar + `do_orm_execute`), Auto-Set von `owner_id` beim Insert; Admin-Bypass | `db.py` |
 | **WP4** | Frontend: Login/Registrierung (Invite), Auth-Guard/Redirect, Logout, Account-Menü | `frontend/` |
@@ -122,10 +124,19 @@ Transitiv besessene Constraints (`membership`, `milestone`, `timebooking` — au
 | **WP6** | Deployment: verschlüsseltes Volume + verschlüsselte Backups; Proxy-Basic-Auth durch App-Login ersetzen | `docker-compose.server.yml`, `deploy/` |
 | **später** | Übergang Modell A: Teams/Rollen/Sichtbarkeit als ACL-Schicht über `owner_id` (Filter aufweichen) | — |
 
+### Umsetzungsstand WP1 (auf `dev`)
+- **Neue Modelle:** `models/user.py` (`User`, fastapi-users-kompatible Felder, int-PK, `is_superuser` = Admin/Filter-Bypass), `models/invite_token.py` (`InviteToken`).
+- **`owner_id`** (nullable FK → `user.id`, indiziert) auf allen 15 besitzbaren Tabellen (Root + Kinder **denormalisiert**, s. §8-Entscheidung). Referenzdaten `holiday` bleibt global; `user`/`invite_token` tragen kein `owner_id`.
+- **Composite-Uniques** `(owner_id, feld)` für `program_number`, `project_number`, `sage_employee_name`, `sage_project_name`.
+- **App-Level-Duplikatprüfung** in den vier CRUD-Routern (create+update) statt Verlass auf den DB-Constraint — verhält sich in WP1 (owner NULL) korrekt und wird in WP3 automatisch owner-gescoped.
+- **Alembic** `e7a1c9d2f3b4` (batch-Mode, Guards, Up-/Downgrade gegen Wegwerf-DB validiert). Prod baut per `alembic upgrade head`, daher vollständige Migration.
+- **Tests:** `tests/unit/test_models_owner_tenancy.py` (owner_id-Präsenz, Per-Owner-Eindeutigkeit, Auth-Tabellen). Suite: 554 grün.
+
 ---
 
 ## 8. Offene Punkte für die Umsetzungsphase
-- Referenzdaten-Grenze endgültig festlegen (Feiertags-Cache & welche `settings` global bleiben).
-- `owner_id` denormalisiert auf Kind-Tabellen vs. Filter über Join (Performance vs. Einfachheit).
-- Invite-Token: Ablaufzeit, Mehrfach-Kontingent (1 Token = 1 Account) — Default: einmalig, mit Ablauf.
-- Passwort-Policy / Reset-Weg ohne SMTP (Admin-gestützter Reset?).
+- ~~`owner_id` denormalisiert auf Kind-Tabellen vs. Filter über Join.~~ **Entschieden (WP1): denormalisiert** — jede besitzbare Tabelle trägt `owner_id`, damit der zentrale Filter (`with_loader_criteria`) uniform ohne Join greift und keine Route ihn „vergessen" kann. Speicher-Overhead bei dieser App-Größe vernachlässigbar.
+- ~~Referenzdaten-Grenze.~~ **Entschieden:** `holiday` bleibt global; `setting` wird in WP3 pro-Owner (s. §5.1).
+- `owner_id` ist in WP1 **nullable**; WP3 setzt es beim Insert automatisch und erzwingt den Filter. Eine spätere Migration kann auf NOT NULL verschärfen, sobald jede Zeile nachweislich einen Owner hat.
+- Invite-Token: Ablaufzeit, Mehrfach-Kontingent (1 Token = 1 Account) — Default: einmalig, mit Ablauf (WP2).
+- Passwort-Policy / Reset-Weg ohne SMTP (Admin-gestützter Reset?) (WP2).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, NavLink, Navigate } from 'react-router-dom'
-import { FolderOpen, Users, Briefcase, Map, LayoutDashboard, CalendarDays, ArrowDownToLine, Settings } from 'lucide-react'
+import { FolderOpen, Users, Briefcase, Map, LayoutDashboard, CalendarDays, ArrowDownToLine, Settings, Ticket, LogOut, ShieldCheck } from 'lucide-react'
 import ProjectsPage from './pages/ProjectsPage'
 import ProjectDetailPage from './pages/ProjectDetailPage'
 import PersonsPage from './pages/PersonsPage'
@@ -9,6 +9,11 @@ import CalendarPage from './pages/CalendarPage'
 import ImportPage from './pages/ImportPage'
 import PersonDetailPage from './pages/PersonDetailPage'
 import SettingsPage from './pages/SettingsPage'
+import InvitesPage from './pages/InvitesPage'
+import LoginPage from './pages/LoginPage'
+import RegisterPage from './pages/RegisterPage'
+import { RequireAuth, RequireAdmin } from './auth/RequireAuth'
+import { useAuth } from './auth/AuthContext'
 
 const navItems = [
   { to: '/calendar', label: 'Kalender', icon: CalendarDays },
@@ -19,7 +24,37 @@ const navItems = [
   { to: '/mappings', label: 'Sage-Mapping', icon: Map },
 ]
 
-export default function App() {
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  `flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+    isActive ? 'bg-blue-600 text-white' : 'text-slate-400 hover:text-white hover:bg-slate-800'
+  }`
+
+function AccountMenu() {
+  const { user, logout } = useAuth()
+  if (!user) return null
+  return (
+    <div className="border-t border-slate-700 px-2 py-2">
+      <div className="px-3 pb-2 pt-1">
+        <p className="truncate text-xs font-medium text-slate-200" title={user.email}>{user.email}</p>
+        {user.is_superuser && (
+          <span className="mt-1 inline-flex items-center gap-1 rounded bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-blue-300">
+            <ShieldCheck size={10} /> Administrator
+          </span>
+        )}
+      </div>
+      <button
+        onClick={() => { void logout() }}
+        className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
+      >
+        <LogOut size={15} />
+        Abmelden
+      </button>
+    </div>
+  )
+}
+
+function AppShell() {
+  const { user } = useAuth()
   return (
     <div className="flex h-screen bg-gray-50 overflow-hidden">
       {/* Sidebar */}
@@ -34,17 +69,7 @@ export default function App() {
 
         <nav className="flex-1 px-2 py-3 space-y-0.5 overflow-y-auto">
           {navItems.map(({ to, label, icon: Icon }) => (
-            <NavLink
-              key={to}
-              to={to}
-              className={({ isActive }) =>
-                `flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-600 text-white'
-                    : 'text-slate-400 hover:text-white hover:bg-slate-800'
-                }`
-              }
-            >
+            <NavLink key={to} to={to} className={navLinkClass}>
               <Icon size={15} />
               {label}
             </NavLink>
@@ -52,21 +77,20 @@ export default function App() {
         </nav>
 
         <div className="px-2 py-2 border-t border-slate-700">
-          <NavLink
-            to="/settings"
-            className={({ isActive }) =>
-              `flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                isActive
-                  ? 'bg-blue-600 text-white'
-                  : 'text-slate-400 hover:text-white hover:bg-slate-800'
-              }`
-            }
-          >
+          {user?.is_superuser && (
+            <NavLink to="/invites" className={navLinkClass}>
+              <Ticket size={15} />
+              Einladungen
+            </NavLink>
+          )}
+          <NavLink to="/settings" className={navLinkClass}>
             <Settings size={15} />
             Einstellungen
           </NavLink>
           <p className="text-xs text-slate-400 px-3 pt-2">v{__APP_VERSION__}</p>
         </div>
+
+        <AccountMenu />
       </aside>
 
       {/* Main content area */}
@@ -82,8 +106,25 @@ export default function App() {
           <Route path="/programs" element={<ProgramsPage />} />
           <Route path="/mappings" element={<MappingsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route element={<RequireAdmin />}>
+            <Route path="/invites" element={<InvitesPage />} />
+          </Route>
         </Routes>
       </main>
     </div>
+  )
+}
+
+export default function App() {
+  return (
+    <Routes>
+      {/* Public auth screens */}
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      {/* Everything else requires a session */}
+      <Route element={<RequireAuth />}>
+        <Route path="/*" element={<AppShell />} />
+      </Route>
+    </Routes>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, NavLink, Navigate } from 'react-router-dom'
-import { FolderOpen, Users, Briefcase, Map, LayoutDashboard, CalendarDays, ArrowDownToLine, Settings, Ticket, LogOut, ShieldCheck } from 'lucide-react'
+import { FolderOpen, Users, Briefcase, Map, LayoutDashboard, CalendarDays, ArrowDownToLine, Settings, Ticket, LogOut, ShieldCheck, UserCog } from 'lucide-react'
 import ProjectsPage from './pages/ProjectsPage'
 import ProjectDetailPage from './pages/ProjectDetailPage'
 import PersonsPage from './pages/PersonsPage'
@@ -9,6 +9,7 @@ import CalendarPage from './pages/CalendarPage'
 import ImportPage from './pages/ImportPage'
 import PersonDetailPage from './pages/PersonDetailPage'
 import SettingsPage from './pages/SettingsPage'
+import AccountPage from './pages/AccountPage'
 import InvitesPage from './pages/InvitesPage'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
@@ -42,6 +43,10 @@ function AccountMenu() {
           </span>
         )}
       </div>
+      <NavLink to="/account" className={navLinkClass}>
+        <UserCog size={15} />
+        Konto
+      </NavLink>
       <button
         onClick={() => { void logout() }}
         className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-slate-400 transition-colors hover:bg-slate-800 hover:text-white"
@@ -106,6 +111,7 @@ function AppShell() {
           <Route path="/programs" element={<ProgramsPage />} />
           <Route path="/mappings" element={<MappingsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/account" element={<AccountPage />} />
           <Route element={<RequireAdmin />}>
             <Route path="/invites" element={<InvitesPage />} />
           </Route>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,22 @@ export class ApiError extends Error {
   }
 }
 
+/** Event fired when any authenticated request gets a 401 — the session expired
+ *  or the cookie is gone. The AuthProvider listens and drops the user, so the
+ *  route guard bounces to the login page. Not fired by the bootstrap `me()`
+ *  check (a logged-out visitor is normal, not an expiry). */
+export const AUTH_UNAUTHORIZED_EVENT = 'auth:unauthorized';
+
+function raiseHttpError(method: string, path: string, status: number, text: string): never {
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* keep raw text */
+  }
+  throw new ApiError(status, parsed, `${method} ${path} → ${status}: ${text}`);
+}
+
 async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     method,
@@ -22,14 +38,12 @@ async function req<T>(method: string, path: string, body?: unknown): Promise<T> 
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
-    const text = await res.text();
-    let parsed: unknown = text;
-    try {
-      parsed = JSON.parse(text);
-    } catch {
-      /* keep raw text */
+    // A 401 on a normal call means the session lapsed mid-use → tell the app to
+    // re-authenticate, then still throw so the caller's own error path runs.
+    if (res.status === 401 && typeof window !== 'undefined') {
+      window.dispatchEvent(new Event(AUTH_UNAUTHORIZED_EVENT));
     }
-    throw new ApiError(res.status, parsed, `${method} ${path} → ${res.status}: ${text}`);
+    raiseHttpError(method, path, res.status, await res.text());
   }
   if (res.status === 204) return undefined as T;
   return res.json();
@@ -609,4 +623,56 @@ export const imports = {
 export const bookings = {
   flag: (id: number, data: { is_excluded: boolean; exclusion_reason?: ExclusionReason | null; exclusion_note?: string | null }) =>
     req<TimeBooking>('PUT', `/bookings/${id}/flag`, data),
+};
+
+// ─── Auth / account (multi-user, doc 25 WP4) ───────────────────────────────────
+
+export interface User {
+  id: number;
+  email: string;
+  is_active: boolean;
+  is_superuser: boolean;
+  is_verified: boolean;
+}
+
+export interface Invite {
+  id: number;
+  token: string;
+  created_by: number | null;
+  used_by: number | null;
+  created_at: string | null;
+  used_at: string | null;
+  expires_at: string | null;
+}
+
+export const auth = {
+  /** Current user, or null when unauthenticated. Uses a bare fetch so a logged-out
+   *  visitor (401) is a normal outcome and does NOT raise the global re-auth event. */
+  me: async (): Promise<User | null> => {
+    const res = await fetch(`${BASE}/users/me`);
+    if (res.status === 401) return null;
+    if (!res.ok) raiseHttpError('GET', '/users/me', res.status, await res.text());
+    return res.json();
+  },
+
+  /** fastapi-users login expects form-encoded `username`/`password` (OAuth2 form). */
+  login: async (email: string, password: string): Promise<void> => {
+    const res = await fetch(`${BASE}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: email, password }),
+    });
+    if (!res.ok) raiseHttpError('POST', '/auth/login', res.status, await res.text());
+  },
+
+  logout: () => req<void>('POST', '/auth/logout'),
+
+  register: (d: { email: string; password: string; invite_token: string }) =>
+    req<User>('POST', '/auth/register', d),
+
+  invites: {
+    list: () => req<Invite[]>('GET', '/auth/invites'),
+    create: (expiresInDays: number | null = 14) =>
+      req<Invite>('POST', '/auth/invites', { expires_in_days: expiresInDays }),
+  },
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -670,6 +670,9 @@ export const auth = {
   register: (d: { email: string; password: string; invite_token: string }) =>
     req<User>('POST', '/auth/register', d),
 
+  /** Update the current account (self-service). Send only the fields that change. */
+  updateMe: (d: { email?: string; password?: string }) => req<User>('PATCH', '/users/me', d),
+
   invites: {
     list: () => req<Invite[]>('GET', '/auth/invites'),
     create: (expiresInDays: number | null = 14) =>

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,65 @@
+/** Client-side auth state (doc 25, WP4).
+ *
+ * Holds the current user, bootstrapped once from `GET /users/me`. The session
+ * itself lives in the httpOnly cookie the backend sets — this context never sees
+ * a token, it only mirrors "is someone logged in and who". A global
+ * `auth:unauthorized` event (fired by the API layer on any 401) drops the user so
+ * the route guard bounces to the login page when a session lapses mid-use.
+ */
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { auth, AUTH_UNAUTHORIZED_EVENT, type User } from '../api'
+
+interface AuthState {
+  /** undefined = still bootstrapping, null = logged out, User = logged in. */
+  user: User | null | undefined
+  /** Re-fetch the current user (after login/register). */
+  refresh: () => Promise<User | null>
+  /** Clear the server session and local user. */
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null | undefined>(undefined)
+
+  const refresh = useCallback(async () => {
+    const me = await auth.me()
+    setUser(me)
+    return me
+  }, [])
+
+  const logout = useCallback(async () => {
+    try {
+      await auth.logout()
+    } finally {
+      setUser(null)
+    }
+  }, [])
+
+  useEffect(() => {
+    // Bootstrap the session from the server on mount. setUser runs only after the
+    // fetch resolves (inside refresh), so this is an async subscribe-to-external-
+    // system effect, not a synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    refresh()
+  }, [refresh])
+
+  // A 401 anywhere in the app means the session is gone — reflect that so the guard
+  // redirects. Setting null is idempotent, so a stray event during bootstrap is safe.
+  useEffect(() => {
+    const onUnauthorized = () => setUser(null)
+    window.addEventListener(AUTH_UNAUTHORIZED_EVENT, onUnauthorized)
+    return () => window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, onUnauthorized)
+  }, [])
+
+  return <AuthContext.Provider value={{ user, refresh, logout }}>{children}</AuthContext.Provider>
+}
+
+// Colocated with the provider by design; fast-refresh only-components warning N/A.
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
+  return ctx
+}

--- a/frontend/src/auth/AuthLayout.tsx
+++ b/frontend/src/auth/AuthLayout.tsx
@@ -1,0 +1,29 @@
+/** Centered card shell shared by the login and registration screens (doc 25, WP4). */
+import { LayoutDashboard } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+export default function AuthLayout({ title, subtitle, children }: {
+  title: string
+  subtitle: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-6 flex flex-col items-center gap-1">
+          <div className="flex items-center gap-2">
+            <LayoutDashboard size={22} className="text-blue-600" />
+            <h1 className="text-lg font-bold tracking-wide text-slate-900">ProjektPlanner</h1>
+          </div>
+          <p className="text-xs text-gray-500">Project Planning</p>
+        </div>
+
+        <div className="rounded-lg border border-gray-200 bg-white px-6 py-6 shadow-sm">
+          <h2 className="text-base font-semibold text-gray-800">{title}</h2>
+          <p className="mb-4 mt-0.5 text-xs text-gray-500">{subtitle}</p>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/auth/RequireAuth.tsx
+++ b/frontend/src/auth/RequireAuth.tsx
@@ -1,0 +1,35 @@
+/** Route guards (doc 25, WP4).
+ *
+ * `RequireAuth` gates the whole authenticated app: while the user is being
+ * bootstrapped it shows a spinner, and a logged-out visitor is redirected to
+ * /login (remembering where they wanted to go). `RequireAdmin` additionally
+ * restricts a subtree to superusers.
+ */
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { Loader2 } from 'lucide-react'
+import { useAuth } from './AuthContext'
+
+function FullscreenSpinner() {
+  return (
+    <div className="flex h-screen items-center justify-center bg-gray-50" role="status" aria-label="Lädt">
+      <Loader2 className="animate-spin text-blue-600" size={28} />
+    </div>
+  )
+}
+
+export function RequireAuth() {
+  const { user } = useAuth()
+  const location = useLocation()
+
+  if (user === undefined) return <FullscreenSpinner />
+  if (user === null) return <Navigate to="/login" state={{ from: location }} replace />
+  return <Outlet />
+}
+
+export function RequireAdmin() {
+  const { user } = useAuth()
+
+  if (user === undefined) return <FullscreenSpinner />
+  if (!user?.is_superuser) return <Navigate to="/calendar" replace />
+  return <Outlet />
+}

--- a/frontend/src/auth/__tests__/auth.test.tsx
+++ b/frontend/src/auth/__tests__/auth.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AuthProvider } from '../AuthContext'
+import { RequireAuth, RequireAdmin } from '../RequireAuth'
+import LoginPage from '../../pages/LoginPage'
+import { auth, AUTH_UNAUTHORIZED_EVENT } from '../../api'
+
+const USER = { id: 1, email: 'a@b.c', is_active: true, is_superuser: false, is_verified: true }
+const ADMIN = { ...USER, id: 2, email: 'admin@b.c', is_superuser: true }
+
+/** Mutable session the fake backend reflects through /users/me. */
+let session: typeof USER | null = null
+
+function jsonRes(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as Response
+}
+
+function installFetch(impl?: (url: string, init?: RequestInit) => Response) {
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    if (impl) return impl(url, init)
+    if (url.endsWith('/users/me')) return session ? jsonRes(200, session) : jsonRes(401, { detail: 'Unauthorized' })
+    if (url.endsWith('/auth/login')) {
+      const body = String(init?.body ?? '')
+      if (body.includes('username=a%40b.c') && body.includes('password=secret')) {
+        session = USER
+        return { ok: true, status: 204, text: async () => '', json: async () => undefined } as Response
+      }
+      return jsonRes(400, { detail: 'LOGIN_BAD_CREDENTIALS' })
+    }
+    if (url.endsWith('/auth/logout')) {
+      session = null
+      return { ok: true, status: 204, text: async () => '', json: async () => undefined } as Response
+    }
+    return jsonRes(404, {})
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+beforeEach(() => { session = null })
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+// ── API layer ────────────────────────────────────────────────────────────────
+
+describe('auth api', () => {
+  it('me() returns null on 401 without raising the re-auth event', async () => {
+    installFetch()
+    const spy = vi.fn()
+    window.addEventListener(AUTH_UNAUTHORIZED_EVENT, spy)
+    expect(await auth.me()).toBeNull()
+    window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, spy)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('login() form-encodes username/password', async () => {
+    const fn = installFetch()
+    await auth.login('a@b.c', 'secret')
+    const [, init] = fn.mock.calls[0]
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/x-www-form-urlencoded')
+    expect(String(init?.body)).toContain('username=a%40b.c')
+  })
+})
+
+// ── Route guards ───────────────────────────────────────────────────────────────
+
+function renderGuarded(initial: string, guard: 'auth' | 'admin') {
+  const Guard = guard === 'auth' ? RequireAuth : RequireAdmin
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<div>LOGIN SCREEN</div>} />
+          <Route path="/calendar" element={<div>CALENDAR</div>} />
+          <Route element={<Guard />}>
+            <Route path="/secret" element={<div>SECRET CONTENT</div>} />
+          </Route>
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('RequireAuth', () => {
+  it('redirects an unauthenticated visitor to /login', async () => {
+    installFetch()
+    renderGuarded('/secret', 'auth')
+    expect(await screen.findByText('LOGIN SCREEN')).toBeInTheDocument()
+    expect(screen.queryByText('SECRET CONTENT')).not.toBeInTheDocument()
+  })
+
+  it('renders the protected content for an authenticated user', async () => {
+    session = USER
+    installFetch()
+    renderGuarded('/secret', 'auth')
+    expect(await screen.findByText('SECRET CONTENT')).toBeInTheDocument()
+  })
+})
+
+describe('RequireAdmin', () => {
+  it('sends a non-admin back to /calendar', async () => {
+    session = USER
+    installFetch()
+    renderGuarded('/secret', 'admin')
+    expect(await screen.findByText('CALENDAR')).toBeInTheDocument()
+    expect(screen.queryByText('SECRET CONTENT')).not.toBeInTheDocument()
+  })
+
+  it('lets an admin through', async () => {
+    session = ADMIN
+    installFetch()
+    renderGuarded('/secret', 'admin')
+    expect(await screen.findByText('SECRET CONTENT')).toBeInTheDocument()
+  })
+})
+
+// ── Login flow ───────────────────────────────────────────────────────────────
+
+function renderLogin() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/calendar" element={<div>CALENDAR</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('LoginPage', () => {
+  it('logs in with valid credentials and lands on the target route', async () => {
+    installFetch()
+    renderLogin()
+    await userEvent.type(screen.getByLabelText('E-Mail'), 'a@b.c')
+    await userEvent.type(screen.getByLabelText('Passwort'), 'secret')
+    await userEvent.click(screen.getByRole('button', { name: 'Anmelden' }))
+    expect(await screen.findByText('CALENDAR')).toBeInTheDocument()
+  })
+
+  it('shows an error on bad credentials', async () => {
+    installFetch()
+    renderLogin()
+    await userEvent.type(screen.getByLabelText('E-Mail'), 'a@b.c')
+    await userEvent.type(screen.getByLabelText('Passwort'), 'wrong')
+    await userEvent.click(screen.getByRole('button', { name: 'Anmelden' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('E-Mail oder Passwort ist falsch.')
+  })
+})
+
+// ── Session expiry ─────────────────────────────────────────────────────────────
+
+describe('session expiry', () => {
+  it('a global 401 event drops the user back to the login screen', async () => {
+    session = USER
+    installFetch()
+    renderGuarded('/secret', 'auth')
+    expect(await screen.findByText('SECRET CONTENT')).toBeInTheDocument()
+    // Simulate a 401 raised by some later API call.
+    window.dispatchEvent(new Event(AUTH_UNAUTHORIZED_EVENT))
+    expect(await screen.findByText('LOGIN SCREEN')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/PasswordChecklist.tsx
+++ b/frontend/src/components/PasswordChecklist.tsx
@@ -1,0 +1,23 @@
+/** Live password-policy checklist (#53). Shows each rule with a check/circle as
+ *  the user types. Purely visual — the backend enforces the policy authoritatively. */
+import { Check, Circle } from 'lucide-react'
+import { PASSWORD_RULES } from '../lib/passwordPolicy'
+
+export default function PasswordChecklist({ password }: { password: string }) {
+  return (
+    <ul className="mt-1.5 space-y-0.5" aria-label="Passwort-Anforderungen">
+      {PASSWORD_RULES.map((rule) => {
+        const ok = rule.test(password)
+        return (
+          <li
+            key={rule.label}
+            className={`flex items-center gap-1.5 text-xs ${ok ? 'text-green-600' : 'text-gray-400'}`}
+          >
+            {ok ? <Check size={12} /> : <Circle size={12} />}
+            {rule.label}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/src/lib/__tests__/passwordPolicy.test.ts
+++ b/frontend/src/lib/__tests__/passwordPolicy.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { isPasswordValid, PASSWORD_RULES, PASSWORD_MIN_LENGTH } from '../passwordPolicy'
+
+describe('passwordPolicy', () => {
+  it('accepts a password meeting every rule', () => {
+    expect(isPasswordValid('Pw123456789!')).toBe(true)
+  })
+
+  it('rejects a too-short password', () => {
+    expect(isPasswordValid('Aa1!')).toBe(false)
+    expect('Aa1!'.length).toBeLessThan(PASSWORD_MIN_LENGTH)
+  })
+
+  it('rejects a long password missing character classes', () => {
+    expect(isPasswordValid('abcdefghijklmnop')).toBe(false) // no upper/digit/special
+  })
+
+  it('exposes one rule per requirement', () => {
+    expect(PASSWORD_RULES).toHaveLength(4)
+    // the min-length rule reflects the constant
+    expect(PASSWORD_RULES[0].test('x'.repeat(PASSWORD_MIN_LENGTH))).toBe(true)
+    expect(PASSWORD_RULES[0].test('x'.repeat(PASSWORD_MIN_LENGTH - 1))).toBe(false)
+  })
+})

--- a/frontend/src/lib/passwordPolicy.ts
+++ b/frontend/src/lib/passwordPolicy.ts
@@ -1,0 +1,24 @@
+/** Password policy (doc 25, #53) — frontend mirror of backend/app/auth/password_policy.py.
+ *
+ * The backend's validate_password is authoritative; these rules drive the live
+ * checklist so the user sees requirements while typing. Keep BOTH in sync. */
+
+export const PASSWORD_MIN_LENGTH = 12
+
+export interface PasswordRule {
+  /** Short German label shown in the checklist. */
+  label: string
+  test: (pw: string) => boolean
+}
+
+export const PASSWORD_RULES: PasswordRule[] = [
+  { label: `Mindestens ${PASSWORD_MIN_LENGTH} Zeichen`, test: (pw) => pw.length >= PASSWORD_MIN_LENGTH },
+  { label: 'Groß- und Kleinbuchstaben', test: (pw) => /[a-z]/.test(pw) && /[A-Z]/.test(pw) },
+  { label: 'Mindestens eine Ziffer', test: (pw) => /\d/.test(pw) },
+  { label: 'Mindestens ein Sonderzeichen', test: (pw) => /[^A-Za-z0-9]/.test(pw) },
+]
+
+/** True when the password satisfies every rule. */
+export function isPasswordValid(pw: string): boolean {
+  return PASSWORD_RULES.every((r) => r.test(pw))
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './auth/AuthContext'
 
 const qc = new QueryClient()
 
@@ -11,7 +12,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={qc}>
       <BrowserRouter>
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -1,0 +1,217 @@
+/** Account self-service (doc 25, #53).
+ *
+ * Lets the logged-in user change their e-mail and password. The backend
+ * (`PATCH /users/me`) does not re-check the current password, so we verify it
+ * client-side by re-logging-in before applying a change — a wrong current
+ * password is rejected before anything is sent. The password field mirrors the
+ * shared policy checklist; the backend enforces it authoritatively. */
+import { useState, type FormEvent } from 'react'
+import { Loader2, ShieldCheck, Mail, KeyRound, CheckCircle } from 'lucide-react'
+import { auth, ApiError } from '../api'
+import { useAuth } from '../auth/AuthContext'
+import { isPasswordValid } from '../lib/passwordPolicy'
+import PasswordChecklist from '../components/PasswordChecklist'
+import PageHeader from '../components/PageHeader'
+
+/** Map a fastapi-users update 400 to a German message. */
+function messageFor(err: unknown): string {
+  if (err instanceof ApiError && err.status === 400) {
+    const detail = (err.body as { detail?: unknown } | null)?.detail
+    if (detail === 'UPDATE_USER_EMAIL_ALREADY_EXISTS') return 'Diese E-Mail wird bereits verwendet.'
+    if (detail && typeof detail === 'object' && 'code' in detail) {
+      const reason = (detail as { reason?: string }).reason
+      if ((detail as { code?: string }).code === 'UPDATE_USER_INVALID_PASSWORD') {
+        return `Passwort zu schwach${reason ? `: ${reason}` : '.'}`
+      }
+    }
+  }
+  return 'Änderung fehlgeschlagen. Bitte Eingaben prüfen.'
+}
+
+const inputClass =
+  'w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+
+function Card({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+        {icon}
+        {title}
+      </h2>
+      <div className="bg-white rounded-lg border border-gray-200 px-6 py-4">{children}</div>
+    </section>
+  )
+}
+
+function Feedback({ ok, msg }: { ok: boolean; msg: string }) {
+  return (
+    <p
+      role={ok ? 'status' : 'alert'}
+      className={`mt-3 flex items-center gap-1.5 rounded border px-3 py-2 text-xs ${
+        ok ? 'border-green-200 bg-green-50 text-green-700' : 'border-red-200 bg-red-50 text-red-700'
+      }`}
+    >
+      {ok && <CheckCircle size={13} />}
+      {msg}
+    </p>
+  )
+}
+
+export default function AccountPage() {
+  const { user, refresh } = useAuth()
+
+  // ── Change e-mail ──
+  const [newEmail, setNewEmail] = useState(user?.email ?? '')
+  const [emailPw, setEmailPw] = useState('')
+  const [emailBusy, setEmailBusy] = useState(false)
+  const [emailFeedback, setEmailFeedback] = useState<{ ok: boolean; msg: string } | null>(null)
+
+  // ── Change password ──
+  const [curPw, setCurPw] = useState('')
+  const [newPw, setNewPw] = useState('')
+  const [newPw2, setNewPw2] = useState('')
+  const [pwBusy, setPwBusy] = useState(false)
+  const [pwFeedback, setPwFeedback] = useState<{ ok: boolean; msg: string } | null>(null)
+
+  if (!user) return null
+
+  /** Verify the supplied current password by re-authenticating. */
+  const verifyCurrent = async (password: string): Promise<boolean> => {
+    try {
+      await auth.login(user.email, password)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const submitEmail = async (e: FormEvent) => {
+    e.preventDefault()
+    setEmailFeedback(null)
+    const email = newEmail.trim()
+    if (email === user.email) {
+      setEmailFeedback({ ok: false, msg: 'Das ist bereits deine aktuelle E-Mail.' })
+      return
+    }
+    setEmailBusy(true)
+    try {
+      if (!(await verifyCurrent(emailPw))) {
+        setEmailFeedback({ ok: false, msg: 'Aktuelles Passwort ist falsch.' })
+        return
+      }
+      await auth.updateMe({ email })
+      await refresh()
+      setEmailPw('')
+      setEmailFeedback({ ok: true, msg: 'E-Mail aktualisiert.' })
+    } catch (err) {
+      setEmailFeedback({ ok: false, msg: messageFor(err) })
+    } finally {
+      setEmailBusy(false)
+    }
+  }
+
+  const submitPassword = async (e: FormEvent) => {
+    e.preventDefault()
+    setPwFeedback(null)
+    if (!isPasswordValid(newPw)) {
+      setPwFeedback({ ok: false, msg: 'Das neue Passwort erfüllt die Anforderungen nicht.' })
+      return
+    }
+    if (newPw !== newPw2) {
+      setPwFeedback({ ok: false, msg: 'Die beiden neuen Passwörter stimmen nicht überein.' })
+      return
+    }
+    setPwBusy(true)
+    try {
+      if (!(await verifyCurrent(curPw))) {
+        setPwFeedback({ ok: false, msg: 'Aktuelles Passwort ist falsch.' })
+        return
+      }
+      await auth.updateMe({ password: newPw })
+      setCurPw(''); setNewPw(''); setNewPw2('')
+      setPwFeedback({ ok: true, msg: 'Passwort geändert.' })
+    } catch (err) {
+      setPwFeedback({ ok: false, msg: messageFor(err) })
+    } finally {
+      setPwBusy(false)
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader title="Konto" subtitle="E-Mail und Passwort deines Zugangs verwalten" />
+      <div className="p-6 space-y-8 max-w-2xl">
+
+        {/* Identity */}
+        <Card icon={<ShieldCheck size={15} className="text-gray-400" />} title="Zugang">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-xs text-gray-500">Angemeldet als</p>
+              <p className="text-sm font-medium text-gray-800">{user.email}</p>
+            </div>
+            {user.is_superuser && (
+              <span className="inline-flex items-center gap-1 rounded bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 border border-blue-200">
+                <ShieldCheck size={12} /> Administrator
+              </span>
+            )}
+          </div>
+        </Card>
+
+        {/* Change e-mail */}
+        <Card icon={<Mail size={15} className="text-gray-400" />} title="E-Mail ändern">
+          <form onSubmit={submitEmail} className="space-y-3">
+            <div>
+              <label htmlFor="acc-email" className="mb-1 block text-xs font-medium text-gray-600">Neue E-Mail</label>
+              <input id="acc-email" type="email" autoComplete="email" required value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)} className={inputClass} />
+            </div>
+            <div>
+              <label htmlFor="acc-email-pw" className="mb-1 block text-xs font-medium text-gray-600">Aktuelles Passwort</label>
+              <input id="acc-email-pw" type="password" autoComplete="current-password" required value={emailPw}
+                onChange={(e) => setEmailPw(e.target.value)} className={inputClass} />
+            </div>
+            <div className="flex justify-end">
+              <button type="submit" disabled={emailBusy}
+                className="flex items-center gap-2 rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+                {emailBusy && <Loader2 size={14} className="animate-spin" />}
+                E-Mail speichern
+              </button>
+            </div>
+            {emailFeedback && <Feedback ok={emailFeedback.ok} msg={emailFeedback.msg} />}
+          </form>
+        </Card>
+
+        {/* Change password */}
+        <Card icon={<KeyRound size={15} className="text-gray-400" />} title="Passwort ändern">
+          <form onSubmit={submitPassword} className="space-y-3">
+            <div>
+              <label htmlFor="acc-cur-pw" className="mb-1 block text-xs font-medium text-gray-600">Aktuelles Passwort</label>
+              <input id="acc-cur-pw" type="password" autoComplete="current-password" required value={curPw}
+                onChange={(e) => setCurPw(e.target.value)} className={inputClass} />
+            </div>
+            <div>
+              <label htmlFor="acc-new-pw" className="mb-1 block text-xs font-medium text-gray-600">Neues Passwort</label>
+              <input id="acc-new-pw" type="password" autoComplete="new-password" required value={newPw}
+                onChange={(e) => setNewPw(e.target.value)} className={inputClass} />
+              <PasswordChecklist password={newPw} />
+            </div>
+            <div>
+              <label htmlFor="acc-new-pw2" className="mb-1 block text-xs font-medium text-gray-600">Neues Passwort wiederholen</label>
+              <input id="acc-new-pw2" type="password" autoComplete="new-password" required value={newPw2}
+                onChange={(e) => setNewPw2(e.target.value)} className={inputClass} />
+            </div>
+            <div className="flex justify-end">
+              <button type="submit" disabled={pwBusy || !isPasswordValid(newPw)}
+                className="flex items-center gap-2 rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+                {pwBusy && <Loader2 size={14} className="animate-spin" />}
+                Passwort speichern
+              </button>
+            </div>
+            {pwFeedback && <Feedback ok={pwFeedback.ok} msg={pwFeedback.msg} />}
+          </form>
+        </Card>
+
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/InvitesPage.tsx
+++ b/frontend/src/pages/InvitesPage.tsx
@@ -1,0 +1,116 @@
+/** Invite-token management (doc 25, WP4) — admin only.
+ *
+ * The only way new users get in: an admin mints a one-time token here and shares
+ * it (out of band) with the invitee, who redeems it on the registration screen.
+ * The full token is shown only in this list; there is no e-mail delivery.
+ */
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Ticket, Plus, Copy, Check, Loader2 } from 'lucide-react'
+import { auth, type Invite } from '../api'
+import PageHeader from '../components/PageHeader'
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString('de-DE')
+}
+
+function statusOf(inv: Invite): { label: string; cls: string } {
+  if (inv.used_by != null) return { label: 'Verwendet', cls: 'bg-gray-100 text-gray-500' }
+  if (inv.expires_at && new Date(inv.expires_at) < new Date()) return { label: 'Abgelaufen', cls: 'bg-amber-50 text-amber-700' }
+  return { label: 'Offen', cls: 'bg-green-50 text-green-700' }
+}
+
+function TokenCell({ token }: { token: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(token)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable — token is visible for manual copy */
+    }
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <code className="max-w-[22rem] truncate rounded bg-gray-50 px-2 py-0.5 text-xs text-gray-700">{token}</code>
+      <button onClick={copy} title="Token kopieren"
+        className="text-gray-400 hover:text-gray-700" aria-label="Token kopieren">
+        {copied ? <Check size={14} className="text-green-600" /> : <Copy size={14} />}
+      </button>
+    </div>
+  )
+}
+
+export default function InvitesPage() {
+  const qc = useQueryClient()
+  const { data, isLoading } = useQuery({ queryKey: ['invites'], queryFn: auth.invites.list })
+
+  const create = useMutation({
+    mutationFn: () => auth.invites.create(14),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['invites'] }),
+  })
+
+  return (
+    <div>
+      <PageHeader
+        title="Einladungen"
+        subtitle="Einmal-Token zur Registrierung neuer Nutzer erzeugen und verwalten"
+        actions={
+          <button
+            onClick={() => create.mutate()} disabled={create.isPending}
+            className="flex items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {create.isPending ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+            Token erzeugen
+          </button>
+        }
+      />
+
+      <div className="p-6 max-w-4xl">
+        <p className="mb-4 flex items-start gap-2 rounded border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-800">
+          <Ticket size={14} className="mt-0.5 flex-shrink-0" />
+          Ein Token gilt für genau eine Registrierung, läuft nach 14 Tagen ab und wird beim Anlegen des Kontos verbraucht. Gib den Token sicher an die einzuladende Person weiter.
+        </p>
+
+        {isLoading ? (
+          <p className="text-sm text-gray-400">Lade…</p>
+        ) : !data || data.length === 0 ? (
+          <p className="text-sm text-gray-500">Noch keine Einladungen. Erzeuge oben ein Token.</p>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 bg-gray-50 text-left text-xs font-medium text-gray-500">
+                  <th className="px-4 py-2">Token</th>
+                  <th className="px-4 py-2">Status</th>
+                  <th className="px-4 py-2">Erstellt</th>
+                  <th className="px-4 py-2">Läuft ab</th>
+                  <th className="px-4 py-2">Verwendet</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((inv) => {
+                  const s = statusOf(inv)
+                  return (
+                    <tr key={inv.id} className="border-b border-gray-100 last:border-0">
+                      <td className="px-4 py-2"><TokenCell token={inv.token} /></td>
+                      <td className="px-4 py-2">
+                        <span className={`rounded px-2 py-0.5 text-xs font-medium ${s.cls}`}>{s.label}</span>
+                      </td>
+                      <td className="px-4 py-2 text-gray-500">{formatDate(inv.created_at)}</td>
+                      <td className="px-4 py-2 text-gray-500">{formatDate(inv.expires_at)}</td>
+                      <td className="px-4 py-2 text-gray-500">{formatDate(inv.used_at)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,90 @@
+/** Login screen (doc 25, WP4).
+ *
+ * Posts credentials to the cookie-auth backend, then re-bootstraps the user and
+ * returns to wherever the guard sent them from (or the calendar). An
+ * already-authenticated visitor is bounced straight in.
+ */
+import { useState, type FormEvent } from 'react'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { Loader2 } from 'lucide-react'
+import { auth, ApiError } from '../api'
+import { useAuth } from '../auth/AuthContext'
+import AuthLayout from '../auth/AuthLayout'
+
+interface FromState { from?: { pathname?: string } }
+
+export default function LoginPage() {
+  const { user, refresh } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const target = (location.state as FromState | null)?.from?.pathname ?? '/calendar'
+
+  // Already logged in? Don't show the form.
+  if (user) return <Navigate to={target} replace />
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      await auth.login(email.trim(), password)
+      const me = await refresh()
+      if (me) navigate(target, { replace: true })
+      else setError('Anmeldung fehlgeschlagen.')
+    } catch (err) {
+      // fastapi-users returns 400 LOGIN_BAD_CREDENTIALS for wrong email/password.
+      if (err instanceof ApiError && err.status === 400) {
+        setError('E-Mail oder Passwort ist falsch.')
+      } else {
+        setError('Anmeldung fehlgeschlagen. Bitte später erneut versuchen.')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <AuthLayout title="Anmelden" subtitle="Melde dich mit deinem Konto an.">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label htmlFor="login-email" className="mb-1 block text-xs font-medium text-gray-600">E-Mail</label>
+          <input
+            id="login-email" type="email" autoComplete="username" required autoFocus
+            value={email} onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="login-password" className="mb-1 block text-xs font-medium text-gray-600">Passwort</label>
+          <input
+            id="login-password" type="password" autoComplete="current-password" required
+            value={password} onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</p>
+        )}
+
+        <button
+          type="submit" disabled={busy}
+          className="flex w-full items-center justify-center gap-2 rounded bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {busy && <Loader2 size={14} className="animate-spin" />}
+          Anmelden
+        </button>
+      </form>
+
+      <p className="mt-4 text-center text-xs text-gray-500">
+        Noch kein Konto?{' '}
+        <Link to="/register" className="font-medium text-blue-600 hover:underline">Mit Einladung registrieren</Link>
+      </p>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -11,6 +11,8 @@ import { Loader2 } from 'lucide-react'
 import { auth, ApiError } from '../api'
 import { useAuth } from '../auth/AuthContext'
 import AuthLayout from '../auth/AuthLayout'
+import PasswordChecklist from '../components/PasswordChecklist'
+import { isPasswordValid } from '../lib/passwordPolicy'
 
 /** Turn a fastapi-users / invite 400 body into a German message. */
 function messageFor(err: unknown): string {
@@ -85,6 +87,7 @@ export default function RegisterPage() {
             value={password} onChange={(e) => setPassword(e.target.value)}
             className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
+          <PasswordChecklist password={password} />
         </div>
         <div>
           <label htmlFor="reg-token" className="mb-1 block text-xs font-medium text-gray-600">Einladungs-Token</label>
@@ -100,7 +103,7 @@ export default function RegisterPage() {
         )}
 
         <button
-          type="submit" disabled={busy}
+          type="submit" disabled={busy || !isPasswordValid(password)}
           className="flex w-full items-center justify-center gap-2 rounded bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
         >
           {busy && <Loader2 size={14} className="animate-spin" />}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,117 @@
+/** Registration screen (doc 25, WP4).
+ *
+ * Self-service sign-up gated by a one-time invite token. On success the user is
+ * logged straight in (registration alone does not create a session) and dropped
+ * into the app. Backend 400s (bad/used/expired token, weak password, duplicate
+ * e-mail) are mapped to readable German messages.
+ */
+import { useState, type FormEvent } from 'react'
+import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
+import { Loader2 } from 'lucide-react'
+import { auth, ApiError } from '../api'
+import { useAuth } from '../auth/AuthContext'
+import AuthLayout from '../auth/AuthLayout'
+
+/** Turn a fastapi-users / invite 400 body into a German message. */
+function messageFor(err: unknown): string {
+  if (err instanceof ApiError && err.status === 400) {
+    const detail = (err.body as { detail?: unknown } | null)?.detail
+    if (typeof detail === 'string') {
+      if (detail === 'REGISTER_USER_ALREADY_EXISTS') return 'Für diese E-Mail existiert bereits ein Konto.'
+      // Invite-token errors arrive as descriptive English strings.
+      const map: Record<string, string> = {
+        'An invite token is required to register.': 'Ein Einladungs-Token ist zur Registrierung erforderlich.',
+        'Invalid invite token.': 'Ungültiges Einladungs-Token.',
+        'This invite token has already been used.': 'Dieses Einladungs-Token wurde bereits verwendet.',
+        'This invite token has expired.': 'Dieses Einladungs-Token ist abgelaufen.',
+      }
+      return map[detail] ?? detail
+    }
+    if (detail && typeof detail === 'object' && 'code' in detail) {
+      const code = (detail as { code?: string }).code
+      const reason = (detail as { reason?: string }).reason
+      if (code === 'REGISTER_INVALID_PASSWORD') {
+        return `Passwort zu schwach${reason ? `: ${reason}` : '.'}`
+      }
+    }
+  }
+  return 'Registrierung fehlgeschlagen. Bitte Eingaben prüfen.'
+}
+
+export default function RegisterPage() {
+  const { user, refresh } = useAuth()
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [token, setToken] = useState(params.get('token') ?? '')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  if (user) return <Navigate to="/calendar" replace />
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      await auth.register({ email: email.trim(), password, invite_token: token.trim() })
+      // Registration does not open a session — log in with the same credentials.
+      await auth.login(email.trim(), password)
+      const me = await refresh()
+      navigate(me ? '/calendar' : '/login', { replace: true })
+    } catch (err) {
+      setError(messageFor(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <AuthLayout title="Registrieren" subtitle="Erstelle ein Konto mit deinem Einladungs-Token.">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label htmlFor="reg-email" className="mb-1 block text-xs font-medium text-gray-600">E-Mail</label>
+          <input
+            id="reg-email" type="email" autoComplete="username" required autoFocus
+            value={email} onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="reg-password" className="mb-1 block text-xs font-medium text-gray-600">Passwort</label>
+          <input
+            id="reg-password" type="password" autoComplete="new-password" required
+            value={password} onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="reg-token" className="mb-1 block text-xs font-medium text-gray-600">Einladungs-Token</label>
+          <input
+            id="reg-token" type="text" required
+            value={token} onChange={(e) => setToken(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-1.5 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</p>
+        )}
+
+        <button
+          type="submit" disabled={busy}
+          className="flex w-full items-center justify-center gap-2 rounded bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {busy && <Loader2 size={14} className="animate-spin" />}
+          Konto erstellen
+        </button>
+      </form>
+
+      <p className="mt-4 text-center text-xs text-gray-500">
+        Bereits registriert?{' '}
+        <Link to="/login" className="font-medium text-blue-600 hover:underline">Anmelden</Link>
+      </p>
+    </AuthLayout>
+  )
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Database, AlertTriangle, CheckCircle, RefreshCw, FolderOpen, CalendarDays } from 'lucide-react'
 import { settings, type DbPathInfo } from '../api'
 import PageHeader from '../components/PageHeader'
+import { useAuth } from '../auth/AuthContext'
 import { GERMAN_STATES, EXTRA_HOLIDAYS } from '../lib/holidayRegions'
 
 const HOLIDAY_KEYS = ['holiday_country', 'holiday_state', 'holiday_extra']
@@ -261,6 +262,7 @@ function DbPathSection() {
 
 export default function SettingsPage() {
   const qc = useQueryClient()
+  const { user } = useAuth()
   const [error, setError] = useState<string | null>(null)
 
   const { data, isLoading } = useQuery({
@@ -334,8 +336,8 @@ export default function SettingsPage() {
           />
         )}
 
-        {/* Database path */}
-        <DbPathSection />
+        {/* Database path — instance-wide setting, admin only (#53) */}
+        {user?.is_superuser && <DbPathSection />}
 
       </div>
     </div>

--- a/frontend/src/pages/__tests__/AccountPage.test.tsx
+++ b/frontend/src/pages/__tests__/AccountPage.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AuthProvider } from '../../auth/AuthContext'
+import AccountPage from '../AccountPage'
+
+const USER = { id: 1, email: 'a@b.c', is_active: true, is_superuser: false, is_verified: true }
+
+function jsonRes(status: number, body: unknown) {
+  return { ok: status >= 200 && status < 300, status, text: async () => JSON.stringify(body), json: async () => body } as Response
+}
+
+/** Fake backend: /users/me (GET bootstrap, PATCH update) + /auth/login for the
+ *  current-password re-verification. Current password is 'secret'. */
+function installFetch() {
+  const fn = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url.endsWith('/users/me') && init?.method === 'PATCH') return jsonRes(200, { ...USER })
+    if (url.endsWith('/users/me')) return jsonRes(200, USER)
+    if (url.endsWith('/auth/login')) {
+      const body = String(init?.body ?? '')
+      return body.includes('password=secret')
+        ? ({ ok: true, status: 204, text: async () => '', json: async () => undefined } as Response)
+        : jsonRes(400, { detail: 'LOGIN_BAD_CREDENTIALS' })
+    }
+    return jsonRes(404, {})
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+function renderAccount() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <AccountPage />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => { installFetch() })
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+describe('AccountPage password change', () => {
+  it('verifies the current password, then PATCHes the new one', async () => {
+    const fn = installFetch()
+    const { container } = renderAccount()
+    expect(await screen.findByText('Angemeldet als')).toBeInTheDocument()
+
+    await userEvent.type(container.querySelector('#acc-cur-pw')!, 'secret')
+    await userEvent.type(container.querySelector('#acc-new-pw')!, 'Pw123456789!')
+    await userEvent.type(container.querySelector('#acc-new-pw2')!, 'Pw123456789!')
+    await userEvent.click(screen.getByRole('button', { name: 'Passwort speichern' }))
+
+    expect(await screen.findByText('Passwort geändert.')).toBeInTheDocument()
+    expect(fn.mock.calls.some(([u, i]) => String(u).endsWith('/users/me') && (i as RequestInit)?.method === 'PATCH')).toBe(true)
+  })
+
+  it('rejects a wrong current password and does not PATCH', async () => {
+    const fn = installFetch()
+    const { container } = renderAccount()
+    expect(await screen.findByText('Angemeldet als')).toBeInTheDocument()
+
+    await userEvent.type(container.querySelector('#acc-cur-pw')!, 'wrong-one')
+    await userEvent.type(container.querySelector('#acc-new-pw')!, 'Pw123456789!')
+    await userEvent.type(container.querySelector('#acc-new-pw2')!, 'Pw123456789!')
+    await userEvent.click(screen.getByRole('button', { name: 'Passwort speichern' }))
+
+    expect(await screen.findByText('Aktuelles Passwort ist falsch.')).toBeInTheDocument()
+    expect(fn.mock.calls.some(([u, i]) => String(u).endsWith('/users/me') && (i as RequestInit)?.method === 'PATCH')).toBe(false)
+  })
+
+  it('disables submit until the new password satisfies the policy', async () => {
+    const { container } = renderAccount()
+    expect(await screen.findByText('Angemeldet als')).toBeInTheDocument()
+    const submit = screen.getByRole('button', { name: 'Passwort speichern' }) as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+    await userEvent.type(container.querySelector('#acc-new-pw')!, 'Pw123456789!')
+    expect(submit.disabled).toBe(false)
+  })
+})


### PR DESCRIPTION
Release **v0.3.0** — Multi-User / Auth-Meilenstein.

Enthält gegenüber `main`:

- **Multi-User WP1–WP4** (#44, #49): Datenmodell (`user`/`invite_token` + `owner_id`), Auth-Backend (fastapi-users, Session-Cookie, Invite-Token, Admin), zentraler Owner-Filter + Auth-Schutz aller CRUD-Router, Frontend (Login/Registrierung/Auth-Guard/Account-Menü/Admin-Invites).
- **Account-Selbstverwaltung & Härtung** (#53): Passwort-Policy (Backend autoritativ + Live-Checkliste), E-Mail-Domain-Allowlist, DB-Pfad admin-only, Konto-Seite (E-Mail/Passwort ändern), Invite-Consume-Regression.
- **Deploy-Bootstrap & Session-Härtung** (#44, #51): First-Admin-Bootstrap + `AUTH_SECRET` + `AUTH_COOKIE_SECURE` über host-seitige `server.env`; ohne Bootstrap kein Einstieg (invite-only). README/Doc aktualisiert.
- **Startup-Seeding** idempotent/mehrprozess-sicher (#42).
- Version-Bump auf **0.3.0**.

**Tests:** Backend 583 grün / 91 % Coverage, Frontend 43 grün. Browser- und API-verifiziert.

Nicht enthalten (Folge-WPs): WP5 (DSGVO-Export/-Löschung, admin-gestützter Passwort-Reset), Rest von WP6 (nginx-Basic-Auth durch App-Login ablösen).