### PR TITLE
Deploy: drop nginx Basic-Auth (app login) (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,18 +161,18 @@ docker compose -f docker-compose.prod.yml down      # stop (data volume is kept)
 
 ### With login + HTTPS (server variant)
 
-`docker-compose.server.yml` puts a reverse proxy (TLS + HTTP Basic Auth) in front;
-the app itself is not published, only the proxy (ports 80/443). One shared login,
-one DB (see issue #45). Host-side secrets live outside the repo at
+`docker-compose.server.yml` puts a reverse proxy (TLS) in front; the app itself is
+not published, only the proxy (ports 80/443). Authentication is handled by the app
+(multi-user session login, v0.3.0+) — the earlier nginx Basic-Auth gate (#45) has
+been removed (WP6, #51). Host-side secrets live outside the repo at
 `/home/<user>/pp-secrets/`:
 
 ```bash
-# once: create the secrets dir, a self-signed cert, and the (nginx) login
+# once: create the secrets dir and a self-signed cert
 mkdir -p ~/pp-secrets
 openssl req -x509 -newkey rsa:2048 -nodes -days 825 \
   -keyout ~/pp-secrets/key.pem -out ~/pp-secrets/cert.pem \
   -subj "/CN=$(hostname)" -addext "subjectAltName=IP:<host-ip>,DNS:$(hostname)"
-htpasswd -cB ~/pp-secrets/htpasswd <login-name>     # prompts for the password
 
 # once: app secrets — first-admin bootstrap + session signing key (see below)
 cp deploy/server-secrets.env.example ~/pp-secrets/server.env

--- a/deploy/proxy.conf
+++ b/deploy/proxy.conf
@@ -1,7 +1,11 @@
-# Reverse proxy in front of the app: terminates TLS and enforces a login (Basic
-# Auth), then forwards to the internal frontend container. Used only in the server
-# deployment (docker-compose.server.yml). Certs + htpasswd are mounted from the host
-# at /etc/nginx/secrets (never in the repo/image).
+# Reverse proxy in front of the app: terminates TLS, then forwards to the internal
+# frontend container. Used only in the server deployment (docker-compose.server.yml).
+# Certs are mounted from the host at /etc/nginx/secrets (never in the repo/image).
+#
+# Auth is handled by the APP itself (session login, v0.3.0+): the SPA is behind a
+# route guard and every data endpoint requires an authenticated session. The former
+# nginx Basic-Auth gate (#45) was the placeholder before the app had its own login
+# and is now removed (WP6, #51). TLS stays; the htpasswd file is no longer used.
 
 # Plain HTTP → redirect to HTTPS.
 server {
@@ -17,10 +21,6 @@ server {
     ssl_certificate     /etc/nginx/secrets/cert.pem;
     ssl_certificate_key /etc/nginx/secrets/key.pem;
     ssl_protocols       TLSv1.2 TLSv1.3;
-
-    # Login gate for the whole app (shared credentials, one tenant — see #45).
-    auth_basic           "ProjektPlanner";
-    auth_basic_user_file /etc/nginx/secrets/htpasswd;
 
     client_max_body_size 25m;
 


### PR DESCRIPTION
Deploy-Config-Patch auf v0.3.0: nginx Basic-Auth entfernt, App-Login uebernimmt (WP6 #51). Keine App-Codeaenderung, kein Versions-Bump. TLS bleibt.