### PR TITLE
Release v0.3.1 — Deployment-Härtung (App-Login + Login-Rate-Limit)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,7 +15,7 @@ DEFAULT_HOLIDAY_COUNTRY=DE
 DEFAULT_HOLIDAY_STATE=BY
 
 # Application
-APP_VERSION=0.3.0
+APP_VERSION=0.3.1
 DEBUG=false
 
 # Auth (multi-user, doc 25 WP2) — session-cookie carrying a signed JWT.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     default_holiday_state: str = "BY"
 
     # Application
-    app_version: str = "0.3.0"
+    app_version: str = "0.3.1"
     debug: bool = False
 
     # Auth (multi-user, doc 25 WP2). Session-cookie carrying a signed JWT.

--- a/deploy/proxy.conf
+++ b/deploy/proxy.conf
@@ -7,6 +7,11 @@
 # nginx Basic-Auth gate (#45) was the placeholder before the app had its own login
 # and is now removed (WP6, #51). TLS stays; the htpasswd file is no longer used.
 
+# Brute-force brake on the login endpoint (replaces the old Basic-Auth as a crude
+# gate). Per-client-IP; ~10 attempts/min with a small burst, then HTTP 429. Defined
+# in http context (conf.d is included inside http{}).
+limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
+
 # Plain HTTP → redirect to HTTPS.
 server {
     listen 80;
@@ -23,6 +28,18 @@ server {
     ssl_protocols       TLSv1.2 TLSv1.3;
 
     client_max_body_size 25m;
+
+    # Rate-limited login (brute-force brake). Exact match wins over `location /`.
+    location = /api/auth/login {
+        limit_req zone=login burst=5 nodelay;
+        limit_req_status 429;
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
 
     location / {
         proxy_pass http://frontend:80;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Deployment-Härtung v0.3.1: nginx-Basic-Auth entfernt (App-Login übernimmt), Login-Endpoint per nginx rate-limit gegen Brute-Force (~10/min/IP, dann 429). Keine App-Logikänderung; Version-Bump 0.3.0→0.3.1.